### PR TITLE
Fix validation blocking async tasks & upgrade mega-evm dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2893,11 +2893,12 @@ dependencies = [
 [[package]]
 name = "mega-evm"
 version = "1.1.1"
-source = "git+https://github.com/megaeth-labs/mega-evm.git?rev=v1.1.1#1634b388e334c5aa9c0065469d7603ff21c3ea33"
+source = "git+https://github.com/megaeth-labs/mega-evm.git?rev=3b28c205c8c2f89730a4dd88abe47e1831c6fac9#3b28c205c8c2f89730a4dd88abe47e1831c6fac9"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-evm",
+ "alloy-hardforks",
  "alloy-op-evm",
  "alloy-op-hardforks",
  "alloy-primitives",
@@ -4212,11 +4213,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39a276ed142b4718dcf64bc9624f474373ed82ef20611025045c3fb23edbef9c"
 dependencies = [
  "alloy-eips",
+ "alloy-provider",
+ "alloy-transport",
  "revm-bytecode",
  "revm-database-interface",
  "revm-primitives",
  "revm-state",
  "serde",
+ "tokio",
 ]
 
 [[package]]
@@ -4230,6 +4234,7 @@ dependencies = [
  "revm-primitives",
  "revm-state",
  "serde",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,11 +61,10 @@ debug-assertions = true
 incremental = true
 
 [profile.release]
-opt-level = 3
-debug = true
+lto = "fat"
 debug-assertions = true
-incremental = true
-
+overflow-checks	= true
+strip = true
 
 [profile.test]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,17 +54,12 @@ tracing = "0.1"
 tracing-subscriber = { version = "=0.3.20", features = ["fmt", "env-filter"] }
 tracing-appender = "0.2"
 
-[profile.bench]
-debug = true
-opt-level = 3
-debug-assertions = true
-incremental = true
-
 [profile.release]
-lto = "fat"
-debug-assertions = true
-strip = true
-panic = "abort"
+opt-level = 3
+lto = "thin"
+codegen-units = 1
+panic = "unwind"
+strip = false
 
 [profile.test]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ op-alloy-rpc-types = { version = "0.18.12", default-features = false }
 revm = { version = "27.1.0", default-features = false }
 
 # megaeth 
-mega-evm = { git = "https://github.com/megaeth-labs/mega-evm.git", rev = "v1.1.1" }
+mega-evm = { git = "https://github.com/megaeth-labs/mega-evm.git", rev = "3b28c205c8c2f89730a4dd88abe47e1831c6fac9" }
 salt = { git = "https://github.com/megaeth-labs/salt.git", rev = "7120f434bdb8a522ac9912044a07b721041e578c" }
 
 # reth

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,8 +63,8 @@ incremental = true
 [profile.release]
 lto = "fat"
 debug-assertions = true
-overflow-checks	= true
 strip = true
+panic = "abort"
 
 [profile.test]
 opt-level = 3

--- a/validator-core/src/chain_spec.rs
+++ b/validator-core/src/chain_spec.rs
@@ -118,7 +118,6 @@ impl ChainSpec {
     }
 }
 
-// copy from mega-reth/crates/megaeth/chainspec/src/genesis.rs
 /// MegaETH hardfork configuration in genesis.
 #[derive(Default, Debug, Clone, Copy, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/validator-core/src/chain_spec.rs
+++ b/validator-core/src/chain_spec.rs
@@ -4,8 +4,8 @@ use alloy_genesis::Genesis;
 use alloy_hardforks::{EthereumHardfork, EthereumHardforks, ForkCondition, Hardfork};
 use alloy_op_hardforks::{OpHardfork, OpHardforks};
 use alloy_serde::OtherFields;
-use mega_evm::SpecId;
-use reth_ethereum_forks::{ChainHardforks, hardfork};
+use mega_evm::{MegaHardfork, MegaHardforks, SpecId};
+use reth_ethereum_forks::ChainHardforks;
 use reth_optimism_chainspec::OpChainSpec;
 
 /// Default blob gas price update fraction for Cancun (from EIP-4844)
@@ -34,8 +34,8 @@ impl OpHardforks for ChainSpec {
     }
 }
 
