### PR TITLE
refactor: Replace `eth_getCode` with `eth_getCodeByHash`

### DIFF
--- a/bin/stateless-validator/src/main.rs
+++ b/bin/stateless-validator/src/main.rs
@@ -1137,7 +1137,9 @@ mod tests {
 
         module
             .register_method("eth_getCodeByHash", |params, context, _| {
-                let (hash,): (B256,) = params.parse().unwrap();
+                let (hash,): (B256,) = params.parse().map_err(|e| {
+                    make_rpc_error(INVALID_PARAMS_CODE, format!("Invalid params: {e}"))
+                })?;
 
                 let code = context.bytecodes.get(&hash).cloned().unwrap_or_default();
 

--- a/validator-core/src/database.rs
+++ b/validator-core/src/database.rs
@@ -263,6 +263,8 @@ impl SaltEnv for WitnessExternalEnv {
         bucket_id: BucketId,
         at_block: BlockNumber,
     ) -> Result<u64, Self::Error> {
+        trace!(?bucket_id, at_block, "get_bucket_capacity");
+
         if at_block != self.block_number {
             return Err(WitnessDatabaseError(format!(
                 "block mismatch: expected {}, got {}",


### PR DESCRIPTION
### Summary
This PR refactors the contract bytecode fetching mechanism to use `eth_getCodeByHash` instead of `eth_getCode`, enabling more efficient and direct bytecode retrieval by code hash rather than by address.

### Motivation
The previous implementation used `eth_getCode(address, blockNumber)` which required maintaining an address-to-codehash mapping. Since the witness data already contains code hashes, querying by hash directly is more efficient and eliminates the need for this intermediate mapping.

### Changes

#### Core API Changes
- **RPC Client** (`bin/stateless-validator/src/rpc.rs`):
  - Replaced `get_code(addresses, block_number)` with `get_code(hashes)` 
  - Now uses `eth_getCodeByHash` RPC method instead of `get_code_at`
  - Simplified method signature - no longer requires block number parameter

- **Database Layer** (`validator-core/src/validator_db.rs`):
  - Replaced singular `add_contract_code()` with batch `add_contract_codes()`
  - Replaced singular `get_contract_code()` with batch `get_contract_codes()`
  - New batch method returns `(HashMap<B256, Bytecode>, Vec<B256>)` tuple with found contracts and missing hashes
  - Improved performance through batch database operations

#### Implementation Updates
- **Main Validator** (`bin/stateless-validator/src/main.rs`):
  - `extract_contract_codes()` now returns `HashSet<B256>` instead of `HashMap<Address, B256>`
  - Streamlined contract fetching logic with better error messages
  - Eliminated address-to-bytecode mapping in favor of direct hash-to-bytecode mapping
  - Added validation to ensure fetched bytecode matches expected hash

- **Test RPC Server**:
  - Updated mock RPC method from `eth_getCode` to `eth_getCodeByHash`
  - Changed test data structure from `address_bytecodes` to `bytecodes` indexed by hash

### Benefits
1. **Reduced Complexity**: Eliminates unnecessary address tracking when code hash is sufficient
2. **Better Performance**: Batch operations reduce database round trips
3. **Improved Accuracy**: Direct hash-based validation prevents address/hash mismatches
4. **Cleaner API**: More intuitive method signatures aligned with actual data dependencies

### Breaking Changes
None for external users. The changes are internal to the validation system.

### Testing
- All existing tests updated to use new `eth_getCodeByHash` RPC method
- Test fixtures maintain compatibility with new hash-based indexing

### Files Changed
- `bin/stateless-validator/src/main.rs` (97 lines changed)
- `bin/stateless-validator/src/rpc.rs` (27 lines changed)
- `validator-core/src/validator_db.rs` (59 lines changed)
- `validator-core/src/database.rs` (2 lines changed)