### PR TITLE
Add Environment Variable Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,10 @@ export STATELESS_VALIDATOR_GENESIS_FILE=/path/to/genesis.json
 export STATELESS_VALIDATOR_START_BLOCK=<trusted-block-hash>
 export STATELESS_VALIDATOR_REPORT_VALIDATION_RESULTS=false
 
-cargo run --bin stateless-validator
+cargo run --release --bin stateless-validator
 ```
+
+**Note**: Command-line arguments take precedence over environment variables.
 
 ### Getting Started
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,30 @@ cargo run --bin stateless-validator -- \
 - `--start-block`: Trusted block hash to initialize validation from (required for first-time setup)
 - `--report-validation-results`: Enable reporting of validated blocks to the upstream node (disabled by default)
 
+### Environment Variables
+
+Each command-line flag has an equivalent environment variable, which allows you to run the validator without passing long argument lists:
+
+- `STATELESS_VALIDATOR_DATA_DIR` → `--data-dir`
+- `STATELESS_VALIDATOR_RPC_ENDPOINT` → `--rpc-endpoint`
+- `STATELESS_VALIDATOR_WITNESS_ENDPOINT` → `--witness-endpoint`
+- `STATELESS_VALIDATOR_GENESIS_FILE` → `--genesis-file`
+- `STATELESS_VALIDATOR_START_BLOCK` → `--start-block`
+- `STATELESS_VALIDATOR_REPORT_VALIDATION_RESULTS` → `--report-validation-results` (set to `true` to enable)
+
+Example:
+
+```bash
+export STATELESS_VALIDATOR_DATA_DIR=/path/to/validator/data
+export STATELESS_VALIDATOR_RPC_ENDPOINT=<public-rpc-endpoint>
+export STATELESS_VALIDATOR_WITNESS_ENDPOINT=<witness-rpc-endpoint>
+export STATELESS_VALIDATOR_GENESIS_FILE=/path/to/genesis.json
+export STATELESS_VALIDATOR_START_BLOCK=<trusted-block-hash>
+export STATELESS_VALIDATOR_REPORT_VALIDATION_RESULTS=false
+
+cargo run --bin stateless-validator
+```
+
 ### Getting Started
 
 The stateless validator requires a trusted starting point and hardfork configuration for security. On first run, you must specify both a genesis file and a trusted block hash:

--- a/bin/stateless-validator/Cargo.toml
+++ b/bin/stateless-validator/Cargo.toml
@@ -26,7 +26,7 @@ salt.workspace = true
 
 # misc
 bincode.workspace = true
-clap.workspace = true
+clap = { workspace = true, features = ["env"] }
 eyre.workspace = true
 futures.workspace = true
 num_cpus.workspace = true

--- a/bin/stateless-validator/src/main.rs
+++ b/bin/stateless-validator/src/main.rs
@@ -124,29 +124,29 @@ impl Default for ChainSyncConfig {
 #[clap(author, version, about, long_about = None)]
 struct CommandLineArgs {
     /// Directory path where validator data and database files will be stored.
-    #[clap(long)]
+    #[clap(long, env = "STATELESS_VALIDATOR_DATA_DIR")]
     data_dir: String,
 
     /// The URL of the Ethereum JSON-RPC API endpoint for fetching blockchain data.
-    #[clap(long)]
+    #[clap(long, env = "STATELESS_VALIDATOR_RPC_ENDPOINT")]
     rpc_endpoint: String,
 
     /// The URL of the MegaETH JSON-RPC API endpoint for fetching witness data.
-    #[clap(long)]
+    #[clap(long, env = "STATELESS_VALIDATOR_WITNESS_ENDPOINT")]
     witness_endpoint: String,
 
     /// Optional trusted block hash to start validation from.
-    #[clap(long)]
+    #[clap(long, env = "STATELESS_VALIDATOR_START_BLOCK")]
     start_block: Option<String>,
 
     /// Path to the genesis JSON file for chain configuration.
     /// Required on first run, optional on subsequent runs (loads from database).
-    #[clap(long)]
+    #[clap(long, env = "STATELESS_VALIDATOR_GENESIS_FILE")]
     genesis_file: Option<String>,
 
     /// Enable reporting of validated blocks to the upstream node.
     /// When enabled, the validator will send validation results via mega_setValidatedBlock RPC.
-    #[clap(long)]
+    #[clap(long, env = "STATELESS_VALIDATOR_REPORT_VALIDATION_RESULTS")]
     report_validation_results: bool,
 }
 


### PR DESCRIPTION
## Add Environment Variable Support

### Summary
This PR adds support for configuring the stateless validator through environment variables in addition to command-line arguments. This improves usability by allowing users to set configuration once through environment variables rather than passing long argument lists every time.

### Changes

**1. Enhanced CLI with Environment Variable Support**
- Updated all command-line arguments to support corresponding environment variables
- Added `env` feature to the `clap` dependency to enable environment variable parsing

**2. New Environment Variables**
The following environment variables are now supported:
- `STATELESS_VALIDATOR_DATA_DIR` → `--data-dir`
- `STATELESS_VALIDATOR_RPC_ENDPOINT` → `--rpc-endpoint`
- `STATELESS_VALIDATOR_WITNESS_ENDPOINT` → `--witness-endpoint`
- `STATELESS_VALIDATOR_GENESIS_FILE` → `--genesis-file`
- `STATELESS_VALIDATOR_START_BLOCK` → `--start-block`
- `STATELESS_VALIDATOR_REPORT_VALIDATION_RESULTS` → `--report-validation-results`

### Benefits
- **Improved Developer Experience**: Reduce repetitive typing of long command-line arguments
- **Better CI/CD Integration**: Easier to configure in containerized environments and CI pipelines
- **Backward Compatibility**: All existing command-line arguments continue to work as before
- **Flexibility**: Users can mix environment variables and command-line arguments (CLI args take precedence)

### Example Usage

```bash
export STATELESS_VALIDATOR_DATA_DIR=/path/to/validator/data
export STATELESS_VALIDATOR_RPC_ENDPOINT=<public-rpc-endpoint>
export STATELESS_VALIDATOR_WITNESS_ENDPOINT=<witness-rpc-endpoint>
export STATELESS_VALIDATOR_GENESIS_FILE=/path/to/genesis.json
export STATELESS_VALIDATOR_START_BLOCK=<trusted-block-hash>
export STATELESS_VALIDATOR_REPORT_VALIDATION_RESULTS=false

cargo run --bin stateless-validator
```

### Testing
- All existing functionality remains unchanged
- Command-line arguments still work as expected
- Environment variables can be used as an alternative or in combination with CLI args