### PR TITLE
Optimize External Crate Log Filtering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
 /target
+
+# mcp
+.claude/
+.cursor/
 .mcp.json
+
+# database
 validator-data


### PR DESCRIPTION
### Summary
This PR improves log filtering by reducing noise from external dependencies while maintaining clear visibility into stateless-validator's own operations.

### Changes

**Logging Configuration Refactor**

The logging initialization has been updated to use a more efficient filtering approach:

- **Stdout Layer**: Changed from simple `EnvFilter` to a two-tier approach:
  - Set default log level to `warn` for all crates
  - Apply the configured log level (via `STATELESS_VALIDATOR_LOG_STDOUT`) only to `stateless_validator` crate

- **File Layer**: Simplified the filtering logic:
  - Removed explicit `off` directives for individual external crates (`hyper_util`, `alloy_transport_http`, `hyper`, `reqwest`)
  - Replaced with a unified approach: `warn` level by default, with `stateless_validator` crate following `STATELESS_VALIDATOR_LOG_FILE` configuration

- **Test Logging**: Updated test initialization to follow the same pattern:
  - Default `warn` level for external dependencies
  - `debug` level for `stateless_validator` crate

### Benefits

1. **Reduced Log Noise**: External dependencies now default to `warn` level, significantly reducing verbose logs from HTTP clients, utilities, and other libraries
2. **Cleaner Code**: Eliminates the need to maintain a list of specific crates to filter
3. **Maintainability**: More scalable approach that automatically applies to any future external dependencies
4. **Consistency**: Same filtering pattern applied across stdout, file, and test logging

### Technical Details

The new approach uses `EnvFilter::new("warn")` as the base level, then adds a specific directive for the stateless-validator crate using `.add_directive()`. This ensures:
- All external crates default to warning level or above
- Only stateless-validator logs respect the user-configured verbosity levels