### PR TITLE
Add hardfork log when replay block

### DIFF
--- a/bin/stateless-validator/src/main.rs
+++ b/bin/stateless-validator/src/main.rs
@@ -53,6 +53,7 @@ fn init_logging() -> Result<()> {
         .with_writer(std::io::stdout)
         .with_filter(
             EnvFilter::new("warn")
+                .add_directive(format!("validator_core={}", stdout_filter).parse()?)
                 .add_directive(format!("stateless_validator={}", stdout_filter).parse()?),
         )
         .boxed();
@@ -74,6 +75,7 @@ fn init_logging() -> Result<()> {
             ))
             .with_filter(
                 EnvFilter::new("warn")
+                    .add_directive(format!("validator_core={}", file_filter).parse()?)
                     .add_directive(format!("stateless_validator={}", file_filter).parse()?),
             )
             .boxed();

--- a/validator-core/src/executor.rs
+++ b/validator-core/src/executor.rs
@@ -64,6 +64,7 @@ use revm::{
 use salt::{EphemeralSaltState, SaltValue, SaltWitness, StateRoot, StateUpdates, Witness};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
+use tracing::debug;
 
 use crate::{
     chain_spec::{BLOB_GASPRICE_UPDATE_FRACTION, ChainSpec},
@@ -302,6 +303,10 @@ where
     );
 
     let hardfork = chain_spec.hardfork(block.header.timestamp);
+    debug!(
+        "[Replay Block] block_number={}, block_hash={:?}, hardfork={:?}",
+        block.header.number, block.header.hash, hardfork
+    );
     let block_limits = if let Some(hardfork) = hardfork {
         BlockLimits::from_hardfork_and_block_gas_limit(hardfork, block.header.gas_limit)
     } else {


### PR DESCRIPTION
## Summary
- Add debug logging in `validator-core` to output block number, block hash, and hardfork information when replaying blocks
- Update logging configuration to include `validator_core` module in log filter directives for both stdout and file outputs

## Changes

### `validator-core/src/executor.rs`
Added a `debug!` log statement that outputs:
- `block_number`
- `block_hash`
- `hardfork`

This provides better visibility into which hardfork is being used when processing each block.

### `bin/stateless-validator/src/main.rs`
Added `validator_core` to the `EnvFilter` directives for both:
- Stdout logging layer
- File logging layer

This ensures the new debug logs from `validator_core` are captured based on the configured log level.

## Test plan
- [x] Run the validator and verify hardfork information is logged at debug level when replaying blocks
- [x] Confirm logs appear in both stdout and log files when appropriate log levels are set