### PR TITLE
chore(deps): upgrade mega-evm to v1.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2892,8 +2892,8 @@ dependencies = [
 
 [[package]]
 name = "mega-evm"
-version = "0.0.1"
-source = "git+https://github.com/megaeth-labs/mega-evm.git?rev=9d4eef2e74d3e4b12bd1c044408637c33fb3b9a2#9d4eef2e74d3e4b12bd1c044408637c33fb3b9a2"
+version = "1.1.0"
+source = "git+https://github.com/megaeth-labs/mega-evm.git?rev=v1.1.0#12cb5954ff76173d46389c99481f9313e4e9bd1e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ op-alloy-rpc-types = { version = "0.18.12", default-features = false }
 revm = { version = "27.1.0", default-features = false }
 
 # megaeth 
-mega-evm = { git = "https://github.com/megaeth-labs/mega-evm.git", rev = "9d4eef2e74d3e4b12bd1c044408637c33fb3b9a2" }
+mega-evm = { git = "https://github.com/megaeth-labs/mega-evm.git", rev = "v1.1.0" }
 salt = { git = "https://github.com/megaeth-labs/salt.git", rev = "80a46f2cd4c24417ec7fa265015270c623ae5340" }
 
 # reth


### PR DESCRIPTION
This PR upgrades the mega-evm dependency from rev 9d4eef2e to v1.1.0.