### PR TITLE
chore: Update mega-evm Dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2972,7 +2972,7 @@ dependencies = [
 [[package]]
 name = "mega-evm"
 version = "0.0.1"
-source = "git+https://github.com/megaeth-labs/mega-evm.git?rev=8ac0e2fdd28b6d4a1aa21ee9a4bbc1cfaba4e17e#8ac0e2fdd28b6d4a1aa21ee9a4bbc1cfaba4e17e"
+source = "git+https://github.com/megaeth-labs/mega-evm.git?rev=cb6df8c2aa5081f7a2ec4492e060ccd2b89de080#cb6df8c2aa5081f7a2ec4492e060ccd2b89de080"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ op-revm = { version = "8.1.0", default-features = false }
 revm = { version = "27.1.0", default-features = false }
 
 # megaeth 
-mega-evm = { git = "https://github.com/megaeth-labs/mega-evm.git", rev = "8ac0e2fdd28b6d4a1aa21ee9a4bbc1cfaba4e17e" }
+mega-evm = { git = "https://github.com/megaeth-labs/mega-evm.git", rev = "cb6df8c2aa5081f7a2ec4492e060ccd2b89de080" }
 salt = { git = "https://github.com/megaeth-labs/salt.git", rev = "80a46f2cd4c24417ec7fa265015270c623ae5340" }
 
 # reth


### PR DESCRIPTION
### Summary
This PR updates the `mega-evm` dependency to a newer revision.

### Changes
- Updated `mega-evm` dependency from revision `8ac0e2f` to `cb6df8c`
- Modified `Cargo.toml` and `Cargo.lock` accordingly

### Technical Details
**Previous version:**
```
rev = "8ac0e2fdd28b6d4a1aa21ee9a4bbc1cfaba4e17e"
```

**New version:**
```
rev = "cb6df8c2aa5081f7a2ec4492e060ccd2b89de080"
```

### Files Changed
- `Cargo.toml` - Updated mega-evm git dependency revision
- `Cargo.lock` - Updated lockfile with new dependency resolution

### Impact
This update ensures the stateless-validator uses the latest mega-evm implementation from the upstream repository.