### PR TITLE
Fix: Add Logs Bloom and Gas Used Validation

### DIFF
--- a/bin/stateless-validator/src/main.rs
+++ b/bin/stateless-validator/src/main.rs
@@ -7,8 +7,8 @@ use futures::future;
 use op_alloy_rpc_types::Transaction;
 use revm::{primitives::KECCAK_EMPTY, state::Bytecode};
 use salt::SaltWitness;
-use std::collections::{HashMap, HashSet};
 use std::{
+    collections::{HashMap, HashSet},
     path::PathBuf,
     sync::Arc,
     time::{Duration, Instant, SystemTime},


### PR DESCRIPTION
### Summary
This PR enhances block validation by adding checks for `logs_bloom` and `gas_used` fields in the block header. Previously, only the `receipts_root` was validated after transaction execution.

### Changes

#### New Validation Checks
- **Logs Bloom Validation**: Verifies that the computed logs bloom (aggregated from all transaction receipts) matches the block header's `logs_bloom` field
- **Gas Used Validation**: Verifies that the total gas used by all transactions matches the block header's `gas_used` field

#### New Error Types
Added two new validation error variants:
- `ValidationError::LogsBloomMismatch` - Reports discrepancies between computed and claimed logs bloom
- `ValidationError::GasUsedMismatch` - Reports discrepancies between computed and claimed gas used

#### Refactoring
- Introduced `BlockExecutionOutput` struct to encapsulate execution results:
  - `receipts_root`: The computed receipts root
  - `logs_bloom`: The aggregated logs bloom from all receipts
  - `gas_used`: The total gas used by all transactions
- Updated `replay_block()` and `execute_transactions()` to return `BlockExecutionOutput` instead of just the receipts root

#### Implementation Details
- **Logs Bloom Calculation**: Computed by folding over all receipts and ORing their blooms together
- **Gas Used Extraction**: Retrieved from the cumulative gas used of the last receipt in the block

### Testing
This change strengthens block validation by catching malformed blocks that have incorrect `logs_bloom` or `gas_used` values in their headers, even if the receipts root is correct.

### Files Modified
- `validator-core/src/executor.rs` (+80, -14)