### PR TITLE
upgrade mega-evm from v1.2.1 to v1.2.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2892,8 +2892,8 @@ dependencies = [
 
 [[package]]
 name = "mega-evm"
-version = "1.2.1"
-source = "git+https://github.com/megaeth-labs/mega-evm.git?rev=v1.2.1#fa3b03c1a524d90eaf6ec338023e3269b94cec9c"
+version = "1.2.3"
+source = "git+https://github.com/megaeth-labs/mega-evm.git?rev=v1.2.3#21b313827348e7d1c579488d555a7a38521a1a46"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ op-alloy-rpc-types = { version = "0.18.12", default-features = false }
 revm = { version = "27.1.0", default-features = false }
 
 # megaeth 
-mega-evm = { git = "https://github.com/megaeth-labs/mega-evm.git", rev = "v1.2.1" }
+mega-evm = { git = "https://github.com/megaeth-labs/mega-evm.git", rev = "v1.2.3" }
 salt = { git = "https://github.com/megaeth-labs/salt.git", rev = "v1.0.0" }
 
 # reth

--- a/validator-core/src/chain_spec.rs
+++ b/validator-core/src/chain_spec.rs
@@ -108,6 +108,8 @@ pub struct MegaethGenesisHardforks {
     pub mini_rex_2_time: Option<u64>,
     /// Rex hardfork timestamp.
     pub rex_time: Option<u64>,
+    /// Rex1 hardfork timestamp.
+    pub rex_1_time: Option<u64>,
 }
 
 impl MegaethGenesisHardforks {
@@ -135,6 +137,10 @@ impl MegaethGenesisHardforks {
                 MegaHardfork::Rex.boxed(),
                 self.rex_time.map(ForkCondition::Timestamp),
             ),
+            (
+                MegaHardfork::Rex1.boxed(),
+                self.rex_1_time.map(ForkCondition::Timestamp),
+            ),
         ]
         .into_iter()
         .filter_map(|(hardfork, condition)| condition.map(|c| (hardfork, c)))
@@ -150,6 +156,7 @@ pub static MEGA_MAINNET_HARDFORKS: std::sync::LazyLock<ChainHardforks> =
             (MegaHardfork::MiniRex1.boxed(), ForkCondition::Timestamp(0)),
             (MegaHardfork::MiniRex2.boxed(), ForkCondition::Timestamp(0)),
             (MegaHardfork::Rex.boxed(), ForkCondition::Timestamp(0)),
+            (MegaHardfork::Rex1.boxed(), ForkCondition::Timestamp(0)),
         ])
     });
 
@@ -230,7 +237,8 @@ mod tests {
           "miniRexTime": 1,
           "miniRex1Time": 2,
           "miniRex2Time": 3,
-          "rexTime": 2
+          "rexTime": 4,
+          "rex1Time": 5
         }
         "#;
         let fields = serde_json::from_str::<OtherFields>(genesis_info).unwrap();
@@ -238,6 +246,7 @@ mod tests {
         assert_eq!(hardforks.mini_rex_time, Some(1));
         assert_eq!(hardforks.mini_rex_1_time, Some(2));
         assert_eq!(hardforks.mini_rex_2_time, Some(3));
-        assert_eq!(hardforks.rex_time, Some(2));
+        assert_eq!(hardforks.rex_time, Some(4));
+        assert_eq!(hardforks.rex_1_time, Some(5));
     }
 }


### PR DESCRIPTION
## Summary

- Upgrade `mega-evm` dependency from v1.2.1 to v1.2.3
- Add support for the Rex1 hardfork

## Changes

### Dependency Update
- Updated `mega-evm` dependency from `v1.2.1` to `v1.2.3` in `Cargo.toml`
- Updated lock file to reflect the new version (commit hash: `21b31382`)

### Rex1 Hardfork Support
- Added `rex_1_time` field to `MegaethGenesisHardforks` struct to configure Rex1 hardfork activation timestamp
- Integrated `MegaHardfork::Rex1` into the hardfork chain configuration
- Added Rex1 to `MEGA_MAINNET_HARDFORKS` with initial timestamp of 0
- Updated tests to validate Rex1 hardfork deserialization and configuration
