### PR TITLE
feat: Add Prometheus Metrics Support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1163,28 +1163,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "aws-lc-rs"
-version = "1.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b5ce75405893cd713f9ab8e297d8e438f624dde7d706108285f7e17a25a180f"
-dependencies = [
- "aws-lc-sys",
- "zeroize",
-]
-
-[[package]]
-name = "aws-lc-sys"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "179c3777a8b5e70e90ea426114ffc565b2c1a9f82f6c4a0c5a34aa6ef5e781b6"
-dependencies = [
- "cc",
- "cmake",
- "dunce",
- "fs_extra",
-]
-
-[[package]]
 name = "az"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1488,15 +1466,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
-name = "cmake"
-version = "0.1.54"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1553,16 +1522,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb402b8d4c85569410425650ce3eddc7d698ed96d39a73f941b08fb63082f1e7"
 dependencies = [
  "unicode-segmentation",
-]
-
-[[package]]
-name = "core-foundation"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -2035,12 +1994,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
-
-[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2374,23 +2327,6 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
-]
-
-[[package]]
-name = "hyper-rustls"
-version = "0.27.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
-dependencies = [
- "http",
- "hyper",
- "hyper-util",
- "rustls",
- "rustls-native-certs",
- "rustls-pki-types",
- "tokio",
- "tokio-rustls",
- "tower-service",
 ]
 
 [[package]]
