### PR TITLE
Add test-bucket-resize Feature & Dependency Cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5404,7 +5404,6 @@ dependencies = [
  "dyn-clone",
  "mega-evm",
  "op-alloy-rpc-types",
- "op-revm",
  "redb",
  "reth-ethereum-forks",
  "reth-optimism-chainspec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ alloy-op-evm = { version = "0.15.0", default-features = false }
 alloy-op-hardforks = { version = "0.2.7" }
 op-alloy-network = { version = "0.18.12", default-features = false }
 op-alloy-rpc-types = { version = "0.18.12", default-features = false }
-op-revm = { version = "8.1.0", default-features = false }
 
 # revm
 revm = { version = "27.1.0", default-features = false }

--- a/bin/stateless-validator/Cargo.toml
+++ b/bin/stateless-validator/Cargo.toml
@@ -42,3 +42,6 @@ validator-core = { path = "../../validator-core" }
 jsonrpsee = { version = "0.26", features = ["server", "macros"] }
 jsonrpsee-types = { version = "0.26" }
 tempfile = "3.8"
+
+[features]
+test-bucket-resize = ["salt/test-bucket-resize"]

--- a/bin/stateless-validator/Cargo.toml
+++ b/bin/stateless-validator/Cargo.toml
@@ -44,4 +44,4 @@ jsonrpsee-types = { version = "0.26" }
 tempfile = "3.8"
 
 [features]
-test-bucket-resize = ["salt/test-bucket-resize"]
+test-bucket-resize = ["salt/test-bucket-resize", "validator-core/test-bucket-resize"]

--- a/validator-core/Cargo.toml
+++ b/validator-core/Cargo.toml
@@ -20,7 +20,6 @@ alloy-serde.workspace = true
 alloy-op-evm.workspace = true
 alloy-op-hardforks.workspace = true
 op-alloy-rpc-types.workspace = true
-op-revm.workspace = true
 
 # revm
 revm.workspace = true
@@ -43,3 +42,6 @@ redb.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
+
+[features]
+test-bucket-resize = ["salt/test-bucket-resize"]

--- a/validator-core/src/executor.rs
+++ b/validator-core/src/executor.rs
@@ -29,8 +29,9 @@ use alloy_network_primitives::TransactionResponse;
 use alloy_op_evm::block::OpAlloyReceiptBuilder;
 use alloy_primitives::{Address, BlockHash, BlockNumber};
 use alloy_rpc_types_eth::{Block, BlockTransactions, Header};
-use mega_evm::MegaEvmEnvAndSettings;
-use mega_evm::{MegaBlockExecutionCtx, MegaBlockExecutorFactory, MegaEvmFactory};
+use mega_evm::{
+    MegaBlockExecutionCtx, MegaBlockExecutorFactory, MegaEvmEnvAndSettings, MegaEvmFactory,
+};
 use op_alloy_rpc_types::Transaction as OpTransaction;
 use revm::{
     context::{BlockEnv, CfgEnv},
@@ -245,7 +246,7 @@ fn replay_block(
         .apply_post_execution_changes()
         .map_err(ValidationError::BlockReplayFailed)?;
 
-    Ok(state.cache.accounts.clone())
+    Ok(state.cache.accounts)
 }
 
 /// Validates a block by creating a witness, replaying transactions, and comparing state roots.

--- a/validator-core/src/withdrawals.rs
+++ b/validator-core/src/withdrawals.rs
@@ -9,11 +9,9 @@ use alloy_primitives::{Address, B256, Bytes, address, keccak256, map::B256Map};
 use alloy_rlp::Decodable;
 use alloy_rpc_types_eth::Header;
 use reth_trie::Nibbles;
-use reth_trie_common::HashedStorage;
-use reth_trie_common::{EMPTY_ROOT_HASH, TrieNode};
-use reth_trie_sparse::SparseTrieInterface;
+use reth_trie_common::{EMPTY_ROOT_HASH, HashedStorage, TrieNode};
 use reth_trie_sparse::{
-    SerialSparseTrie, SparseTrie, TrieMasks, provider::DefaultTrieNodeProvider,
+    SerialSparseTrie, SparseTrie, SparseTrieInterface, TrieMasks, provider::DefaultTrieNodeProvider,
 };
 use revm::database::states::CacheAccount;
 use serde::{Deserialize, Serialize};


### PR DESCRIPTION
### Summary
This PR introduces the `test-bucket-resize` feature flag and performs dependency cleanup by removing unused `op-revm` dependency and optimizing code for better performance.

### Changes

#### 🚀 New Features
- **Added `test-bucket-resize` feature flag** to both `stateless-validator` binary and `validator-core` crate
  - Forwards the `test-bucket-resize` feature from the `salt` dependency
  - Enables testing of bucket resize functionality when needed

#### 🧹 Dependency Cleanup
- **Removed `op-revm` dependency** from workspace and core crate
  - Eliminated from root `Cargo.toml`
  - Removed from `validator-core/Cargo.toml`
  - Updated `Cargo.lock` accordingly

#### ⚡ Code Optimizations
- **Executor improvements** (`validator-core/src/executor.rs`)
  - Reorganized imports from `mega_evm` for better readability
  - Removed unnecessary `.clone()` call in `replay_block()` function, returning owned value directly

- **Import organization** (`validator-core/src/withdrawals.rs`)
  - Consolidated imports for better structure and readability
  - Grouped related imports together

### Files Modified
- `Cargo.toml` - Removed `op-revm` from workspace dependencies
- `Cargo.lock` - Updated dependency tree
- `bin/stateless-validator/Cargo.toml` - Added `test-bucket-resize` feature
- `validator-core/Cargo.toml` - Removed `op-revm`, added `test-bucket-resize` feature
- `validator-core/src/executor.rs` - Import cleanup and performance optimization
- `validator-core/src/withdrawals.rs` - Import reorganization

### Impact
- **Performance**: Slight improvement by removing unnecessary clone operation
- **Maintainability**: Cleaner imports and reduced unused dependencies
- **Testing**: New feature flag enables bucket resize testing when needed