### PR TITLE
chore: Upgrade `mega-evm` dependency from v1.2.0 to v1.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2892,8 +2892,8 @@ dependencies = [
 
 [[package]]
 name = "mega-evm"
-version = "1.2.0"
-source = "git+https://github.com/megaeth-labs/mega-evm.git?rev=v1.2.0#0a524a5e72de42e682105dbb94de697376ca7410"
+version = "1.2.1"
+source = "git+https://github.com/megaeth-labs/mega-evm.git?rev=v1.2.1#fa3b03c1a524d90eaf6ec338023e3269b94cec9c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ op-alloy-rpc-types = { version = "0.18.12", default-features = false }
 revm = { version = "27.1.0", default-features = false }
 
 # megaeth 
-mega-evm = { git = "https://github.com/megaeth-labs/mega-evm.git", rev = "v1.2.0" }
+mega-evm = { git = "https://github.com/megaeth-labs/mega-evm.git", rev = "v1.2.1" }
 salt = { git = "https://github.com/megaeth-labs/salt.git", rev = "v1.0.0" }
 
 # reth

--- a/bin/stateless-validator/src/main.rs
+++ b/bin/stateless-validator/src/main.rs
@@ -1,3 +1,10 @@
+use std::{
+    collections::{HashMap, HashSet},
+    path::PathBuf,
+    sync::Arc,
+    time::{Duration, Instant, SystemTime},
+};
+
 use alloy_genesis::Genesis;
 use alloy_primitives::{B256, BlockHash, BlockNumber, hex};
 use alloy_rpc_types_eth::{Block, BlockId};
@@ -7,12 +14,6 @@ use futures::future;
 use op_alloy_rpc_types::Transaction;
 use revm::{primitives::KECCAK_EMPTY, state::Bytecode};
 use salt::SaltWitness;
-use std::{
-    collections::{HashMap, HashSet},
-    path::PathBuf,
-    sync::Arc,
-    time::{Duration, Instant, SystemTime},
-};
 use tokio::{signal, task};
 use tracing::{debug, error, info, warn};
 use tracing_subscriber::{EnvFilter, Layer, fmt, layer::SubscriberExt, util::SubscriberInitExt};
@@ -946,7 +947,13 @@ async fn find_divergence_point(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use std::{
+        collections::BTreeMap,
+        fs::File,
+        io::{BufRead, BufReader},
+        path::Path,
+    };
+
     use alloy_primitives::{BlockHash, BlockNumber};
     use alloy_rpc_types_eth::Block;
     use eyre::Context;
@@ -959,13 +966,9 @@ mod tests {
     };
     use op_alloy_rpc_types::Transaction;
     use serde::{Deserialize, Serialize, de::DeserializeOwned};
-    use std::{
-        collections::BTreeMap,
-        fs::File,
-        io::{BufRead, BufReader},
-        path::Path,
-    };
     use validator_core::withdrawals::MptWitness;
+
+    use super::*;
 
     /// Serialized witness data for a blockchain block.
     ///

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,5 @@
+# Import organization (requires nightly rustfmt with unstable features)
+# Merge imports from the same crate using {}
+imports_granularity = "Crate"
+# One/StdExternalCrate
+group_imports = "StdExternalCrate"

--- a/validator-core/src/chain_spec.rs
+++ b/validator-core/src/chain_spec.rs
@@ -155,8 +155,9 @@ pub static MEGA_MAINNET_HARDFORKS: std::sync::LazyLock<ChainHardforks> =
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use alloy_serde::OtherFields;
+
+    use super::*;
 
     #[test]
     fn test_create_from_default_genesis() {

--- a/validator-core/src/database.rs
+++ b/validator-core/src/database.rs
@@ -4,7 +4,6 @@
 //! a block witness rather than a full blockchain database, enabling stateless block
 //! validation.
 
-use crate::data_types::{PlainKey, PlainValue};
 use alloy_eips::eip2935::{HISTORY_SERVE_WINDOW, HISTORY_STORAGE_ADDRESS};
 use alloy_primitives::{Address, B256, BlockNumber};
 use alloy_rpc_types_eth::Header;
@@ -21,6 +20,8 @@ use salt::{
 };
 use std::collections::HashMap;
 use tracing::trace;
+
+use crate::data_types::{PlainKey, PlainValue};
 
 /// Error type for witness database operations
 #[derive(Debug, Clone)]

--- a/validator-core/src/database.rs
+++ b/validator-core/src/database.rs
@@ -4,6 +4,8 @@
 //! a block witness rather than a full blockchain database, enabling stateless block
 //! validation.
 
+use std::collections::HashMap;
+
 use alloy_eips::eip2935::{HISTORY_SERVE_WINDOW, HISTORY_STORAGE_ADDRESS};
 use alloy_primitives::{Address, B256, BlockNumber};
 use alloy_rpc_types_eth::Header;
@@ -18,7 +20,6 @@ use salt::{
     BucketId, BucketMeta, EphemeralSaltState, METADATA_KEYS_RANGE, SaltKey, SaltValue, SaltWitness,
     Witness, bucket_id_from_metadata_key, hasher,
 };
-use std::collections::HashMap;
 use tracing::trace;
 
 use crate::data_types::{PlainKey, PlainValue};

--- a/validator-core/src/executor.rs
+++ b/validator-core/src/executor.rs
@@ -23,6 +23,8 @@
 //! The module integrates with the Salt witness system for state reconstruction
 //! and uses Revm for transaction execution.
 
+use std::{collections::BTreeMap, fmt::Debug, io::Write, time::SystemTime};
+
 use alloy_consensus::{
     TxReceipt,
     proofs::calculate_receipt_root,
@@ -56,7 +58,6 @@ use revm::{
 };
 use salt::{EphemeralSaltState, SaltValue, SaltWitness, StateRoot, StateUpdates, Witness};
 use serde::{Deserialize, Serialize};
-use std::{collections::BTreeMap, fmt::Debug, io::Write, time::SystemTime};
 use thiserror::Error;
 
 use crate::{

--- a/validator-core/src/validator_db.rs
+++ b/validator-core/src/validator_db.rs
@@ -57,6 +57,8 @@
 //! - `add_contract_codes()` - Cache contract bytecodes needed during validation in batch
 //! - `get_contract_codes()` - Retrieve cached contract bytecodes by code hashes in batch
 
+use std::{collections::HashMap, fmt};
+
 use alloy_genesis::Genesis;
 use alloy_primitives::{B256, BlockHash, BlockNumber};
 use alloy_rpc_types_eth::{Block, Header};
@@ -65,7 +67,6 @@ use redb::{Database, ReadableDatabase, ReadableTable, TableDefinition};
 use revm::state::Bytecode;
 use salt::SaltWitness;
 use serde_json;
-use std::{collections::HashMap, fmt};
 use thiserror::Error;
 
 use crate::{

--- a/validator-core/src/validator_db.rs
+++ b/validator-core/src/validator_db.rs
@@ -65,12 +65,13 @@ use redb::{Database, ReadableDatabase, ReadableTable, TableDefinition};
 use revm::state::Bytecode;
 use salt::SaltWitness;
 use serde_json;
+use std::{collections::HashMap, fmt};
 use thiserror::Error;
 
-use std::{collections::HashMap, fmt};
-
-use crate::executor::{ValidationError, ValidationResult};
-use crate::withdrawals::MptWitness;
+use crate::{
+    executor::{ValidationError, ValidationResult},
+    withdrawals::MptWitness,
+};
 
 /// Stores our local view of the canonical chain.
 ///

--- a/validator-core/src/withdrawals.rs
+++ b/validator-core/src/withdrawals.rs
@@ -5,6 +5,8 @@
 //! storage updates from block execution, it cryptographically proves the storage root
 //! transition is valid.
 
+use std::collections::{HashSet, VecDeque};
+
 use alloy_primitives::{Address, B256, Bytes, U256, address, keccak256, map::B256Map};
 use alloy_rlp::Decodable;
 use alloy_rpc_types_eth::Header;
@@ -14,7 +16,6 @@ use reth_trie_sparse::{
     SerialSparseTrie, SparseTrie, SparseTrieInterface, TrieMasks, provider::DefaultTrieNodeProvider,
 };
 use serde::{Deserialize, Serialize};
-use std::collections::{HashSet, VecDeque};
 use thiserror::Error;
 
 /// Number of children in an MPT branch node (0-15, hex digits)


### PR DESCRIPTION
## Changes

- **Dependency Update**: Updated `mega-evm` from v1.2.0 to v1.2.1
  - Updated dependency reference in `Cargo.toml`
  - Updated lock file with new git revision: `fa3b03c1a524d90eaf6ec338023e3269b94cec9c`

https://github.com/megaeth-labs/mega-reth/pull/1281
mega-evm v1.2.1 fixes a bug in the inspector that could affect the evm trace in the validator-core executor.


- **Code Cleanup**: Minor import organization improvements
  - Reorganized imports in `validator-core/src/database.rs` to follow Rust conventions (external crates before internal modules)
  - Improved import grouping in `validator-core/src/validator_db.rs` for better readability

## Files Changed

- `Cargo.toml` - Updated mega-evm dependency version
- `Cargo.lock` - Updated dependency lock with new revision
- `validator-core/src/database.rs` - Import ordering cleanup
- `validator-core/src/validator_db.rs` - Import formatting improvements

## Testing

- [x] Verify project builds successfully with new mega-evm version
- [x] Run existing test suite to ensure compatibility
- [x] Validate stateless validator functionality with updated dependency