### PR TITLE
Upgrade mega-evm dependency from cb6df8c2 to a64ab67b

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2972,7 +2972,7 @@ dependencies = [
 [[package]]
 name = "mega-evm"
 version = "0.0.1"
-source = "git+https://github.com/megaeth-labs/mega-evm.git?rev=cb6df8c2aa5081f7a2ec4492e060ccd2b89de080#cb6df8c2aa5081f7a2ec4492e060ccd2b89de080"
+source = "git+https://github.com/megaeth-labs/mega-evm.git?rev=a64ab67bb560d9125f07a144585c12b42a5ca819#a64ab67bb560d9125f07a144585c12b42a5ca819"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ op-alloy-rpc-types = { version = "0.18.12", default-features = false }
 revm = { version = "27.1.0", default-features = false }
 
 # megaeth 
-mega-evm = { git = "https://github.com/megaeth-labs/mega-evm.git", rev = "cb6df8c2aa5081f7a2ec4492e060ccd2b89de080" }
+mega-evm = { git = "https://github.com/megaeth-labs/mega-evm.git", rev = "a64ab67bb560d9125f07a144585c12b42a5ca819" }
 salt = { git = "https://github.com/megaeth-labs/salt.git", rev = "80a46f2cd4c24417ec7fa265015270c623ae5340" }
 
 # reth


### PR DESCRIPTION
### Summary
This PR upgrades the `mega-evm` dependency to the latest revision (a64ab67b) and adapts the codebase to accommodate API changes introduced in the new version.

### Changes

#### Dependency Update
- Updated `mega-evm` from revision `cb6df8c2aa5081f7a2ec4492e060ccd2b89de080` to `a64ab67bb560d9125f07a144585c12b42a5ca819`

#### Code Adaptations (`validator-core/src/executor.rs`)

**Imports:**
- Removed: `MegaEvmEnvAndSettings`
- Added: `BlockLimits`, `MegaSpecId`

**Function Signature Changes:**
- Updated `create_evm_env()` return type from `MegaEvmEnvAndSettings` to `EvmEnv<MegaSpecId>`
- Simplified the function to directly return `EvmEnv::new(cfg_env, block_env)` instead of wrapping it in a settings struct

**Executor Initialization:**
- Added `BlockLimits::from_evm_env(&evm_env)` parameter when creating `MegaBlockExecutionCtx`
- Changed executor creation method from `create_executor_with_config()` to `create_executor()`

### Impact
- **Breaking Change**: The mega-evm API has been refactored with a simpler interface
- **Code Simplification**: Removed unnecessary wrapper types and simplified executor initialization
- **Functionality**: Core validation functionality remains unchanged

### Files Modified
- `Cargo.toml` - dependency version bump
- `Cargo.lock` - lockfile update
- `validator-core/src/executor.rs` - API adaptation (7 insertions, 10 deletions)