### PR TITLE
Fix Graceful Shutdown to Prevent Validator Freeze

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ redb = "3.0.1"
 serde = { version = "1.0", default-features = false }
 serde_json = "1.0"
 thiserror = "2.0.16"
-tokio = { version = "1.46", features = ["rt-multi-thread", "macros", "signal"] }
+tokio = { version = "1.46", features = ["rt-multi-thread", "signal"] }
 tracing = "0.1"
 tracing-subscriber = { version = "=0.3.20", features = ["fmt", "env-filter"] }
 tracing-appender = "0.2"

--- a/bin/stateless-validator/src/main.rs
+++ b/bin/stateless-validator/src/main.rs
@@ -235,7 +235,6 @@ fn main() -> Result<()> {
 
     let rt = Runtime::new()?;
     let result = rt.block_on(async_main());
-
     // Force shutdown after 5 seconds to avoid hanging on spawn_blocking tasks
     rt.shutdown_timeout(Duration::from_secs(5));
 
@@ -333,7 +332,7 @@ async fn async_main() -> Result<()> {
     let validator_logic = chain_sync(client.clone(), validator_db.clone(), config, chain_spec);
 
     let mut sigterm = signal::unix::signal(signal::unix::SignalKind::terminate())
-        .expect("Failed to register SIGTERM handler");
+        .map_err(|e| anyhow!("[Main] Failed to register SIGTERM handler: {e}"))?;
     tokio::select! {
         res = validator_logic => res?,
         _ = signal::ctrl_c() => {


### PR DESCRIPTION
### Problem

There was a low probability that running `systemctl stop/restart stateless-validator` would cause the system to freeze, eventually get killed after 60 seconds (systemd's default timeout).

**Root Cause:**
1. When using `#[tokio::main]`, the runtime would wait indefinitely for `spawn_blocking` tasks to complete during shutdown, causing the process to hang until systemd forcefully killed it with `SIGKILL`.
2. The service only handled `SIGINT` (Ctrl+C), but `systemctl stop/restart` sends `SIGTERM`. Since `SIGTERM` wasn't being caught, the application didn't initiate a graceful shutdown.

### Solution

1. **Added SIGTERM handler**: The application now properly handles both `SIGINT` and `SIGTERM` signals, ensuring `systemctl stop/restart` triggers a graceful shutdown.

2. **Manual runtime management with shutdown timeout**: Replaced `#[tokio::main]` with explicit `Runtime::new()` and `rt.shutdown_timeout(Duration::from_secs(5))`. This ensures the runtime will force-stop any lingering `spawn_blocking` tasks after 5 seconds.

### Changes

- `bin/stateless-validator/src/main.rs`: 
  - Split `main()` into sync `main()` and `async_main()`
  - Added manual tokio runtime with 1-second shutdown timeout
  - Added `SIGTERM` signal handler alongside existing `SIGINT` handler

### Testing

- Verified `systemctl stop stateless-validator` now exits cleanly within seconds
- Verified `systemctl restart stateless-validator` completes without hanging
- Confirmed database integrity is preserved after stop/restart cycles