@@ -3017,14 +2953,12 @@ dependencies = [
  "base64",
  "http-body-util",
  "hyper",
- "hyper-rustls",
  "hyper-util",
  "indexmap 2.12.1",
  "ipnet",
  "metrics",
  "metrics-util",
  "quanta",
- "rustls",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -3325,12 +3259,6 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
-
-[[package]]
-name = "openssl-probe"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "p256"
@@ -4490,20 +4418,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ring"
-version = "0.17.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
-dependencies = [
- "cc",
- "cfg-if",
- "getrandom 0.2.16",
- "libc",
- "untrusted",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "ripemd"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4618,53 +4532,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls"
-version = "0.23.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "533f54bc6a7d4f647e46ad909549eda97bf5afc1585190ef692b4286b198bd8f"
-dependencies = [
- "aws-lc-rs",
- "once_cell",
- "rustls-pki-types",
- "rustls-webpki",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "rustls-native-certs"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9980d917ebb0c0536119ba501e90834767bffc3d60641457fd84a1f3fd337923"
-dependencies = [
- "openssl-probe",
- "rustls-pki-types",
- "schannel",
- "security-framework",
-]
-
-[[package]]
-name = "rustls-pki-types"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "708c0f9d5f54ba0272468c1d306a52c495b31fa155e91bc25371e6df7996908c"
-dependencies = [
- "zeroize",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.103.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
-dependencies = [
- "aws-lc-rs",
- "ring",
- "rustls-pki-types",
- "untrusted",
-]
-
-[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4706,15 +4573,6 @@ dependencies = [
  "serde_arrays",
  "thiserror 2.0.17",
  "zerocopy 0.7.35",
-]
-
-[[package]]
-name = "schannel"
-version = "0.1.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
-dependencies = [
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4801,29 +4659,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcb913707158fadaf0d8702c2db0e857de66eb003ccfdda5924b5f5ac98efb38"
 dependencies = [
  "cc",
-]
-
-[[package]]
-name = "security-framework"
-version = "3.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
-dependencies = [
- "bitflags",
- "core-foundation",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -5445,16 +5280,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-rustls"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
-dependencies = [
- "rustls",
- "tokio",
-]
-
-[[package]]
 name = "tokio-stream"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5690,12 +5515,6 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "untrusted"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "unty"
@@ -5979,20 +5798,11 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -6006,42 +5816,20 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
 version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
  "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -6051,21 +5839,9 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6075,21 +5851,9 @@ checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -6099,33 +5863,15 @@ checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1163,6 +1163,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b5ce75405893cd713f9ab8e297d8e438f624dde7d706108285f7e17a25a180f"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "179c3777a8b5e70e90ea426114ffc565b2c1a9f82f6c4a0c5a34aa6ef5e781b6"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "az"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1466,6 +1488,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
+name = "cmake"
+version = "0.1.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1522,6 +1553,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb402b8d4c85569410425650ce3eddc7d698ed96d39a73f941b08fb63082f1e7"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -1994,6 +2035,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2327,6 +2374,23 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
 ]
 
 [[package]]
@@ -2945,6 +3009,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "metrics-exporter-prometheus"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3589659543c04c7dc5526ec858591015b87cd8746583b51b48ef4353f99dbcda"
+dependencies = [
+ "base64",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "indexmap 2.12.1",
+ "ipnet",
+ "metrics",
+ "metrics-util",
+ "quanta",
+ "rustls",
+ "thiserror 2.0.17",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdfb1365fea27e6dd9dc1dbc19f570198bc86914533ad639dae939635f096be4"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown 0.16.1",
+ "metrics",
+ "quanta",
+ "rand 0.9.2",
+ "rand_xoshiro",
+ "sketches-ddsketch",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3223,6 +3325,12 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "p256"
@@ -3631,6 +3739,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "quanta"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3726,6 +3849,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
  "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
+dependencies = [
+ "rand_core 0.9.3",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -4349,6 +4490,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.16",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "ripemd"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4463,6 +4618,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "533f54bc6a7d4f647e46ad909549eda97bf5afc1585190ef692b4286b198bd8f"
+dependencies = [
+ "aws-lc-rs",
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9980d917ebb0c0536119ba501e90834767bffc3d60641457fd84a1f3fd337923"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "708c0f9d5f54ba0272468c1d306a52c495b31fa155e91bc25371e6df7996908c"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
+dependencies = [
+ "aws-lc-rs",
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4504,6 +4706,15 @@ dependencies = [
  "serde_arrays",
  "thiserror 2.0.17",
  "zerocopy 0.7.35",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4590,6 +4801,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcb913707158fadaf0d8702c2db0e857de66eb003ccfdda5924b5f5ac98efb38"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -4818,6 +5052,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
+name = "sketches-ddsketch"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1e9a774a6c28142ac54bb25d25562e6bcf957493a184f15ad4eebccb23e410a"
+
+[[package]]
 name = "slab"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4940,6 +5180,8 @@ dependencies = [
  "futures",
  "jsonrpsee",
  "jsonrpsee-types",
+ "metrics",
+ "metrics-exporter-prometheus",
  "num_cpus",
  "op-alloy-network",
  "op-alloy-rpc-types",
@@ -5203,6 +5445,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5440,6 +5692,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "unty"
 version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5639,6 +5897,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5699,11 +5979,20 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -5717,20 +6006,42 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
  "windows-link",
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -5740,9 +6051,21 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5752,9 +6075,21 @@ checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
 
 [[package]]
 name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5764,15 +6099,33 @@ checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,8 @@ clap = { version = "4.5", features = ["derive"] }
 dyn-clone = "1.0"
 eyre = "0.6"
 futures = "0.3"
+metrics = "0.24"
+metrics-exporter-prometheus = "0.18"
 num_cpus = "1.17"
 redb = "3.0.1"
 serde = { version = "1.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ dyn-clone = "1.0"
 eyre = "0.6"
 futures = "0.3"
 metrics = "0.24"
-metrics-exporter-prometheus = "0.18"
+metrics-exporter-prometheus = { version = "0.18", default-features = false, features = ["http-listener"] }
 num_cpus = "1.17"
 redb = "3.0.1"
 serde = { version = "1.0", default-features = false }

--- a/README.md
+++ b/README.md
@@ -106,32 +106,35 @@ The validator exposes Prometheus-compatible metrics for monitoring performance, 
 
 Once enabled, metrics are available at `http://0.0.0.0:9090/metrics` for Prometheus scraping.
 
-| Metric                                              | Type      | Description                                                          |
-| --------------------------------------------------- | --------- | -------------------------------------------------------------------- |
-| `stateless_validator_block_validation_time_seconds` | Histogram | Block validation time                                                |
+| Metric                                                  | Type      | Description                                                          |
+| ------------------------------------------------------- | --------- | -------------------------------------------------------------------- |
+| `stateless_validator_block_validation_time_seconds`     | Histogram | Block validation time                                                |
 | `stateless_validator_witness_verification_time_seconds` | Histogram | Witness verification time                                            |
-| `stateless_validator_block_replay_time_seconds`     | Histogram | EVM execution time                                                   |
-| `stateless_validator_salt_update_time_seconds`      | Histogram | SALT update time                                                     |
-| `stateless_validator_transactions_total`            | Counter   | Total transactions validated                                         |
-| `stateless_validator_gas_used_total`                | Counter   | Total gas used in validated blocks                                   |
-| `stateless_validator_block_state_reads`             | Histogram | State reads per block                                                |
-| `stateless_validator_block_state_writes`            | Histogram | State writes per block                                               |
-| `stateless_validator_worker_tasks_completed_total`  | Counter   | Tasks completed per worker (with `worker_id` label)                  |
-| `stateless_validator_worker_tasks_failed_total`     | Counter   | Tasks failed per worker (with `worker_id` label)                     |
-| `stateless_validator_local_chain_height`            | Gauge     | Current height of local chain                                        |
-| `stateless_validator_remote_chain_height`           | Gauge     | Current height of remote chain tracker                               |
-| `stateless_validator_validation_lag`                | Gauge     | Blocks pending validation (remote - local)                           |
-| `stateless_validator_reorgs_detected_total`         | Counter   | Chain reorgs detected                                                |
-| `stateless_validator_reorg_depth`                   | Histogram | Depth of chain reorganizations                                       |
-| `stateless_validator_rpc_requests_total`            | Counter   | Total RPC requests (with `method` label)                             |
-| `stateless_validator_rpc_errors_total`              | Counter   | RPC errors (with `method` label)                                     |
-| `stateless_validator_block_fetch_time_seconds`      | Histogram | Block fetch time                                                     |
-| `stateless_validator_witness_fetch_time_seconds`    | Histogram | Witness fetch time                                                   |
-| `stateless_validator_code_fetch_time_seconds`       | Histogram | Contract code fetch time (includes optional `type="per_code"` label) |
-| `stateless_validator_contract_cache_hits_total`     | Counter   | Contract cache hits                                                  |
-| `stateless_validator_contract_cache_misses_total`   | Counter   | Contract cache misses                                                |
-| `stateless_validator_blocks_pruned_total`           | Counter   | Blocks pruned from history                                           |
-| `stateless_validator_witness_salt_keys`             | Histogram | Salt witness key count                                               |
+| `stateless_validator_block_replay_time_seconds`         | Histogram | EVM execution time                                                   |
+| `stateless_validator_salt_update_time_seconds`          | Histogram | SALT update time                                                     |
+| `stateless_validator_transactions_total`                | Counter   | Total transactions validated                                         |
+| `stateless_validator_gas_used_total`                    | Counter   | Total gas used in validated blocks                                   |
+| `stateless_validator_block_state_reads`                 | Histogram | State reads per block                                                |
+| `stateless_validator_block_state_writes`                | Histogram | State writes per block                                               |
+| `stateless_validator_worker_tasks_completed_total`      | Counter   | Tasks completed per worker (with `worker_id` label)                  |
+| `stateless_validator_worker_tasks_failed_total`         | Counter   | Tasks failed per worker (with `worker_id` label)                     |
+| `stateless_validator_local_chain_height`                | Gauge     | Current height of local chain                                        |
+| `stateless_validator_remote_chain_height`               | Gauge     | Current height of remote chain tracker                               |
+| `stateless_validator_validation_lag`                    | Gauge     | Blocks pending validation (remote - local)                           |
+| `stateless_validator_reorgs_detected_total`             | Counter   | Chain reorgs detected                                                |
+| `stateless_validator_reorg_depth`                       | Histogram | Depth of chain reorganizations                                       |
+| `stateless_validator_rpc_requests_total`                | Counter   | Total RPC requests (with `method` label)                             |
+| `stateless_validator_rpc_errors_total`                  | Counter   | RPC errors (with `method` label)                                     |
+| `stateless_validator_block_fetch_time_seconds`          | Histogram | Block fetch time                                                     |
+| `stateless_validator_witness_fetch_time_seconds`        | Histogram | Witness fetch time                                                   |
+| `stateless_validator_code_fetch_time_seconds`           | Histogram | Contract code fetch time (includes optional `type="per_code"` label) |
+| `stateless_validator_contract_cache_hits_total`         | Counter   | Contract cache hits                                                  |
+| `stateless_validator_contract_cache_misses_total`       | Counter   | Contract cache misses                                                |
+| `stateless_validator_blocks_pruned_total`               | Counter   | Blocks pruned from history                                           |
+| `stateless_validator_salt_witness_keys`                 | Histogram | Salt witness key count                                               |
+| `stateless_validator_salt_witness_size_bytes`           | Histogram | Salt witness size (bytes)                                            |
+| `stateless_validator_salt_witness_kvs_bytes`            | Histogram | Salt witness KVs size (bytes)                                        |
+| `stateless_validator_mpt_witness_size_bytes`            | Histogram | MPT witness size (bytes)                                             |
 
 **Example Prometheus configuration:**
 

--- a/README.md
+++ b/README.md
@@ -106,30 +106,26 @@ The validator exposes Prometheus-compatible metrics for monitoring performance, 
 
 Once enabled, metrics are available at `http://0.0.0.0:9090/metrics` for Prometheus scraping.
 
-| Metric                                                  | Type      | Description                                                          |
-| ------------------------------------------------------- | --------- | -------------------------------------------------------------------- |
-| `stateless_validator_blocks_validated_total`            | Counter   | Total blocks successfully validated                                  |
-| `stateless_validator_blocks_failed_total`               | Counter   | Total blocks that failed validation (with `error_type` label)        |
-| `stateless_validator_block_validation_duration_seconds` | Histogram | Block validation time                                                |
-| `stateless_validator_transactions_per_block`            | Histogram | Transactions per validated block                                     |
-| `stateless_validator_gas_used_per_block`                | Histogram | Gas used per validated block                                         |
-| `stateless_validator_worker_tasks_completed_total`      | Counter   | Tasks completed per worker (with `worker_id` label)                  |
-| `stateless_validator_worker_tasks_failed_total`         | Counter   | Tasks failed per worker (with `worker_id` label)                     |
-| `stateless_validator_canonical_chain_height`            | Gauge     | Current height of local canonical chain                              |
-| `stateless_validator_remote_chain_height`               | Gauge     | Current height of remote chain tracker                               |
-| `stateless_validator_chain_gap`                         | Gauge     | Gap between remote and canonical chains                              |
-| `stateless_validator_blocks_advanced_total`             | Counter   | Blocks advanced on canonical chain                                   |
-| `stateless_validator_reorgs_detected_total`             | Counter   | Chain reorganizations detected                                       |
-| `stateless_validator_reorg_depth`                       | Histogram | Depth of chain reorganizations                                       |
-| `stateless_validator_rpc_requests_total`                | Counter   | Total RPC requests (with `method` label)                             |
-| `stateless_validator_rpc_errors_total`                  | Counter   | RPC errors (with `method` label)                                     |
-| `stateless_validator_rpc_latency_seconds`               | Histogram | RPC request latency (with `method` label)                            |
-| `stateless_validator_block_fetch_duration_seconds`      | Histogram | Block fetch time                                                     |
-| `stateless_validator_witness_fetch_duration_seconds`    | Histogram | Witness fetch time                                                   |
-| `stateless_validator_code_fetch_duration_seconds`       | Histogram | Contract code fetch time (includes optional `type="per_code"` label) |
-| `stateless_validator_contract_cache_hits_total`         | Counter   | Contract cache hits                                                  |
-| `stateless_validator_contract_cache_misses_total`       | Counter   | Contract cache misses                                                |
-| `stateless_validator_blocks_pruned_total`               | Counter   | Blocks pruned from history                                           |
+| Metric                                              | Type      | Description                                                          |
+| --------------------------------------------------- | --------- | -------------------------------------------------------------------- |
+| `stateless_validator_block_validation_time_seconds` | Histogram | Block validation time                                                |
+| `stateless_validator_transactions_per_block`        | Histogram | Transactions per validated block                                     |
+| `stateless_validator_gas_used_per_block`            | Histogram | Gas used per validated block                                         |
+| `stateless_validator_worker_tasks_completed_total`  | Counter   | Tasks completed per worker (with `worker_id` label)                  |
+| `stateless_validator_worker_tasks_failed_total`     | Counter   | Tasks failed per worker (with `worker_id` label)                     |
+| `stateless_validator_local_chain_height`            | Gauge     | Current height of local canonical chain                              |
+| `stateless_validator_remote_chain_height`           | Gauge     | Current height of remote chain tracker                               |
+| `stateless_validator_validation_lag`                | Gauge     | Blocks pending validation (remote - local)                           |
+| `stateless_validator_reorgs_detected_total`         | Counter   | Chain reorganizations detected                                       |
+| `stateless_validator_reorg_depth`                   | Histogram | Depth of chain reorganizations                                       |
+| `stateless_validator_rpc_requests_total`            | Counter   | Total RPC requests (with `method` label)                             |
+| `stateless_validator_rpc_errors_total`              | Counter   | RPC errors (with `method` label)                                     |
+| `stateless_validator_block_fetch_time_seconds`      | Histogram | Block fetch time                                                     |
+| `stateless_validator_witness_fetch_time_seconds`    | Histogram | Witness fetch time                                                   |
+| `stateless_validator_code_fetch_time_seconds`       | Histogram | Contract code fetch time (includes optional `type="per_code"` label) |
+| `stateless_validator_contract_cache_hits_total`     | Counter   | Contract cache hits                                                  |
+| `stateless_validator_contract_cache_misses_total`   | Counter   | Contract cache misses                                                |
+| `stateless_validator_blocks_pruned_total`           | Counter   | Blocks pruned from history                                           |
 
 **Example Prometheus configuration:**
 

--- a/README.md
+++ b/README.md
@@ -113,10 +113,10 @@ Once enabled, metrics are available at `http://0.0.0.0:9090/metrics` for Prometh
 | `stateless_validator_gas_used_per_block`            | Histogram | Gas used per validated block                                         |
 | `stateless_validator_worker_tasks_completed_total`  | Counter   | Tasks completed per worker (with `worker_id` label)                  |
 | `stateless_validator_worker_tasks_failed_total`     | Counter   | Tasks failed per worker (with `worker_id` label)                     |
-| `stateless_validator_local_chain_height`            | Gauge     | Current height of local canonical chain                              |
+| `stateless_validator_local_chain_height`            | Gauge     | Current height of local local chain                                  |
 | `stateless_validator_remote_chain_height`           | Gauge     | Current height of remote chain tracker                               |
 | `stateless_validator_validation_lag`                | Gauge     | Blocks pending validation (remote - local)                           |
-| `stateless_validator_reorgs_detected_total`         | Counter   | Chain reorganizations detected                                       |
+| `stateless_validator_reorgs_detected_total`         | Counter   | Chain reorgs detected                                                |
 | `stateless_validator_reorg_depth`                   | Histogram | Depth of chain reorganizations                                       |
 | `stateless_validator_rpc_requests_total`            | Counter   | Total RPC requests (with `method` label)                             |
 | `stateless_validator_rpc_errors_total`              | Counter   | RPC errors (with `method` label)                                     |

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Once enabled, metrics are available at `http://0.0.0.0:9090/metrics` for Prometh
 | Metric                                              | Type      | Description                                                          |
 | --------------------------------------------------- | --------- | -------------------------------------------------------------------- |
 | `stateless_validator_block_validation_time_seconds` | Histogram | Block validation time                                                |
-| `stateless_validator_witness_verify_time_seconds`   | Histogram | Witness verification time                                            |
+| `stateless_validator_witness_verification_time_seconds` | Histogram | Witness verification time                                            |
 | `stateless_validator_block_replay_time_seconds`     | Histogram | EVM execution time                                                   |
 | `stateless_validator_salt_update_time_seconds`      | Histogram | SALT update time                                                     |
 | `stateless_validator_transactions_total`            | Counter   | Total transactions validated                                         |
@@ -131,10 +131,7 @@ Once enabled, metrics are available at `http://0.0.0.0:9090/metrics` for Prometh
 | `stateless_validator_contract_cache_hits_total`     | Counter   | Contract cache hits                                                  |
 | `stateless_validator_contract_cache_misses_total`   | Counter   | Contract cache misses                                                |
 | `stateless_validator_blocks_pruned_total`           | Counter   | Blocks pruned from history                                           |
-| `stateless_validator_witness_salt_size_bytes`       | Histogram | Salt witness size in bytes                                           |
 | `stateless_validator_witness_salt_keys`             | Histogram | Salt witness key count                                               |
-| `stateless_validator_witness_salt_kvs_bytes`        | Histogram | Salt witness KVs size in bytes                                       |
-| `stateless_validator_witness_mpt_size_bytes`        | Histogram | MPT witness size in bytes                                            |
 
 **Example Prometheus configuration:**
 

--- a/README.md
+++ b/README.md
@@ -109,11 +109,16 @@ Once enabled, metrics are available at `http://0.0.0.0:9090/metrics` for Prometh
 | Metric                                              | Type      | Description                                                          |
 | --------------------------------------------------- | --------- | -------------------------------------------------------------------- |
 | `stateless_validator_block_validation_time_seconds` | Histogram | Block validation time                                                |
-| `stateless_validator_transactions_per_block`        | Histogram | Transactions per validated block                                     |
-| `stateless_validator_gas_used_per_block`            | Histogram | Gas used per validated block                                         |
+| `stateless_validator_witness_verify_time_seconds`   | Histogram | Witness verification time                                            |
+| `stateless_validator_block_replay_time_seconds`     | Histogram | EVM execution time                                                   |
+| `stateless_validator_salt_update_time_seconds`      | Histogram | SALT update time                                                     |
+| `stateless_validator_transactions_total`            | Counter   | Total transactions validated                                         |
+| `stateless_validator_gas_used_total`                | Counter   | Total gas used in validated blocks                                   |
+| `stateless_validator_block_state_reads`             | Histogram | State reads per block                                                |
+| `stateless_validator_block_state_writes`            | Histogram | State writes per block                                               |
 | `stateless_validator_worker_tasks_completed_total`  | Counter   | Tasks completed per worker (with `worker_id` label)                  |
 | `stateless_validator_worker_tasks_failed_total`     | Counter   | Tasks failed per worker (with `worker_id` label)                     |
-| `stateless_validator_local_chain_height`            | Gauge     | Current height of local local chain                                  |
+| `stateless_validator_local_chain_height`            | Gauge     | Current height of local chain                                        |
 | `stateless_validator_remote_chain_height`           | Gauge     | Current height of remote chain tracker                               |
 | `stateless_validator_validation_lag`                | Gauge     | Blocks pending validation (remote - local)                           |
 | `stateless_validator_reorgs_detected_total`         | Counter   | Chain reorgs detected                                                |
@@ -126,6 +131,10 @@ Once enabled, metrics are available at `http://0.0.0.0:9090/metrics` for Prometh
 | `stateless_validator_contract_cache_hits_total`     | Counter   | Contract cache hits                                                  |
 | `stateless_validator_contract_cache_misses_total`   | Counter   | Contract cache misses                                                |
 | `stateless_validator_blocks_pruned_total`           | Counter   | Blocks pruned from history                                           |
+| `stateless_validator_witness_salt_size_bytes`       | Histogram | Salt witness size in bytes                                           |
+| `stateless_validator_witness_salt_keys`             | Histogram | Salt witness key count                                               |
+| `stateless_validator_witness_salt_kvs_bytes`        | Histogram | Salt witness KVs size in bytes                                       |
+| `stateless_validator_witness_mpt_size_bytes`        | Histogram | MPT witness size in bytes                                            |
 
 **Example Prometheus configuration:**
 

--- a/bin/stateless-validator/Cargo.toml
+++ b/bin/stateless-validator/Cargo.toml
@@ -29,6 +29,8 @@ bincode.workspace = true
 clap = { workspace = true, features = ["env"] }
 eyre.workspace = true
 futures.workspace = true
+metrics.workspace = true
+metrics-exporter-prometheus.workspace = true
 num_cpus.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/bin/stateless-validator/src/main.rs
+++ b/bin/stateless-validator/src/main.rs
@@ -444,7 +444,6 @@ async fn chain_sync(
                 (validator_db.get_local_tip(), validator_db.get_remote_tip())
             {
                 let remote_height = remote_tip.map(|(n, _)| n).unwrap_or(local_tip);
-                // The overhead is negligible when metrics are disabled
                 metrics::set_chain_heights(local_tip, remote_height);
             }
 

--- a/bin/stateless-validator/src/main.rs
+++ b/bin/stateless-validator/src/main.rs
@@ -534,8 +534,7 @@ async fn remote_chain_tracker(
                     match find_divergence_point(&client, &validator_db, remote_tip.0).await {
                         Ok(rollback_to) => {
                             warn!("[Tracker] Rolling back to block {rollback_to}");
-                            let reorg_depth = remote_tip.0.saturating_sub(rollback_to);
-                            metrics::on_chain_reorg(reorg_depth);
+                            metrics::on_chain_reorg(remote_tip.0.saturating_sub(rollback_to));
                             validator_db.rollback_chain(rollback_to)?;
                             return Ok(());
                         }
@@ -774,13 +773,13 @@ async fn validate_one(
             let (success, error_message) = match &validation_result {
                 Ok(stats) => {
                     info!("[Worker {worker_id}] Successfully validated block {block_number}");
-                    metrics::on_block_validation_time(
+                    metrics::on_validation_time(
                         start.elapsed().as_secs_f64(),
                         stats.witness_verify_time,
                         stats.block_replay_time,
                         stats.salt_update_time,
                     );
-                    metrics::on_block_validation(
+                    metrics::on_block_stats(
                         tx_count,
                         gas_used,
                         stats.state_reads,

--- a/bin/stateless-validator/src/main.rs
+++ b/bin/stateless-validator/src/main.rs
@@ -445,6 +445,7 @@ async fn chain_sync(
                 (validator_db.get_local_tip(), validator_db.get_remote_tip())
             {
                 let remote_height = remote_tip.map(|(n, _)| n).unwrap_or(local_tip);
+                // The overhead is negligible when metrics are disabled
                 metrics::set_chain_heights(local_tip, remote_height);
             }
 

--- a/bin/stateless-validator/src/metrics.rs
+++ b/bin/stateless-validator/src/metrics.rs
@@ -58,10 +58,10 @@ pub mod names {
     metric!(BLOCKS_PRUNED, "blocks_pruned_total");
 
     // Witness
-    metric!(WITNESS_SALT_SIZE, "witness_salt_size_bytes");
-    metric!(WITNESS_SALT_KEYS, "witness_salt_keys");
-    metric!(WITNESS_SALT_KVS_SIZE, "witness_salt_kvs_bytes");
-    metric!(WITNESS_MPT_SIZE, "witness_mpt_size_bytes");
+    metric!(SALT_WITNESS_SIZE, "salt_witness_size_bytes");
+    metric!(SALT_WITNESS_KEYS, "salt_witness_keys");
+    metric!(SALT_WITNESS_KVS_SIZE, "salt_witness_kvs_bytes");
+    metric!(MPT_WITNESS_SIZE, "mpt_witness_size_bytes");
 }
 
 /// Initialize the Prometheus metrics exporter at the given address.
@@ -118,11 +118,11 @@ fn register_metric_descriptions() {
     describe_counter!(names::BLOCKS_PRUNED, "Blocks pruned from history");
 
     // Witness
-    describe_histogram!(names::WITNESS_SALT_SIZE, "Salt witness size (bytes)");
-    describe_histogram!(names::WITNESS_MPT_SIZE, "MPT witness size (bytes)");
-    describe_histogram!(names::WITNESS_SALT_KEYS, "Salt witness key count");
+    describe_histogram!(names::SALT_WITNESS_SIZE, "Salt witness size (bytes)");
+    describe_histogram!(names::MPT_WITNESS_SIZE, "MPT witness size (bytes)");
+    describe_histogram!(names::SALT_WITNESS_KEYS, "Salt witness key count");
     describe_histogram!(
-        names::WITNESS_SALT_KVS_SIZE,
+        names::SALT_WITNESS_KVS_SIZE,
         "Salt witness KVs size (bytes)"
     );
 }
@@ -226,8 +226,8 @@ pub fn on_blocks_pruned(count: u64) {
 
 // Witness metrics
 pub fn on_witness_stats(salt_size: usize, keys_count: usize, kvs_size: usize, mpt_size: usize) {
-    histogram!(names::WITNESS_SALT_SIZE).record(salt_size as f64);
-    histogram!(names::WITNESS_SALT_KEYS).record(keys_count as f64);
-    histogram!(names::WITNESS_SALT_KVS_SIZE).record(kvs_size as f64);
-    histogram!(names::WITNESS_MPT_SIZE).record(mpt_size as f64);
+    histogram!(names::SALT_WITNESS_SIZE).record(salt_size as f64);
+    histogram!(names::SALT_WITNESS_KEYS).record(keys_count as f64);
+    histogram!(names::SALT_WITNESS_KVS_SIZE).record(kvs_size as f64);
+    histogram!(names::MPT_WITNESS_SIZE).record(mpt_size as f64);
 }

--- a/bin/stateless-validator/src/metrics.rs
+++ b/bin/stateless-validator/src/metrics.rs
@@ -90,7 +90,7 @@ fn register_metric_descriptions() {
     describe_counter!(names::WORKER_TASKS_FAILED, "Tasks that failed");
 
     // Chain
-    describe_gauge!(names::LOCAL_CHAIN_HEIGHT, "Local local chain height");
+    describe_gauge!(names::LOCAL_CHAIN_HEIGHT, "Local chain height");
     describe_gauge!(names::REMOTE_CHAIN_HEIGHT, "Remote chain height");
     describe_gauge!(
         names::VALIDATION_LAG,

--- a/bin/stateless-validator/src/metrics.rs
+++ b/bin/stateless-validator/src/metrics.rs
@@ -225,7 +225,7 @@ pub fn on_blocks_pruned(count: u64) {
 }
 
 // Witness metrics
-pub fn on_witness_stats(salt_size: usize, keys_count: usize, kvs_size: usize, mpt_size: usize) {
+pub fn on_witness_fetch(salt_size: usize, keys_count: usize, kvs_size: usize, mpt_size: usize) {
     histogram!(names::SALT_WITNESS_SIZE).record(salt_size as f64);
     histogram!(names::SALT_WITNESS_KEYS).record(keys_count as f64);
     histogram!(names::SALT_WITNESS_KVS_SIZE).record(kvs_size as f64);

--- a/bin/stateless-validator/src/metrics.rs
+++ b/bin/stateless-validator/src/metrics.rs
@@ -121,15 +121,16 @@ fn register_metric_descriptions() {
     );
 }
 
-// Record all validation metrics for a block.
-pub fn on_block_validation_time(duration: f64, wit_verify: f64, replay: f64, salt_update: f64) {
+/// Record validation timing breakdown for a block.
+pub fn on_validation_time(duration: f64, wit_verify: f64, replay: f64, salt_update: f64) {
     histogram!(names::BLOCK_VALIDATION_TIME).record(duration);
     histogram!(names::WITNESS_VERIFY_TIME).record(wit_verify);
     histogram!(names::BLOCK_REPLAY_TIME).record(replay);
     histogram!(names::SALT_UPDATE_TIME).record(salt_update);
 }
 
-pub fn on_block_validation(tx_count: u64, gas_used: u64, state_reads: usize, state_writes: usize) {
+/// Record block statistics after successful validation.
+pub fn on_block_stats(tx_count: u64, gas_used: u64, state_reads: usize, state_writes: usize) {
     counter!(names::TRANSACTIONS_TOTAL).increment(tx_count);
     counter!(names::GAS_USED_TOTAL).increment(gas_used);
     histogram!(names::BLOCK_STATE_READS).record(state_reads as f64);

--- a/bin/stateless-validator/src/metrics.rs
+++ b/bin/stateless-validator/src/metrics.rs
@@ -1,0 +1,211 @@
+//! Prometheus-compatible metrics for the stateless validator.
+//!
+//! This module provides Prometheus-compatible metrics for monitoring the validator's
+//! performance, health, and resource utilization. Metrics are exposed via an HTTP
+//! endpoint that can be scraped by Prometheus or compatible monitoring systems.
+//!
+//! ## Metric Categories
+//!
+//! - **Validation**: Block validation timing, success/failure rates, throughput
+//! - **Worker**: Task processing statistics
+//! - **Chain**: Chain progression, gaps, reorg tracking
+//! - **RPC**: Request latency, error rates, fetch timing
+//! - **Database**: Cache statistics
+//!
+//! Enable via `--metrics-enabled --metrics-port 9090` or environment variables.
+//! Metrics available at `http://0.0.0.0:<port>/metrics`
+
+use eyre::Result;
+use metrics::{counter, describe_counter, describe_gauge, describe_histogram, gauge, histogram};
+use metrics_exporter_prometheus::PrometheusBuilder;
+use std::net::SocketAddr;
+use tracing::info;
+
+/// Default port for Prometheus metrics HTTP endpoint
+pub const DEFAULT_METRICS_PORT: u16 = 9090;
+
+/// Metric names as constants for consistency
+pub mod names {
+    macro_rules! metric {
+        ($name:ident, $suffix:expr) => {
+            pub const $name: &str = concat!("stateless_validator_", $suffix);
+        };
+    }
+
+    // Validation
+    metric!(BLOCKS_VALIDATED_TOTAL, "blocks_validated_total");
+    metric!(BLOCKS_FAILED_TOTAL, "blocks_failed_total");
+    metric!(
+        BLOCK_VALIDATION_DURATION,
+        "block_validation_duration_seconds"
+    );
+    metric!(TRANSACTIONS_PER_BLOCK, "transactions_per_block");
+    metric!(GAS_USED_PER_BLOCK, "gas_used_per_block");
+
+    // Worker
+    metric!(WORKER_TASKS_COMPLETED, "worker_tasks_completed_total");
+    metric!(WORKER_TASKS_FAILED, "worker_tasks_failed_total");
+
+    // Chain
+    metric!(CANONICAL_CHAIN_HEIGHT, "canonical_chain_height");
+    metric!(REMOTE_CHAIN_HEIGHT, "remote_chain_height");
+    metric!(CHAIN_GAP, "chain_gap");
+    metric!(BLOCKS_ADVANCED, "blocks_advanced_total");
+    metric!(REORGS_DETECTED, "reorgs_detected_total");
+    metric!(REORG_DEPTH, "reorg_depth");
+
+    // RPC
+    metric!(RPC_REQUESTS_TOTAL, "rpc_requests_total");
+    metric!(RPC_ERRORS_TOTAL, "rpc_errors_total");
+    metric!(RPC_LATENCY, "rpc_latency_seconds");
+    metric!(BLOCK_FETCH_DURATION, "block_fetch_duration_seconds");
+    metric!(WITNESS_FETCH_DURATION, "witness_fetch_duration_seconds");
+    metric!(CODE_FETCH_DURATION, "code_fetch_duration_seconds");
+
+    // Database
+    metric!(CONTRACT_CACHE_HITS, "contract_cache_hits_total");
+    metric!(CONTRACT_CACHE_MISSES, "contract_cache_misses_total");
+    metric!(BLOCKS_PRUNED, "blocks_pruned_total");
+}
+
+/// Initialize the Prometheus metrics exporter.
+///
+/// Sets up an HTTP server that exposes metrics at `/metrics` endpoint.
+/// The server runs in the background and is automatically cleaned up
+/// when the process exits.
+pub fn init_metrics(addr: SocketAddr) -> Result<()> {
+    PrometheusBuilder::new()
+        .with_http_listener(addr)
+        .install()
+        .map_err(|e| eyre::eyre!("Failed to install Prometheus exporter: {}", e))?;
+
+    register_metric_descriptions();
+    info!("[Metrics] Prometheus exporter listening on {}", addr);
+    Ok(())
+}
+
+/// Register descriptions for all metrics.
+///
+/// This provides human-readable descriptions that appear in Prometheus
+/// and monitoring UIs.
+fn register_metric_descriptions() {
+    // Validation
+    describe_counter!(
+        names::BLOCKS_VALIDATED_TOTAL,
+        "Blocks successfully validated"
+    );
+    describe_counter!(names::BLOCKS_FAILED_TOTAL, "Blocks that failed validation");
+    describe_histogram!(
+        names::BLOCK_VALIDATION_DURATION,
+        "Block validation time (s)"
+    );
+    describe_histogram!(names::TRANSACTIONS_PER_BLOCK, "Transactions per block");
+    describe_histogram!(names::GAS_USED_PER_BLOCK, "Gas used per block");
+
+    // Worker
+    describe_counter!(names::WORKER_TASKS_COMPLETED, "Tasks completed by workers");
+    describe_counter!(names::WORKER_TASKS_FAILED, "Tasks that failed");
+
+    // Chain
+    describe_gauge!(
+        names::CANONICAL_CHAIN_HEIGHT,
+        "Local canonical chain height"
+    );
+    describe_gauge!(names::REMOTE_CHAIN_HEIGHT, "Remote chain height");
+    describe_gauge!(names::CHAIN_GAP, "Gap between remote and canonical heights");
+    describe_counter!(names::BLOCKS_ADVANCED, "Blocks advanced on canonical chain");
+    describe_counter!(names::REORGS_DETECTED, "Chain reorganizations detected");
+    describe_histogram!(names::REORG_DEPTH, "Reorg depth");
+
+    // RPC
+    describe_counter!(names::RPC_REQUESTS_TOTAL, "RPC requests made");
+    describe_counter!(names::RPC_ERRORS_TOTAL, "RPC errors encountered");
+    describe_histogram!(names::RPC_LATENCY, "RPC latency (s)");
+    describe_histogram!(names::BLOCK_FETCH_DURATION, "Block fetch time (s)");
+    describe_histogram!(names::WITNESS_FETCH_DURATION, "Witness fetch time (s)");
+    describe_histogram!(names::CODE_FETCH_DURATION, "Code fetch time (s)");
+
+    // Database
+    describe_counter!(names::CONTRACT_CACHE_HITS, "Contract cache hits");
+    describe_counter!(names::CONTRACT_CACHE_MISSES, "Contract cache misses");
+    describe_counter!(names::BLOCKS_PRUNED, "Blocks pruned from history");
+}
+
+// Validation metrics
+pub fn record_block_validated(duration_secs: f64, tx_count: u64, gas_used: u64) {
+    counter!(names::BLOCKS_VALIDATED_TOTAL).increment(1);
+    histogram!(names::BLOCK_VALIDATION_DURATION).record(duration_secs);
+    histogram!(names::TRANSACTIONS_PER_BLOCK).record(tx_count as f64);
+    histogram!(names::GAS_USED_PER_BLOCK).record(gas_used as f64);
+}
+
+pub fn record_block_failed(error_type: &str) {
+    counter!(names::BLOCKS_FAILED_TOTAL, "error_type" => error_type.to_string()).increment(1);
+}
+
+// Worker metrics
+pub fn record_worker_task_completed(worker_id: usize) {
+    counter!(names::WORKER_TASKS_COMPLETED, "worker_id" => worker_id.to_string()).increment(1);
+}
+
+pub fn record_worker_task_failed(worker_id: usize) {
+    counter!(names::WORKER_TASKS_FAILED, "worker_id" => worker_id.to_string()).increment(1);
+}
+
+// Chain metrics
+pub fn set_chain_heights(canonical: u64, remote: u64) {
+    gauge!(names::CANONICAL_CHAIN_HEIGHT).set(canonical as f64);
+    gauge!(names::REMOTE_CHAIN_HEIGHT).set(remote as f64);
+    gauge!(names::CHAIN_GAP).set((remote.saturating_sub(canonical)) as f64);
+}
+
+pub fn record_blocks_advanced(count: u64) {
+    counter!(names::BLOCKS_ADVANCED).increment(count);
+}
+
+pub fn record_reorg(depth: u64) {
+    counter!(names::REORGS_DETECTED).increment(1);
+    histogram!(names::REORG_DEPTH).record(depth as f64);
+}
+
+// RPC metrics
+pub fn record_rpc_request(method: &str, duration_secs: f64, success: bool) {
+    let method = method.to_string();
+    counter!(names::RPC_REQUESTS_TOTAL, "method" => method.clone()).increment(1);
+    histogram!(names::RPC_LATENCY, "method" => method.clone()).record(duration_secs);
+    if !success {
+        counter!(names::RPC_ERRORS_TOTAL, "method" => method).increment(1);
+    }
+}
+
+pub fn record_block_fetch(duration_secs: f64) {
+    histogram!(names::BLOCK_FETCH_DURATION).record(duration_secs);
+}
+
+pub fn record_witness_fetch(duration_secs: f64) {
+    histogram!(names::WITNESS_FETCH_DURATION).record(duration_secs);
+}
+
+pub fn record_code_fetch(duration_secs: f64, count: usize) {
+    histogram!(names::CODE_FETCH_DURATION).record(duration_secs);
+    if count > 1 {
+        histogram!(names::CODE_FETCH_DURATION, "type" => "per_code")
+            .record(duration_secs / count as f64);
+    }
+}
+
+pub fn record_contract_cache_hits(count: u64) {
+    if count > 0 {
+        counter!(names::CONTRACT_CACHE_HITS).increment(count);
+    }
+}
+
+pub fn record_contract_cache_misses(count: u64) {
+    if count > 0 {
+        counter!(names::CONTRACT_CACHE_MISSES).increment(count);
+    }
+}
+
+pub fn record_blocks_pruned(count: u64) {
+    counter!(names::BLOCKS_PRUNED).increment(count);
+}

--- a/bin/stateless-validator/src/rpc.rs
+++ b/bin/stateless-validator/src/rpc.rs
@@ -196,7 +196,7 @@ impl RpcClient {
         // MptWitness: storage_root (32 bytes) + sum of state bytes
         let mpt_size = 32 + mpt_witness.state.iter().map(|b| b.len()).sum::<usize>();
 
-        metrics::on_witness_stats(salt_size, kvs_count, salt_kvs_size, mpt_size);
+        metrics::on_witness_fetch(salt_size, kvs_count, salt_kvs_size, mpt_size);
 
         Ok((witness, mpt_witness))
     }

--- a/scripts/validator-status.sh
+++ b/scripts/validator-status.sh
@@ -56,10 +56,9 @@ if [ -n "$VAL_COUNT" ] && [ "$VAL_COUNT" != "0" ]; then
     # Validation phase breakdown
     WITNESS_VERIFY=$(hist_avg 'stateless_validator_witness_verify_time_seconds')
     BLOCK_REPLAY=$(hist_avg 'stateless_validator_block_replay_time_seconds')
-    STATE_UPDATE=$(hist_avg 'stateless_validator_state_update_time_seconds')
-    STATE_ROOT=$(hist_avg 'stateless_validator_state_root_time_seconds')
-    printf "   Phases (avg): Witness: %s ms | Replay: %s ms | State: %s ms | Root: %s ms\n" \
-        "$(fmt_ms "$WITNESS_VERIFY")" "$(fmt_ms "$BLOCK_REPLAY")" "$(fmt_ms "$STATE_UPDATE")" "$(fmt_ms "$STATE_ROOT")"
+    SALT_UPDATE=$(hist_avg 'stateless_validator_salt_update_time_seconds')
+    printf "   Phases (avg): Witness: %s ms | Replay: %s ms | State: %s ms \n" \
+        "$(fmt_ms "$WITNESS_VERIFY")" "$(fmt_ms "$BLOCK_REPLAY")" "$(fmt_ms "$SALT_UPDATE")"
 else
     echo "   No data yet"
 fi

--- a/scripts/validator-status.sh
+++ b/scripts/validator-status.sh
@@ -1,285 +1,161 @@
 #!/bin/bash
 # Stateless Validator Status Dashboard
 # Usage: ./validator-status.sh [metrics_url]
-# Example: ./validator-status.sh http://localhost:9090/metrics
-
 set -e
 
 METRICS_URL="${1:-http://localhost:9090/metrics}"
+METRICS=$(curl -s "$METRICS_URL" 2>/dev/null) || { echo "Error: Could not fetch metrics from $METRICS_URL"; exit 1; }
+[ -z "$METRICS" ] && { echo "Error: Empty response from $METRICS_URL"; exit 1; }
 
-# Fetch all metrics once
-METRICS=$(curl -s "$METRICS_URL" 2>/dev/null)
-
-if [ -z "$METRICS" ]; then
-    echo "Error: Could not fetch metrics from $METRICS_URL"
-    exit 1
-fi
-
-# Helper functions
-fetch_metric() {
-    echo "$METRICS" | grep "^$1" | grep -v quantile | head -1 | awk '{print $2}' | cut -d'.' -f1
-}
-
-fetch_metric_float() {
-    echo "$METRICS" | grep "^$1" | grep -v quantile | head -1 | awk '{print $2}'
-}
-
-fetch_metric_with_label() {
-    echo "$METRICS" | grep "^$1{$2}" | grep -v quantile | head -1 | awk '{print $2}'
-}
-
-fetch_quantile() {
-    echo "$METRICS" | grep "^$1{quantile=\"$2\"}" | head -1 | awk '{print $2}'
-}
-
-fetch_quantile_with_label() {
-    echo "$METRICS" | grep "^$1{.*$2.*quantile=\"$3\"}" | head -1 | awk '{print $2}'
-}
-
-fetch_sum() {
-    echo "$METRICS" | grep "^${1}_sum" | grep -v "{" | head -1 | awk '{print $2}'
-}
-
-fetch_sum_with_label() {
-    echo "$METRICS" | grep "^${1}_sum{$2}" | head -1 | awk '{print $2}'
-}
-
-fetch_count() {
-    echo "$METRICS" | grep "^${1}_count" | grep -v "{" | head -1 | awk '{print $2}'
-}
-
-fetch_count_with_label() {
-    echo "$METRICS" | grep "^${1}_count{$2}" | head -1 | awk '{print $2}'
-}
-
-format_duration_ms() {
-    if [ -n "$1" ] && [ "$1" != "0" ]; then
-        # Convert to ms and format to 2 decimal places
-        RESULT=$(echo "scale=6; $1 * 1000" | bc 2>/dev/null)
-        if [ -n "$RESULT" ]; then
-            printf "%.2f" "$RESULT" 2>/dev/null || echo "$RESULT"
-        else
-            echo "N/A"
-        fi
-    else
-        echo "N/A"
-    fi
-}
-
-format_number() {
-    if [ -n "$1" ]; then
-        printf "%'d" "${1%.*}" 2>/dev/null || echo "$1"
-    else
-        echo "0"
-    fi
-}
+# Helpers
+metric()       { echo "$METRICS" | grep "^$1" | grep -v quantile | head -1 | awk '{print $2}' | cut -d'.' -f1; }
+metric_float() { echo "$METRICS" | grep "^$1" | grep -v quantile | head -1 | awk '{print $2}'; }
+quantile()     { echo "$METRICS" | grep "^$1{quantile=\"$2\"}" | head -1 | awk '{print $2}'; }
+hist_sum()     { echo "$METRICS" | grep "^${1}_sum" | grep -v "{" | head -1 | awk '{print $2}'; }
+hist_count()   { echo "$METRICS" | grep "^${1}_count" | grep -v "{" | head -1 | awk '{print $2}'; }
+hist_avg()     { S=$(hist_sum "$1"); C=$(hist_count "$1"); [ -n "$C" ] && [ "$C" != "0" ] && echo "scale=2; $S / $C" | bc 2>/dev/null || echo "0"; }
+fmt_ms()       { [ -n "$1" ] && [ "$1" != "0" ] && printf "%.2f" "$(echo "scale=6; $1 * 1000" | bc 2>/dev/null)" || echo "N/A"; }
+fmt_num()      { [ -n "$1" ] && printf "%'d" "${1%.*}" 2>/dev/null || echo "0"; }
+fmt_bytes()    { [ -n "$1" ] && [ "${1%.*}" -gt 0 ] && { B=${1%.*}; [ "$B" -ge 1048576 ] && printf "%.2f MB" "$(echo "scale=2; $B / 1048576" | bc)" || { [ "$B" -ge 1024 ] && printf "%.2f KB" "$(echo "scale=2; $B / 1024" | bc)" || printf "%d B" "$B"; }; } || echo "0 B"; }
 
 # Header
 echo ""
-echo "══════════════════════════════════════════════════════════════════════"
-echo "                    STATELESS VALIDATOR STATUS"
-echo "══════════════════════════════════════════════════════════════════════"
-echo "  Metrics URL: $METRICS_URL"
-echo "  Timestamp:   $(date '+%Y-%m-%d %H:%M:%S')"
-echo "══════════════════════════════════════════════════════════════════════"
+echo "═══════════════════════════════════════════════════════════════"
+echo "                  STATELESS VALIDATOR STATUS"
+echo "═══════════════════════════════════════════════════════════════"
+echo "  URL: $METRICS_URL | $(date '+%Y-%m-%d %H:%M:%S')"
 
 # Chain Status
-CANONICAL=$(fetch_metric 'stateless_validator_local_chain_height')
-REMOTE=$(fetch_metric 'stateless_validator_remote_chain_height')
-GAP=$(fetch_metric 'stateless_validator_validation_lag')
+CANONICAL=$(metric 'stateless_validator_local_chain_height')
+REMOTE=$(metric 'stateless_validator_remote_chain_height')
+GAP=$(metric 'stateless_validator_validation_lag')
 
 echo ""
-echo "  CHAIN STATUS"
-echo "──────────────────────────────────────────────────────────────────────"
-printf "   %-24s %s\n" "Canonical Height:" "$(format_number "$CANONICAL")"
-printf "   %-24s %s\n" "Remote Height:" "$(format_number "$REMOTE")"
-if [ "${GAP:-0}" -eq 0 ]; then
-    printf "   %-24s %s ✓\n" "Chain Gap:" "0 (synced)"
-else
-    printf "   %-24s %s blocks behind\n" "Chain Gap:" "$GAP"
-fi
+echo "  CHAIN"
+echo "───────────────────────────────────────────────────────────────"
+printf "   %-20s %-15s %-20s %s\n" "Local: $(fmt_num "$CANONICAL")" "Remote: $(fmt_num "$REMOTE")" \
+    "Gap: ${GAP:-0}$( [ "${GAP:-0}" -eq 0 ] && echo ' ✓' || echo ' blocks')" "Reorgs: $(metric 'stateless_validator_reorgs_detected_total' || echo 0)"
 
-# Validation Stats
-REORGS=$(fetch_metric 'stateless_validator_reorgs_detected_total')
-
-echo ""
-echo "  VALIDATION"
-echo "──────────────────────────────────────────────────────────────────────"
-printf "   %-24s %s\n" "Reorgs Detected:" "${REORGS:-0}"
-
-# Performance Metrics
-VAL_SUM=$(fetch_sum 'stateless_validator_block_validation_time_seconds')
-VAL_COUNT=$(fetch_count 'stateless_validator_block_validation_time_seconds')
-VAL_P50=$(fetch_quantile 'stateless_validator_block_validation_time_seconds' '0.5')
-VAL_P95=$(fetch_quantile 'stateless_validator_block_validation_time_seconds' '0.95')
-VAL_P99=$(fetch_quantile 'stateless_validator_block_validation_time_seconds' '0.99')
+# Performance
+VAL_SUM=$(hist_sum 'stateless_validator_block_validation_time_seconds')
+VAL_COUNT=$(hist_count 'stateless_validator_block_validation_time_seconds')
+VAL_P50=$(quantile 'stateless_validator_block_validation_time_seconds' '0.5')
+VAL_P95=$(quantile 'stateless_validator_block_validation_time_seconds' '0.95')
+VAL_P99=$(quantile 'stateless_validator_block_validation_time_seconds' '0.99')
 
 echo ""
-echo "  PERFORMANCE"
-echo "──────────────────────────────────────────────────────────────────────"
-echo "   Block Validation Latency:"
+echo "  PERFORMANCE (Block Validation)"
+echo "───────────────────────────────────────────────────────────────"
 if [ -n "$VAL_COUNT" ] && [ "$VAL_COUNT" != "0" ]; then
     AVG=$(echo "scale=6; $VAL_SUM / $VAL_COUNT" | bc 2>/dev/null)
-    printf "      %-20s %s ms\n" "Average:" "$(format_duration_ms "$AVG")"
-    printf "      %-20s %s ms\n" "P50 (median):" "$(format_duration_ms "$VAL_P50")"
-    printf "      %-20s %s ms\n" "P95:" "$(format_duration_ms "$VAL_P95")"
-    printf "      %-20s %s ms\n" "P99:" "$(format_duration_ms "$VAL_P99")"
+    BPS=$(echo "scale=2; 1 / $AVG" | bc 2>/dev/null)
+    printf "   Avg: %s ms | P50: %s ms | P95: %s ms | P99: %s ms\n" \
+        "$(fmt_ms "$AVG")" "$(fmt_ms "$VAL_P50")" "$(fmt_ms "$VAL_P95")" "$(fmt_ms "$VAL_P99")"
+    printf "   Throughput: %s blocks/sec\n" "$BPS"
 
-    # Calculate blocks per second
-    if [ -n "$AVG" ] && [ "$AVG" != "0" ]; then
-        BPS=$(echo "scale=2; 1 / $AVG" | bc 2>/dev/null)
-        printf "      %-20s %s blocks/sec\n" "Throughput:" "$BPS"
-    fi
+    # Validation phase breakdown
+    WITNESS_VERIFY=$(hist_avg 'stateless_validator_witness_verify_time_seconds')
+    BLOCK_REPLAY=$(hist_avg 'stateless_validator_block_replay_time_seconds')
+    STATE_UPDATE=$(hist_avg 'stateless_validator_state_update_time_seconds')
+    STATE_ROOT=$(hist_avg 'stateless_validator_state_root_time_seconds')
+    printf "   Phases (avg): Witness: %s ms | Replay: %s ms | State: %s ms | Root: %s ms\n" \
+        "$(fmt_ms "$WITNESS_VERIFY")" "$(fmt_ms "$BLOCK_REPLAY")" "$(fmt_ms "$STATE_UPDATE")" "$(fmt_ms "$STATE_ROOT")"
 else
-    echo "      No data yet"
+    echo "   No data yet"
 fi
 
+# Throughput
+BLOCKS=$(hist_count 'stateless_validator_block_validation_time_seconds')
+TOTAL_TX=$(metric 'stateless_validator_transactions_total')
+TOTAL_GAS=$(metric 'stateless_validator_gas_used_total')
 
-# Block Statistics
 echo ""
 echo "  THROUGHPUT"
-echo "──────────────────────────────────────────────────────────────────────"
-
-TOTAL_GAS=$(fetch_metric 'stateless_validator_gas_used_total')
-TOTAL_TX=$(fetch_metric 'stateless_validator_transactions_total')
-BLOCKS_VALIDATED=$(fetch_count 'stateless_validator_block_validation_time_seconds')
-
-printf "   %-24s %s\n" "Blocks Validated:" "$(format_number "$BLOCKS_VALIDATED")"
-printf "   %-24s %s\n" "Total Transactions:" "$(format_number "$TOTAL_TX")"
-printf "   %-24s %s\n" "Total Gas Used:" "$(format_number "$TOTAL_GAS")"
-
-# Calculate averages if we have blocks
-if [ -n "$BLOCKS_VALIDATED" ] && [ "${BLOCKS_VALIDATED%.*}" -gt 0 ]; then
-    BLOCKS_INT=${BLOCKS_VALIDATED%.*}
-    if [ -n "$TOTAL_TX" ] && [ "${TOTAL_TX:-0}" -gt 0 ]; then
-        AVG_TX=$(echo "scale=2; $TOTAL_TX / $BLOCKS_INT" | bc 2>/dev/null)
-        printf "   %-24s %s\n" "Avg TX/Block:" "$AVG_TX"
-    fi
-    if [ -n "$TOTAL_GAS" ] && [ "${TOTAL_GAS:-0}" -gt 0 ]; then
-        AVG_GAS=$(echo "scale=0; $TOTAL_GAS / $BLOCKS_INT" | bc 2>/dev/null)
-        printf "   %-24s %s\n" "Avg Gas/Block:" "$(format_number "$AVG_GAS")"
-    fi
+echo "───────────────────────────────────────────────────────────────"
+printf "   Blocks: %s | TX: %s | Gas: %s\n" "$(fmt_num "$BLOCKS")" "$(fmt_num "$TOTAL_TX")" "$(fmt_num "$TOTAL_GAS")"
+if [ -n "$BLOCKS" ] && [ "${BLOCKS%.*}" -gt 0 ]; then
+    B=${BLOCKS%.*}
+    [ "${TOTAL_TX:-0}" -gt 0 ] && printf "   Avg TX/Block: %.2f\n" "$(echo "scale=2; $TOTAL_TX / $B" | bc)"
 fi
-
-echo ""
-echo "   Note: Use Prometheus rate() for TPS/Gas-per-second:"
-echo "      rate(stateless_validator_transactions_total[1m])"
-echo "      rate(stateless_validator_gas_used_total[1m])"
 
 # Timing Breakdown
 echo ""
-echo "   Timing Breakdown (P50):"
-WITNESS_P50=$(fetch_quantile 'stateless_validator_witness_fetch_time_seconds' '0.5')
-BLOCK_FETCH_P50=$(fetch_quantile 'stateless_validator_block_fetch_time_seconds' '0.5')
-CODE_FETCH_P50=$(fetch_quantile 'stateless_validator_code_fetch_time_seconds' '0.5')
+echo "   Fetch Latency (P50): Witness: $(fmt_ms "$(quantile 'stateless_validator_witness_fetch_time_seconds' '0.5')") ms | " \
+    "Block: $(fmt_ms "$(quantile 'stateless_validator_block_fetch_time_seconds' '0.5')") ms | " \
+    "Code: $(fmt_ms "$(quantile 'stateless_validator_code_fetch_time_seconds' '0.5')") ms"
 
-printf "      %-20s %s ms\n" "Witness Fetch:" "$(format_duration_ms "$WITNESS_P50")"
-printf "      %-20s %s ms\n" "Block Fetch:" "$(format_duration_ms "$BLOCK_FETCH_P50")"
-printf "      %-20s %s ms\n" "Code Fetch:" "$(format_duration_ms "$CODE_FETCH_P50")"
-
-# Cache Stats
-HITS=$(fetch_metric 'stateless_validator_contract_cache_hits_total')
-MISSES=$(fetch_metric 'stateless_validator_contract_cache_misses_total')
+# Cache
+HITS=$(metric 'stateless_validator_contract_cache_hits_total')
+MISSES=$(metric 'stateless_validator_contract_cache_misses_total')
 
 echo ""
 echo "  CONTRACT CACHE"
-echo "──────────────────────────────────────────────────────────────────────"
-printf "   %-24s %s\n" "Cache Hits:" "$(format_number "$HITS")"
-printf "   %-24s %s\n" "Cache Misses:" "${MISSES:-0}"
-if [ -n "$HITS" ] && [ -n "$MISSES" ]; then
-    TOTAL=$((${HITS:-0} + ${MISSES:-0}))
-    if [ "$TOTAL" -gt 0 ]; then
-        RATE=$(echo "scale=2; ${HITS:-0} * 100 / $TOTAL" | bc 2>/dev/null)
-        printf "   %-24s %s%%\n" "Hit Rate:" "$RATE"
-    fi
-fi
+echo "───────────────────────────────────────────────────────────────"
+TOTAL=$((${HITS:-0} + ${MISSES:-0}))
+RATE=$( [ "$TOTAL" -gt 0 ] && echo "$(echo "scale=1; ${HITS:-0} * 100 / $TOTAL" | bc)%" || echo "N/A" )
+printf "   Hits: %s | Misses: %s | Rate: %s\n" "$(fmt_num "$HITS")" "${MISSES:-0}" "$RATE"
 
-# RPC Stats
+# Witness Stats
+SALT_SIZE=$(hist_avg 'stateless_validator_witness_salt_size_bytes')
+MPT_SIZE=$(hist_avg 'stateless_validator_witness_mpt_size_bytes')
+SALT_KEYS=$(hist_avg 'stateless_validator_witness_salt_keys')
+SALT_KVS=$(hist_avg 'stateless_validator_witness_salt_kvs_bytes')
+
+echo ""
+echo "  WITNESS (avg per block)"
+echo "───────────────────────────────────────────────────────────────"
+printf "   Salt: %s | MPT: %s | Keys: %s | KVs: %s\n" \
+    "$(fmt_bytes "$SALT_SIZE")" "$(fmt_bytes "$MPT_SIZE")" \
+    "$(fmt_num "$SALT_KEYS")" "$(fmt_bytes "$SALT_KVS")"
+
+# State Access
+STATE_READS=$(hist_avg 'stateless_validator_block_state_reads')
+STATE_WRITES=$(hist_avg 'stateless_validator_block_state_writes')
+
+echo ""
+echo "  STATE ACCESS (avg per block)"
+echo "───────────────────────────────────────────────────────────────"
+printf "   Reads: %s | Writes: %s\n" "$(fmt_num "$STATE_READS")" "$(fmt_num "$STATE_WRITES")"
+
+# RPC
 echo ""
 echo "  RPC REQUESTS"
-echo "──────────────────────────────────────────────────────────────────────"
-
-# Extract and display RPC request counts
+echo "───────────────────────────────────────────────────────────────"
 echo "$METRICS" | grep "^stateless_validator_rpc_requests_total{" | while read -r line; do
     METHOD=$(echo "$line" | sed 's/.*method="\([^"]*\)".*/\1/')
     COUNT=$(echo "$line" | awk '{print $2}' | cut -d'.' -f1)
-    printf "   %-32s %s\n" "$METHOD:" "$(format_number "$COUNT")"
+    printf "   %-28s %s\n" "$METHOD:" "$(fmt_num "$COUNT")"
 done
 
-# RPC Errors
-echo ""
-echo "   Errors:"
-HAS_ERRORS=false
-echo "$METRICS" | grep "^stateless_validator_rpc_errors_total{" | while read -r line; do
-    METHOD=$(echo "$line" | sed 's/.*method="\([^"]*\)".*/\1/')
-    COUNT=$(echo "$line" | awk '{print $2}' | cut -d'.' -f1)
-    if [ "${COUNT:-0}" -gt 0 ]; then
-        printf "      %-29s %s\n" "$METHOD:" "$COUNT"
-        HAS_ERRORS=true
-    fi
-done
-if [ "$HAS_ERRORS" = false ]; then
-    TOTAL_ERRORS=$(echo "$METRICS" | grep "^stateless_validator_rpc_errors_total{" | awk '{sum += $2} END {print sum}')
-    if [ -z "$TOTAL_ERRORS" ] || [ "${TOTAL_ERRORS%.*}" -eq 0 ]; then
-        echo "      None ✓"
-    fi
-fi
+ERRORS=$(echo "$METRICS" | grep "^stateless_validator_rpc_errors_total{" | awk '{sum += $2} END {print int(sum)}')
+[ "${ERRORS:-0}" -gt 0 ] && echo "   Errors: $ERRORS" || echo "   Errors: None ✓"
 
-# Worker Stats
+# Workers
 echo ""
 echo "  WORKERS"
-echo "──────────────────────────────────────────────────────────────────────"
-
+echo "───────────────────────────────────────────────────────────────"
 WORKER_DATA=$(echo "$METRICS" | grep "^stateless_validator_worker_tasks_completed_total{" | \
-    sed 's/.*worker_id="\([^"]*\)".* \([0-9.]*\)/\1 \2/' | \
-    sort -n)
+    sed 's/.*worker_id="\([^"]*\)".* \([0-9.]*\)/\1 \2/' | sort -n)
 
 if [ -n "$WORKER_DATA" ]; then
-    TOTAL_TASKS=0
-    WORKER_COUNT=0
-    MIN_TASKS=999999999
-    MAX_TASKS=0
-
-    while read -r WORKER_ID TASKS; do
-        TASKS_INT=${TASKS%.*}
-        TOTAL_TASKS=$((TOTAL_TASKS + TASKS_INT))
-        WORKER_COUNT=$((WORKER_COUNT + 1))
-        if [ "$TASKS_INT" -lt "$MIN_TASKS" ]; then MIN_TASKS=$TASKS_INT; fi
-        if [ "$TASKS_INT" -gt "$MAX_TASKS" ]; then MAX_TASKS=$TASKS_INT; fi
+    TOTAL=0; COUNT=0; MAX=0
+    while read -r _ TASKS; do
+        T=${TASKS%.*}; TOTAL=$((TOTAL + T)); COUNT=$((COUNT + 1))
+        [ "$T" -gt "$MAX" ] && MAX=$T
     done <<< "$WORKER_DATA"
-
-    printf "   %-24s %s\n" "Active Workers:" "$WORKER_COUNT"
-    printf "   %-24s %s\n" "Total Tasks:" "$(format_number "$TOTAL_TASKS")"
-
-    if [ "$WORKER_COUNT" -gt 0 ]; then
-        AVG_TASKS=$((TOTAL_TASKS / WORKER_COUNT))
-        printf "   %-24s %s\n" "Avg Tasks/Worker:" "$AVG_TASKS"
-        printf "   %-24s %s - %s\n" "Task Range:" "$MIN_TASKS" "$MAX_TASKS"
-    fi
-
-    echo ""
-    echo "   Per-Worker Breakdown:"
-    echo "$WORKER_DATA" | while read -r WORKER_ID TASKS; do
-        TASKS_INT=${TASKS%.*}
-        # Create a simple bar chart
-        BAR_LEN=$((TASKS_INT * 20 / MAX_TASKS))
-        BAR=$(printf '%*s' "$BAR_LEN" '' | tr ' ' '█')
-        printf "      Worker %2s: %6s  %s\n" "$WORKER_ID" "$TASKS_INT" "$BAR"
+    printf "   Workers: %d | Total Tasks: %s | Avg: %d\n" "$COUNT" "$(fmt_num "$TOTAL")" "$((TOTAL / COUNT))"
+    echo "$WORKER_DATA" | while read -r WID TASKS; do
+        T=${TASKS%.*}; BAR=$(printf '%*s' "$((T * 20 / MAX))" '' | tr ' ' '█')
+        printf "      Worker %2s: %6d  %s\n" "$WID" "$T" "$BAR"
     done
 else
-    echo "   No worker data available"
+    echo "   No worker data"
 fi
 
-# Pruning Stats
-PRUNED=$(fetch_metric 'stateless_validator_blocks_pruned_total')
-if [ -n "$PRUNED" ] && [ "$PRUNED" != "0" ]; then
-    echo ""
-    echo "   PRUNING"
-    echo "──────────────────────────────────────────────────────────────────────"
-    printf "   %-24s %s\n" "Blocks Pruned:" "$(format_number "$PRUNED")"
-fi
+# Pruning (only if non-zero)
+PRUNED=$(metric 'stateless_validator_blocks_pruned_total')
+[ -n "$PRUNED" ] && [ "$PRUNED" != "0" ] && echo "" && echo "   Blocks Pruned: $(fmt_num "$PRUNED")"
 
-# Footer
 echo ""
-echo "══════════════════════════════════════════════════════════════════════"
+echo "═══════════════════════════════════════════════════════════════"
 echo ""

--- a/scripts/validator-status.sh
+++ b/scripts/validator-status.sh
@@ -26,14 +26,14 @@ echo "════════════════════════�
 echo "  URL: $METRICS_URL | $(date '+%Y-%m-%d %H:%M:%S')"
 
 # Chain Status
-CANONICAL=$(metric 'stateless_validator_local_chain_height')
+LOCAL=$(metric 'stateless_validator_local_chain_height')
 REMOTE=$(metric 'stateless_validator_remote_chain_height')
 GAP=$(metric 'stateless_validator_validation_lag')
 
 echo ""
 echo "  CHAIN"
 echo "───────────────────────────────────────────────────────────────"
-printf "   %-20s %-15s %-20s %s\n" "Local: $(fmt_num "$CANONICAL")" "Remote: $(fmt_num "$REMOTE")" \
+printf "   %-20s %-15s %-20s %s\n" "Local: $(fmt_num "$LOCAL")" "Remote: $(fmt_num "$REMOTE")" \
     "Gap: ${GAP:-0}$( [ "${GAP:-0}" -eq 0 ] && echo ' ✓' || echo ' blocks')" "Reorgs: $(metric 'stateless_validator_reorgs_detected_total' || echo 0)"
 
 # Performance

--- a/scripts/validator-status.sh
+++ b/scripts/validator-status.sh
@@ -116,7 +116,7 @@ if [ -n "$VAL_COUNT" ] && [ "$VAL_COUNT" != "0" ]; then
     printf "   Throughput: %s blocks/sec\n" "$BPS"
 
     # Validation phase breakdown
-    WITNESS_VERIFY=$(hist_avg 'stateless_validator_witness_verify_time_seconds')
+    WITNESS_VERIFY=$(hist_avg 'stateless_validator_witness_verification_time_seconds')
     BLOCK_REPLAY=$(hist_avg 'stateless_validator_block_replay_time_seconds')
     SALT_UPDATE=$(hist_avg 'stateless_validator_salt_update_time_seconds')
     printf "   Phases (avg): Witness: %s ms | Replay: %s ms | Salt Update: %s ms\n" \
@@ -157,17 +157,12 @@ RATE=$( [ "$TOTAL" -gt 0 ] && echo "$(echo "scale=1; ${HITS:-0} * 100 / $TOTAL" 
 printf "   Hits: %s | Misses: %s | Rate: %s\n" "$(fmt_num "$HITS")" "${MISSES:-0}" "$RATE"
 
 # Witness Stats
-SALT_SIZE=$(hist_avg 'stateless_validator_witness_salt_size_bytes')
-MPT_SIZE=$(hist_avg 'stateless_validator_witness_mpt_size_bytes')
 SALT_KEYS=$(hist_avg 'stateless_validator_witness_salt_keys')
-SALT_KVS=$(hist_avg 'stateless_validator_witness_salt_kvs_bytes')
 
 echo ""
 echo "  WITNESS (avg per block)"
 echo "───────────────────────────────────────────────────────────────"
-printf "   Salt: %s | MPT: %s | Keys: %s | KVs: %s\n" \
-    "$(fmt_bytes "$SALT_SIZE")" "$(fmt_bytes "$MPT_SIZE")" \
-    "$(fmt_num "$SALT_KEYS")" "$(fmt_bytes "$SALT_KVS")"
+printf "   Keys: %s\n" "$(fmt_num "$SALT_KEYS")"
 
 # State Access
 STATE_READS=$(hist_avg 'stateless_validator_block_state_reads')

--- a/scripts/validator-status.sh
+++ b/scripts/validator-status.sh
@@ -157,16 +157,16 @@ RATE=$( [ "$TOTAL" -gt 0 ] && echo "$(echo "scale=1; ${HITS:-0} * 100 / $TOTAL" 
 printf "   Hits: %s | Misses: %s | Rate: %s\n" "$(fmt_num "$HITS")" "${MISSES:-0}" "$RATE"
 
 # Witness Stats
-SALT_SIZE=$(hist_avg 'stateless_validator_witness_salt_size_bytes')
-SALT_KEYS=$(hist_avg 'stateless_validator_witness_salt_keys')
-SALT_KVS_SIZE=$(hist_avg 'stateless_validator_witness_salt_kvs_bytes')
-MPT_SIZE=$(hist_avg 'stateless_validator_witness_mpt_size_bytes')
+SALT_SIZE=$(hist_avg 'stateless_validator_salt_witness_size_bytes')
+SALT_KEYS=$(hist_avg 'stateless_validator_salt_witness_keys')
+SALT_KVS_SIZE=$(hist_avg 'stateless_validator_salt_witness_kvs_bytes')
+MPT_SIZE=$(hist_avg 'stateless_validator_mpt_witness_size_bytes')
 
 echo ""
 echo "  WITNESS (avg per block)"
 echo "───────────────────────────────────────────────────────────────"
-printf "   Keys: %s | Salt: %s | KVs: %s | MPT: %s\n" \
-    "$(fmt_num "$SALT_KEYS")" "$(fmt_bytes "$SALT_SIZE")" "$(fmt_bytes "$SALT_KVS_SIZE")" "$(fmt_bytes "$MPT_SIZE")"
+printf "   Salt: %s | Keys: %s | KVs: %s | MPT: %s\n" \
+    "$(fmt_bytes "$SALT_SIZE")" "$(fmt_num "$SALT_KEYS")" "$(fmt_bytes "$SALT_KVS_SIZE")" "$(fmt_bytes "$MPT_SIZE")"
 
 # State Access
 STATE_READS=$(hist_avg 'stateless_validator_block_state_reads')

--- a/scripts/validator-status.sh
+++ b/scripts/validator-status.sh
@@ -119,7 +119,7 @@ if [ -n "$VAL_COUNT" ] && [ "$VAL_COUNT" != "0" ]; then
     WITNESS_VERIFY=$(hist_avg 'stateless_validator_witness_verification_time_seconds')
     BLOCK_REPLAY=$(hist_avg 'stateless_validator_block_replay_time_seconds')
     SALT_UPDATE=$(hist_avg 'stateless_validator_salt_update_time_seconds')
-    printf "   Phases (avg): Witness: %s ms | Replay: %s ms | Salt Update: %s ms\n" \
+    printf "   Phases (avg): Verify: %s ms | Replay: %s ms | Salt Update: %s ms\n" \
         "$(fmt_ms "$WITNESS_VERIFY")" "$(fmt_ms "$BLOCK_REPLAY")" "$(fmt_ms "$SALT_UPDATE")"
 else
     echo "   No data yet"
@@ -157,12 +157,16 @@ RATE=$( [ "$TOTAL" -gt 0 ] && echo "$(echo "scale=1; ${HITS:-0} * 100 / $TOTAL" 
 printf "   Hits: %s | Misses: %s | Rate: %s\n" "$(fmt_num "$HITS")" "${MISSES:-0}" "$RATE"
 
 # Witness Stats
+SALT_SIZE=$(hist_avg 'stateless_validator_witness_salt_size_bytes')
 SALT_KEYS=$(hist_avg 'stateless_validator_witness_salt_keys')
+SALT_KVS_SIZE=$(hist_avg 'stateless_validator_witness_salt_kvs_bytes')
+MPT_SIZE=$(hist_avg 'stateless_validator_witness_mpt_size_bytes')
 
 echo ""
 echo "  WITNESS (avg per block)"
 echo "───────────────────────────────────────────────────────────────"
-printf "   Keys: %s\n" "$(fmt_num "$SALT_KEYS")"
+printf "   Keys: %s | Salt: %s | KVs: %s | MPT: %s\n" \
+    "$(fmt_num "$SALT_KEYS")" "$(fmt_bytes "$SALT_SIZE")" "$(fmt_bytes "$SALT_KVS_SIZE")" "$(fmt_bytes "$MPT_SIZE")"
 
 # State Access
 STATE_READS=$(hist_avg 'stateless_validator_block_state_reads')

--- a/scripts/validator-status.sh
+++ b/scripts/validator-status.sh
@@ -1,0 +1,285 @@
+#!/bin/bash
+# Stateless Validator Status Dashboard
+# Usage: ./validator-status.sh [metrics_url]
+# Example: ./validator-status.sh http://localhost:9090/metrics
+
+set -e
+
+METRICS_URL="${1:-http://localhost:9090/metrics}"
+
+# Fetch all metrics once
+METRICS=$(curl -s "$METRICS_URL" 2>/dev/null)
+
+if [ -z "$METRICS" ]; then
+    echo "Error: Could not fetch metrics from $METRICS_URL"
+    exit 1
+fi
+
+# Helper functions
+fetch_metric() {
+    echo "$METRICS" | grep "^$1" | grep -v quantile | head -1 | awk '{print $2}' | cut -d'.' -f1
+}
+
+fetch_metric_float() {
+    echo "$METRICS" | grep "^$1" | grep -v quantile | head -1 | awk '{print $2}'
+}
+
+fetch_metric_with_label() {
+    echo "$METRICS" | grep "^$1{$2}" | grep -v quantile | head -1 | awk '{print $2}'
+}
+
+fetch_quantile() {
+    echo "$METRICS" | grep "^$1{quantile=\"$2\"}" | head -1 | awk '{print $2}'
+}
+
+fetch_quantile_with_label() {
+    echo "$METRICS" | grep "^$1{.*$2.*quantile=\"$3\"}" | head -1 | awk '{print $2}'
+}
+
+fetch_sum() {
+    echo "$METRICS" | grep "^${1}_sum" | grep -v "{" | head -1 | awk '{print $2}'
+}
+
+fetch_sum_with_label() {
+    echo "$METRICS" | grep "^${1}_sum{$2}" | head -1 | awk '{print $2}'
+}
+
+fetch_count() {
+    echo "$METRICS" | grep "^${1}_count" | grep -v "{" | head -1 | awk '{print $2}'
+}
+
+fetch_count_with_label() {
+    echo "$METRICS" | grep "^${1}_count{$2}" | head -1 | awk '{print $2}'
+}
+
+format_duration_ms() {
+    if [ -n "$1" ] && [ "$1" != "0" ]; then
+        # Convert to ms and format to 2 decimal places
+        RESULT=$(echo "scale=6; $1 * 1000" | bc 2>/dev/null)
+        if [ -n "$RESULT" ]; then
+            printf "%.2f" "$RESULT" 2>/dev/null || echo "$RESULT"
+        else
+            echo "N/A"
+        fi
+    else
+        echo "N/A"
+    fi
+}
+
+format_number() {
+    if [ -n "$1" ]; then
+        printf "%'d" "${1%.*}" 2>/dev/null || echo "$1"
+    else
+        echo "0"
+    fi
+}
+
+# Header
+echo ""
+echo "══════════════════════════════════════════════════════════════════════"
+echo "                    STATELESS VALIDATOR STATUS"
+echo "══════════════════════════════════════════════════════════════════════"
+echo "  Metrics URL: $METRICS_URL"
+echo "  Timestamp:   $(date '+%Y-%m-%d %H:%M:%S')"
+echo "══════════════════════════════════════════════════════════════════════"
+
+# Chain Status
+CANONICAL=$(fetch_metric 'stateless_validator_local_chain_height')
+REMOTE=$(fetch_metric 'stateless_validator_remote_chain_height')
+GAP=$(fetch_metric 'stateless_validator_validation_lag')
+
+echo ""
+echo "  CHAIN STATUS"
+echo "──────────────────────────────────────────────────────────────────────"
+printf "   %-24s %s\n" "Canonical Height:" "$(format_number "$CANONICAL")"
+printf "   %-24s %s\n" "Remote Height:" "$(format_number "$REMOTE")"
+if [ "${GAP:-0}" -eq 0 ]; then
+    printf "   %-24s %s ✓\n" "Chain Gap:" "0 (synced)"
+else
+    printf "   %-24s %s blocks behind\n" "Chain Gap:" "$GAP"
+fi
+
+# Validation Stats
+REORGS=$(fetch_metric 'stateless_validator_reorgs_detected_total')
+
+echo ""
+echo "  VALIDATION"
+echo "──────────────────────────────────────────────────────────────────────"
+printf "   %-24s %s\n" "Reorgs Detected:" "${REORGS:-0}"
+
+# Performance Metrics
+VAL_SUM=$(fetch_sum 'stateless_validator_block_validation_time_seconds')
+VAL_COUNT=$(fetch_count 'stateless_validator_block_validation_time_seconds')
+VAL_P50=$(fetch_quantile 'stateless_validator_block_validation_time_seconds' '0.5')
+VAL_P95=$(fetch_quantile 'stateless_validator_block_validation_time_seconds' '0.95')
+VAL_P99=$(fetch_quantile 'stateless_validator_block_validation_time_seconds' '0.99')
+
+echo ""
+echo "  PERFORMANCE"
+echo "──────────────────────────────────────────────────────────────────────"
+echo "   Block Validation Latency:"
+if [ -n "$VAL_COUNT" ] && [ "$VAL_COUNT" != "0" ]; then
+    AVG=$(echo "scale=6; $VAL_SUM / $VAL_COUNT" | bc 2>/dev/null)
+    printf "      %-20s %s ms\n" "Average:" "$(format_duration_ms "$AVG")"
+    printf "      %-20s %s ms\n" "P50 (median):" "$(format_duration_ms "$VAL_P50")"
+    printf "      %-20s %s ms\n" "P95:" "$(format_duration_ms "$VAL_P95")"
+    printf "      %-20s %s ms\n" "P99:" "$(format_duration_ms "$VAL_P99")"
+
+    # Calculate blocks per second
+    if [ -n "$AVG" ] && [ "$AVG" != "0" ]; then
+        BPS=$(echo "scale=2; 1 / $AVG" | bc 2>/dev/null)
+        printf "      %-20s %s blocks/sec\n" "Throughput:" "$BPS"
+    fi
+else
+    echo "      No data yet"
+fi
+
+
+# Block Statistics
+echo ""
+echo "  THROUGHPUT"
+echo "──────────────────────────────────────────────────────────────────────"
+
+TOTAL_GAS=$(fetch_metric 'stateless_validator_gas_used_total')
+TOTAL_TX=$(fetch_metric 'stateless_validator_transactions_total')
+BLOCKS_VALIDATED=$(fetch_count 'stateless_validator_block_validation_time_seconds')
+
+printf "   %-24s %s\n" "Blocks Validated:" "$(format_number "$BLOCKS_VALIDATED")"
+printf "   %-24s %s\n" "Total Transactions:" "$(format_number "$TOTAL_TX")"
+printf "   %-24s %s\n" "Total Gas Used:" "$(format_number "$TOTAL_GAS")"
+
+# Calculate averages if we have blocks
+if [ -n "$BLOCKS_VALIDATED" ] && [ "${BLOCKS_VALIDATED%.*}" -gt 0 ]; then
+    BLOCKS_INT=${BLOCKS_VALIDATED%.*}
+    if [ -n "$TOTAL_TX" ] && [ "${TOTAL_TX:-0}" -gt 0 ]; then
+        AVG_TX=$(echo "scale=2; $TOTAL_TX / $BLOCKS_INT" | bc 2>/dev/null)
+        printf "   %-24s %s\n" "Avg TX/Block:" "$AVG_TX"
+    fi
+    if [ -n "$TOTAL_GAS" ] && [ "${TOTAL_GAS:-0}" -gt 0 ]; then
+        AVG_GAS=$(echo "scale=0; $TOTAL_GAS / $BLOCKS_INT" | bc 2>/dev/null)
+        printf "   %-24s %s\n" "Avg Gas/Block:" "$(format_number "$AVG_GAS")"
+    fi
+fi
+
+echo ""
+echo "   Note: Use Prometheus rate() for TPS/Gas-per-second:"
+echo "      rate(stateless_validator_transactions_total[1m])"
+echo "      rate(stateless_validator_gas_used_total[1m])"
+
+# Timing Breakdown
+echo ""
+echo "   Timing Breakdown (P50):"
+WITNESS_P50=$(fetch_quantile 'stateless_validator_witness_fetch_time_seconds' '0.5')
+BLOCK_FETCH_P50=$(fetch_quantile 'stateless_validator_block_fetch_time_seconds' '0.5')
+CODE_FETCH_P50=$(fetch_quantile 'stateless_validator_code_fetch_time_seconds' '0.5')
+
+printf "      %-20s %s ms\n" "Witness Fetch:" "$(format_duration_ms "$WITNESS_P50")"
+printf "      %-20s %s ms\n" "Block Fetch:" "$(format_duration_ms "$BLOCK_FETCH_P50")"
+printf "      %-20s %s ms\n" "Code Fetch:" "$(format_duration_ms "$CODE_FETCH_P50")"
+
+# Cache Stats
+HITS=$(fetch_metric 'stateless_validator_contract_cache_hits_total')
+MISSES=$(fetch_metric 'stateless_validator_contract_cache_misses_total')
+
+echo ""
+echo "  CONTRACT CACHE"
+echo "──────────────────────────────────────────────────────────────────────"
+printf "   %-24s %s\n" "Cache Hits:" "$(format_number "$HITS")"
+printf "   %-24s %s\n" "Cache Misses:" "${MISSES:-0}"
+if [ -n "$HITS" ] && [ -n "$MISSES" ]; then
+    TOTAL=$((${HITS:-0} + ${MISSES:-0}))
+    if [ "$TOTAL" -gt 0 ]; then
+        RATE=$(echo "scale=2; ${HITS:-0} * 100 / $TOTAL" | bc 2>/dev/null)
+        printf "   %-24s %s%%\n" "Hit Rate:" "$RATE"
+    fi
+fi
+
+# RPC Stats
+echo ""
+echo "  RPC REQUESTS"
+echo "──────────────────────────────────────────────────────────────────────"
+
+# Extract and display RPC request counts
+echo "$METRICS" | grep "^stateless_validator_rpc_requests_total{" | while read -r line; do
+    METHOD=$(echo "$line" | sed 's/.*method="\([^"]*\)".*/\1/')
+    COUNT=$(echo "$line" | awk '{print $2}' | cut -d'.' -f1)
+    printf "   %-32s %s\n" "$METHOD:" "$(format_number "$COUNT")"
+done
+
+# RPC Errors
+echo ""
+echo "   Errors:"
+HAS_ERRORS=false
+echo "$METRICS" | grep "^stateless_validator_rpc_errors_total{" | while read -r line; do
+    METHOD=$(echo "$line" | sed 's/.*method="\([^"]*\)".*/\1/')
+    COUNT=$(echo "$line" | awk '{print $2}' | cut -d'.' -f1)
+    if [ "${COUNT:-0}" -gt 0 ]; then
+        printf "      %-29s %s\n" "$METHOD:" "$COUNT"
+        HAS_ERRORS=true
+    fi
+done
+if [ "$HAS_ERRORS" = false ]; then
+    TOTAL_ERRORS=$(echo "$METRICS" | grep "^stateless_validator_rpc_errors_total{" | awk '{sum += $2} END {print sum}')
+    if [ -z "$TOTAL_ERRORS" ] || [ "${TOTAL_ERRORS%.*}" -eq 0 ]; then
+        echo "      None ✓"
+    fi
+fi
+
+# Worker Stats
+echo ""
+echo "  WORKERS"
+echo "──────────────────────────────────────────────────────────────────────"
+
+WORKER_DATA=$(echo "$METRICS" | grep "^stateless_validator_worker_tasks_completed_total{" | \
+    sed 's/.*worker_id="\([^"]*\)".* \([0-9.]*\)/\1 \2/' | \
+    sort -n)
+
+if [ -n "$WORKER_DATA" ]; then
+    TOTAL_TASKS=0
+    WORKER_COUNT=0
+    MIN_TASKS=999999999
+    MAX_TASKS=0
+
+    while read -r WORKER_ID TASKS; do
+        TASKS_INT=${TASKS%.*}
+        TOTAL_TASKS=$((TOTAL_TASKS + TASKS_INT))
+        WORKER_COUNT=$((WORKER_COUNT + 1))
+        if [ "$TASKS_INT" -lt "$MIN_TASKS" ]; then MIN_TASKS=$TASKS_INT; fi
+        if [ "$TASKS_INT" -gt "$MAX_TASKS" ]; then MAX_TASKS=$TASKS_INT; fi
+    done <<< "$WORKER_DATA"
+
+    printf "   %-24s %s\n" "Active Workers:" "$WORKER_COUNT"
+    printf "   %-24s %s\n" "Total Tasks:" "$(format_number "$TOTAL_TASKS")"
+
+    if [ "$WORKER_COUNT" -gt 0 ]; then
+        AVG_TASKS=$((TOTAL_TASKS / WORKER_COUNT))
+        printf "   %-24s %s\n" "Avg Tasks/Worker:" "$AVG_TASKS"
+        printf "   %-24s %s - %s\n" "Task Range:" "$MIN_TASKS" "$MAX_TASKS"
+    fi
+
+    echo ""
+    echo "   Per-Worker Breakdown:"
+    echo "$WORKER_DATA" | while read -r WORKER_ID TASKS; do
+        TASKS_INT=${TASKS%.*}
+        # Create a simple bar chart
+        BAR_LEN=$((TASKS_INT * 20 / MAX_TASKS))
+        BAR=$(printf '%*s' "$BAR_LEN" '' | tr ' ' '█')
+        printf "      Worker %2s: %6s  %s\n" "$WORKER_ID" "$TASKS_INT" "$BAR"
+    done
+else
+    echo "   No worker data available"
+fi
+
+# Pruning Stats
+PRUNED=$(fetch_metric 'stateless_validator_blocks_pruned_total')
+if [ -n "$PRUNED" ] && [ "$PRUNED" != "0" ]; then
+    echo ""
+    echo "   PRUNING"
+    echo "──────────────────────────────────────────────────────────────────────"
+    printf "   %-24s %s\n" "Blocks Pruned:" "$(format_number "$PRUNED")"
+fi
+
+# Footer
+echo ""
+echo "══════════════════════════════════════════════════════════════════════"
+echo ""

--- a/validator-core/src/lib.rs
+++ b/validator-core/src/lib.rs
@@ -21,5 +21,7 @@ pub use validator_db::{ValidationDbError, ValidationDbResult, ValidatorDB};
 pub mod data_types;
 pub use data_types::{PlainKey, PlainValue};
 pub mod executor;
-pub use executor::{ValidationError, ValidationResult, replay_block, validate_block};
+pub use executor::{
+    ValidationError, ValidationResult, ValidationStats, replay_block, validate_block,
+};
 pub mod withdrawals;

--- a/validator-core/src/validator_db.rs
+++ b/validator-core/src/validator_db.rs
@@ -936,14 +936,14 @@ impl ValidatorDB {
 }
 
 /// Helper method to serialize data using bincode with legacy config
-pub fn encode_to_vec<T: serde::Serialize>(data: &T) -> Result<Vec<u8>> {
+fn encode_to_vec<T: serde::Serialize>(data: &T) -> Result<Vec<u8>> {
     let encoded = bincode::serde::encode_to_vec(data, bincode::config::legacy())
         .map_err(SerializationError::from)?;
     Ok(encoded)
 }
 
 /// Helper method to deserialize data using bincode with legacy config
-pub fn decode_from_slice<T: serde::de::DeserializeOwned>(bytes: &[u8]) -> T {
+fn decode_from_slice<T: serde::de::DeserializeOwned>(bytes: &[u8]) -> T {
     let (decoded, _) = bincode::serde::decode_from_slice(bytes, bincode::config::legacy())
         .expect("serialization of previously stored data must succeed");
     decoded

--- a/validator-core/src/validator_db.rs
+++ b/validator-core/src/validator_db.rs
@@ -936,14 +936,14 @@ impl ValidatorDB {
 }
 
 /// Helper method to serialize data using bincode with legacy config
-fn encode_to_vec<T: serde::Serialize>(data: &T) -> Result<Vec<u8>> {
+pub fn encode_to_vec<T: serde::Serialize>(data: &T) -> Result<Vec<u8>> {
     let encoded = bincode::serde::encode_to_vec(data, bincode::config::legacy())
         .map_err(SerializationError::from)?;
     Ok(encoded)
 }
 
 /// Helper method to deserialize data using bincode with legacy config
-fn decode_from_slice<T: serde::de::DeserializeOwned>(bytes: &[u8]) -> T {
+pub fn decode_from_slice<T: serde::de::DeserializeOwned>(bytes: &[u8]) -> T {
     let (decoded, _) = bincode::serde::decode_from_slice(bytes, bincode::config::legacy())
         .expect("serialization of previously stored data must succeed");
     decoded


### PR DESCRIPTION
### Summary

This PR adds comprehensive Prometheus-compatible metrics to the stateless validator for monitoring performance, health, and resource utilization.

### Changes

**New Features:**
- Added a new `metrics.rs` module exposing Prometheus metrics via HTTP endpoint
- New CLI flags: `--metrics-enabled` and `--metrics-port` (default: 9090)
- Corresponding environment variables: `STATELESS_VALIDATOR_METRICS_ENABLED` and `STATELESS_VALIDATOR_METRICS_PORT`

**Metrics Categories:**

| Category | Metrics |
|----------|---------|
| **Validation** | `blocks_validated_total`, `blocks_failed_total` (with `error_type` label), `block_validation_duration_seconds`, `transactions_per_block`, `gas_used_per_block` |
| **Worker** | `worker_tasks_completed_total`, `worker_tasks_failed_total` (with `worker_id` label) |
| **Chain** | `canonical_chain_height`, `remote_chain_height`, `chain_gap`, `blocks_advanced_total`, `reorgs_detected_total`, `reorg_depth` |
| **RPC** | `rpc_requests_total`, `rpc_errors_total`, `rpc_latency_seconds` (all with `method` label), `block_fetch_duration_seconds`, `witness_fetch_duration_seconds`, `code_fetch_duration_seconds` |
| **Database** | `contract_cache_hits_total`, `contract_cache_misses_total`, `blocks_pruned_total` |

**Instrumented Components:**
- Block validation timing and throughput in `validate_one()`
- Chain sync progress and reorg detection
- All RPC calls (`eth_getCodeByHash`, `eth_getBlockByNumber`, `eth_blockNumber`, `mega_getBlockWitness`, `mega_setValidatedBlocks`)
- Contract code cache hit/miss tracking
- History pruning statistics

### Usage

```bash
cargo run --bin stateless-validator -- \
  --rpc-endpoint <rpc> \
  --witness-endpoint <witness> \
  --genesis-file genesis.json \
  --start-block <hash> \
  --metrics-enabled \
  --metrics-port 9090
```

Metrics available at `http://0.0.0.0:9090/metrics`

### Files Changed

- `bin/stateless-validator/src/metrics.rs` — New metrics module (211 lines)
- `bin/stateless-validator/src/main.rs` — CLI args, initialization, and instrumentation
- `bin/stateless-validator/src/rpc.rs` — RPC call instrumentation
- `bin/stateless-validator/Cargo.toml` — Added `metrics` and `metrics-exporter-prometheus` dependencies
- `README.md` — Documentation for metrics configuration and available metrics