### PR TITLE
fix: make integration tests fail fast and fix validation error handling

### DIFF
--- a/bin/stateless-validator/src/main.rs
+++ b/bin/stateless-validator/src/main.rs
@@ -100,6 +100,8 @@ pub struct ChainSyncConfig {
     pub worker_error_sleep: Duration,
     /// Enable reporting of validated blocks to upstream node
     pub report_validation_results: bool,
+    /// Stop chain sync on first error (useful for integration tests)
+    pub stop_on_first_err: bool,
 }
 
 impl Default for ChainSyncConfig {
@@ -115,6 +117,7 @@ impl Default for ChainSyncConfig {
             worker_idle_sleep: Duration::from_millis(500),
             worker_error_sleep: Duration::from_millis(1000),
             report_validation_results: false,
+            stop_on_first_err: false,
         }
     }
 }
@@ -356,6 +359,9 @@ async fn chain_sync(
         .await
         {
             error!("[Chain Sync] Iteration failed: {}", e);
+            if config.stop_on_first_err {
+                return Err(e);
+            }
         }
     }
 }
@@ -1304,6 +1310,7 @@ mod tests {
         let config = Arc::new(ChainSyncConfig {
             concurrent_workers: 1,
             sync_target,
+            stop_on_first_err: true,
             ..ChainSyncConfig::default()
         });
 


### PR DESCRIPTION
Problem: Integration tests currently loop forever when validation fails instead of terminating with a clear error message.

Changes:
- Add stop_on_first_err flag to ChainSyncConfig to terminate chain_sync on first error (enabled in integration tests, disabled in production)
- Fix grow_local_chain to use error_message from ValidationResult instead of constructing incorrect StateRootMismatch errors where actual and claimed fields were the same
- Change FailedValidation variant to accept String for better error messages
- Fix clippy warnings (ok_or_else -> ok_or)