### PR TITLE
chore(deps): upgrade salt version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1171,7 +1171,7 @@ checksum = "7b7e4c2464d97fe331d41de9d5db0def0a96f4d823b8b32a2efd503578988973"
 [[package]]
 name = "banderwagon"
 version = "0.1.0"
-source = "git+https://github.com/megaeth-labs/salt.git?rev=80a46f2cd4c24417ec7fa265015270c623ae5340#80a46f2cd4c24417ec7fa265015270c623ae5340"
+source = "git+https://github.com/megaeth-labs/salt.git?rev=7120f434bdb8a522ac9912044a07b721041e578c#7120f434bdb8a522ac9912044a07b721041e578c"
 dependencies = [
  "ark-ec 0.5.0 (git+https://github.com/megaeth-labs/algebra.git?rev=80ca69c37f79d5d00750edc1602af81b5f456695)",
  "ark-ed-on-bls12-381-bandersnatch",
@@ -2537,7 +2537,7 @@ dependencies = [
 [[package]]
 name = "ipa-multipoint"
 version = "0.1.0"
-source = "git+https://github.com/megaeth-labs/salt.git?rev=80a46f2cd4c24417ec7fa265015270c623ae5340#80a46f2cd4c24417ec7fa265015270c623ae5340"
+source = "git+https://github.com/megaeth-labs/salt.git?rev=7120f434bdb8a522ac9912044a07b721041e578c#7120f434bdb8a522ac9912044a07b721041e578c"
 dependencies = [
  "banderwagon",
  "hex",
@@ -4484,7 +4484,7 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 [[package]]
 name = "salt"
 version = "1.0.0"
-source = "git+https://github.com/megaeth-labs/salt.git?rev=80a46f2cd4c24417ec7fa265015270c623ae5340#80a46f2cd4c24417ec7fa265015270c623ae5340"
+source = "git+https://github.com/megaeth-labs/salt.git?rev=7120f434bdb8a522ac9912044a07b721041e578c#7120f434bdb8a522ac9912044a07b721041e578c"
 dependencies = [
  "auto_impl",
  "banderwagon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ revm = { version = "27.1.0", default-features = false }
 
 # megaeth 
 mega-evm = { git = "https://github.com/megaeth-labs/mega-evm.git", rev = "v1.1.0" }
-salt = { git = "https://github.com/megaeth-labs/salt.git", rev = "80a46f2cd4c24417ec7fa265015270c623ae5340" }
+salt = { git = "https://github.com/megaeth-labs/salt.git", rev = "7120f434bdb8a522ac9912044a07b721041e578c" }
 
 # reth
 reth-ethereum-forks = { git = "https://github.com/paradigmxyz/reth", tag = "v1.6.0" }


### PR DESCRIPTION
### Summary
This PR upgrades the `salt` dependency from revision `80a46f2` to `7120f43`, bringing in the latest updates from the megaeth-labs/salt repository.

To maintain consistency with the salt version in mega-reth
### Changes
- Updated `salt` dependency revision in `Cargo.toml`
- Updated `Cargo.lock` to reflect the new revision for:
  - `salt` (main package)
  - `banderwagon` (transitive dependency)
  - `ipa-multipoint` (transitive dependency)

### Dependency Details
**Old revision:** `80a46f2cd4c24417ec7fa265015270c623ae5340`  
**New revision:** `7120f434bdb8a522ac9912044a07b721041e578c`

### Files Modified
- `Cargo.toml` - Updated salt dependency revision
- `Cargo.lock` - Updated lock file with new dependency versions