-impl MegaethHardforks for ChainSpec {
-    fn megaeth_fork_activation(&self, fork: MegaethHardfork) -> ForkCondition {
+impl MegaHardforks for ChainSpec {
+    fn mega_fork_activation(&self, fork: MegaHardfork) -> ForkCondition {
         self.hardforks.fork(fork)
     }
 }
@@ -118,37 +118,7 @@ impl ChainSpec {
     }
 }
 
-hardfork! {
-    /// The name of MegaETH hardforks. It is expected to mix with [`EthereumHardfork`] and
-    /// [`OpHardfork`].
-    #[derive(serde::Serialize, serde::Deserialize)]
-    MegaethHardfork {
-        /// Tentative name for the first hardfork.
-        MiniRex,
-        /// Tentative name for the second hardfork.
-        Rex,
-    }
-}
-
-/// Extends [`OpHardforks`] with MegaETH helper methods.
-pub trait MegaethHardforks {
-    /// Retrieves [`ForkCondition`] by a [`MegaethHardfork`]. If `fork` is not present, returns
-    /// [`ForkCondition::Never`].
-    fn megaeth_fork_activation(&self, fork: MegaethHardfork) -> ForkCondition;
-
-    /// Returns `true` if [`MegaethHardfork::MiniRex`] is active at given block timestamp.
-    fn is_mini_rex_active_at_timestamp(&self, timestamp: u64) -> bool {
-        self.megaeth_fork_activation(MegaethHardfork::MiniRex)
-            .active_at_timestamp(timestamp)
-    }
-
-    /// Returns `true` if [`MegaethHardfork::Rex`] is active at given block timestamp.
-    fn is_rex_active_at_timestamp(&self, timestamp: u64) -> bool {
-        self.megaeth_fork_activation(MegaethHardfork::Rex)
-            .active_at_timestamp(timestamp)
-    }
-}
-
+// copy from mega-reth/crates/megaeth/chainspec/src/genesis.rs
 /// MegaETH hardfork configuration in genesis.
 #[derive(Default, Debug, Clone, Copy, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -169,11 +139,11 @@ impl MegaethGenesisHardforks {
     pub fn into_vec(self) -> Vec<(Box<dyn Hardfork>, ForkCondition)> {
         vec![
             (
-                MegaethHardfork::MiniRex.boxed(),
+                MegaHardfork::MiniRex.boxed(),
                 self.mini_rex_time.map(ForkCondition::Timestamp),
             ),
             (
-                MegaethHardfork::Rex.boxed(),
+                MegaHardfork::Rex.boxed(),
                 self.rex_time.map(ForkCondition::Timestamp),
             ),
         ]
@@ -187,11 +157,8 @@ impl MegaethGenesisHardforks {
 pub static MEGA_MAINNET_HARDFORKS: std::sync::LazyLock<ChainHardforks> =
     std::sync::LazyLock::new(|| {
         ChainHardforks::new(vec![
-            (
-                MegaethHardfork::MiniRex.boxed(),
-                ForkCondition::Timestamp(0),
-            ),
-            (MegaethHardfork::Rex.boxed(), ForkCondition::Timestamp(0)),
+            (MegaHardfork::MiniRex.boxed(), ForkCondition::Timestamp(0)),
+            (MegaHardfork::Rex.boxed(), ForkCondition::Timestamp(0)),
         ])
     });
 
@@ -259,7 +226,7 @@ mod tests {
             ForkCondition::Timestamp(6)
         );
         assert_eq!(
-            spec.hardforks.fork(MegaethHardfork::MiniRex),
+            spec.hardforks.fork(MegaHardfork::MiniRex),
             ForkCondition::Timestamp(3)
         );
     }


### PR DESCRIPTION
### Summary
This PR improves the stateless validator's performance by introducing a thread pool for CPU-intensive validation tasks and upgrades the `mega-evm` dependency with refactored hardfork implementations.

### Purpose
To address two issues encountered in testnet v2:
1. The asynchronous runtime was blocked by `validate_one`, resulting in thousands of blocks being validated without the reporter providing any updates.  At the time, the server was running both the witness generator and the validator simultaneously; the generator was using 200% CPU, and the validator, with 32 workers, was using 800% CPU.
2. The issue of the release build size being excessively large. Before the fix, the validator size was 222MB; after the fix, it was 8MB.

### Changes
#### 1. Use thread pool for validation to avoid blocking async tasks
- Wrapped `validate_block()` call in `task::spawn_blocking()` to run CPU-intensive validation in a dedicated thread pool
- This prevents blocking of other async tasks (reporter, tracker, etc.) during validation
- Adjusted function signatures to properly handle `Arc<ChainSpec>` for thread-safe sharing

#### 2. Optimize release build profile
- Changed to `lto = "fat"` for better link-time optimization
- Added `strip = true` to reduce binary size
- Added `panic = "abort"` for smaller binary and faster panic handling
- Removed incremental compilation for release builds

#### 3. Upgrade mega-evm & refactor chainspec hardfork implementation
- Updated `mega-evm` to commit `3b28c205c8c2f89730a4dd88abe47e1831c6fac9`
- Replaced local `MegaethHardfork` and `MegaethHardforks` definitions with `MegaHardfork` and `MegaHardforks` from `mega-evm`
- Simplified `chain_spec.rs` by removing 43 lines of redundant hardfork code
- Implemented `MegaHardforks` trait for `ChainSpec`

### Files Changed
- `Cargo.toml` - Updated dependencies and release profile
- `Cargo.lock` - Updated lockfile
- `bin/stateless-validator/src/main.rs` - Added spawn_blocking for validation
- `validator-core/src/chain_spec.rs` - Refactored hardfork implementation

