### PR TITLE
refactor: Optimize MPT witness verification by replacing CacheState with BundleState

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2892,8 +2892,8 @@ dependencies = [
 
 [[package]]
 name = "mega-evm"
-version = "1.1.0"
-source = "git+https://github.com/megaeth-labs/mega-evm.git?rev=v1.1.0#12cb5954ff76173d46389c99481f9313e4e9bd1e"
+version = "1.1.1"
+source = "git+https://github.com/megaeth-labs/mega-evm.git?rev=v1.1.1#1634b388e334c5aa9c0065469d7603ff21c3ea33"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ op-alloy-rpc-types = { version = "0.18.12", default-features = false }
 revm = { version = "27.1.0", default-features = false }
 
 # megaeth 
-mega-evm = { git = "https://github.com/megaeth-labs/mega-evm.git", rev = "v1.1.0" }
+mega-evm = { git = "https://github.com/megaeth-labs/mega-evm.git", rev = "v1.1.1" }
 salt = { git = "https://github.com/megaeth-labs/salt.git", rev = "7120f434bdb8a522ac9912044a07b721041e578c" }
 
 # reth

--- a/validator-core/src/executor.rs
+++ b/validator-core/src/executor.rs
@@ -239,13 +239,13 @@ fn create_evm_env(header: &Header, chain_spec: &ChainSpec) -> EvmEnv<MegaSpecId>
 ///
 /// # Process
 ///
-/// 1. Creates a state builder with the witness database
+/// 1. Creates a state builder with the witness database and bundle update tracking
 /// 2. Configures block executor with Optimism-specific parameters
 /// 3. Applies pre-execution changes (deposits, etc.)
 /// 4. Executes each transaction in sequence
 /// 5. Applies post-execution changes
-/// 6. Flattens REVM's cache format into plain key-value pairs
-/// 7. Builds the execution output (receipts root, logs bloom, gas used) from all transaction receipts
+/// 6. Merges state transitions into bundle state
+/// 7. Returns bundle accounts and execution output (receipts root, logs bloom, gas used)
 pub fn replay_block<DB, ENV, E>(
     chain_spec: &ChainSpec,
     block: &Block<OpTransaction>,
@@ -415,7 +415,7 @@ pub fn validate_block(
         })
         .unwrap_or_default();
 
-    // Flatten Revm's CacheAccount format into plain key-value pairs
+    // Flatten Revm's BundleAccount format into plain key-value pairs
     let mut kv_updates: BTreeMap<Vec<u8>, Option<Vec<u8>>> = BTreeMap::new();
     for (address, bundle_account) in accounts {
         if bundle_account.info != bundle_account.original_info {

--- a/validator-core/src/withdrawals.rs
+++ b/validator-core/src/withdrawals.rs
@@ -76,7 +76,7 @@ impl MptWitness {
     /// # Arguments
     ///
     /// * `header` - Block header with expected `withdrawals_root` (post-state root)
-    /// * `account` - Storage updates from block execution, or `None` for no changes
+    /// * `storage_updates` - Hashed storage slot updates from block execution (slot hash → value)
     ///
     /// # Errors
     ///


### PR DESCRIPTION
### Summary
This PR refactors the block validation logic to use `BundleAccount` instead of `CacheAccount` for state management, enabling more efficient tracking of actual state changes during block execution.

### Changes

#### `validator-core/src/executor.rs`
- Replaced `CacheAccount` with `BundleAccount` from revm's state management
- Added `.with_bundle_update()` when building state to enable bundle tracking
- Use `merge_transitions(BundleRetention::PlainState)` to consolidate state transitions
- Optimized state change detection by comparing `previous_or_original_value` with `present_value`:
  - Account info changes: Only write when `info != original_info`
  - Storage changes: Only write when `previous_or_original_value != present_value`
- Pre-compute hashed withdrawal storage updates before passing to verification

#### `validator-core/src/withdrawals.rs`
- Simplified `verify()` method signature to accept `B256Map<U256>` directly instead of `Option<CacheAccount>`
- Removed internal storage extraction and hashing logic (now done at call site)
- Streamlined trie update iteration

### Benefits
- **More accurate change detection**: Only actual state modifications are written to the trie, avoiding unnecessary writes for read-only cache entries
- **Cleaner separation of concerns**: Withdrawal verification receives pre-processed storage updates instead of raw account data
- **Reduced complexity**: Eliminates the need for `CacheAccount` component destructuring and special case handling

### Files Changed
- `validator-core/src/executor.rs` (+55, -58)
- `validator-core/src/withdrawals.rs` (+8, -19)