### PR TITLE
chore: bump version to 2.0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5003,7 +5003,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stateless-validator"
-version = "0.1.0"
+version = "2.0.3"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -5548,7 +5548,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "validator-core"
-version = "0.1.0"
+version = "2.0.3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",

--- a/bin/stateless-validator/Cargo.toml
+++ b/bin/stateless-validator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stateless-validator"
-version = "0.1.0"
+version = "2.0.3"
 edition = "2024"
 
 [[bin]]

--- a/validator-core/Cargo.toml
+++ b/validator-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "validator-core"
-version = "0.1.0"
+version = "2.0.3"
 edition = "2024"
 
 [dependencies]


### PR DESCRIPTION
Update version numbers across the workspace for the v2.0.3 release.