### PR TITLE
Enable redb database logging & close DB cleanly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3824,6 +3824,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae323eb086579a3769daa2c753bb96deb95993c534711e0dbe881b5192906a06"
 dependencies = [
  "libc",
+ "log",
 ]
 
 [[package]]

--- a/bin/stateless-validator/Cargo.toml
+++ b/bin/stateless-validator/Cargo.toml
@@ -47,4 +47,3 @@ tempfile = "3.8"
 
 [features]
 test-bucket-resize = ["salt/test-bucket-resize", "validator-core/test-bucket-resize"]
-redb-logging = ["validator-core/redb-logging"]

--- a/bin/stateless-validator/Cargo.toml
+++ b/bin/stateless-validator/Cargo.toml
@@ -47,3 +47,4 @@ tempfile = "3.8"
 
 [features]
 test-bucket-resize = ["salt/test-bucket-resize", "validator-core/test-bucket-resize"]
+redb-logging = ["validator-core/redb-logging"]

--- a/bin/stateless-validator/src/main.rs
+++ b/bin/stateless-validator/src/main.rs
@@ -343,12 +343,9 @@ async fn main() -> Result<()> {
         handle.abort();
     }
     let timeout = Duration::from_secs(1);
-    if tokio::time::timeout(timeout, future::join_all(handles))
-        .await
-        .is_err()
-    {
+    if let Err(e) = tokio::time::timeout(timeout, future::join_all(handles)).await {
         warn!(
-            "[Main] Tokio runtime shutdown reached the {:?} timeout.",
+            "[Main] Tokio runtime shutdown reached the {:?} timeout, error: {e}.",
             timeout
         );
     }

--- a/validator-core/Cargo.toml
+++ b/validator-core/Cargo.toml
@@ -30,17 +30,17 @@ mega-evm.workspace = true
 salt.workspace = true
 
 # reth
-reth-ethereum-forks = { workspace = true }
-reth-optimism-chainspec = { workspace = true }
-reth-trie = { workspace = true }
-reth-trie-common = { workspace = true }
-reth-trie-sparse = { workspace = true }
+reth-ethereum-forks.workspace = true
+reth-optimism-chainspec.workspace = true
+reth-trie.workspace = true
+reth-trie-common.workspace = true
+reth-trie-sparse.workspace = true
 
 # misc
 bincode.workspace = true
 eyre.workspace = true
 dyn-clone.workspace = true
-redb.workspace = true
+redb = { workspace = true, features = ["logging"] }
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
@@ -48,4 +48,3 @@ tracing.workspace = true
 
 [features]
 test-bucket-resize = ["salt/test-bucket-resize"]
-redb-logging = ["redb/logging"]

--- a/validator-core/Cargo.toml
+++ b/validator-core/Cargo.toml
@@ -48,3 +48,4 @@ tracing.workspace = true
 
 [features]
 test-bucket-resize = ["salt/test-bucket-resize"]
+redb-logging = ["redb/logging"]


### PR DESCRIPTION
### Summary

  Enable redb database logging and refactor shutdown to ensure the database closes cleanly.

### Problem
  When the validator was restarted after exit, it displayed a warning:
```log
2025-12-25T15:59:11.356785Z  WARN redb::db: Database "FileBackend { lock_supported: true, file: File { fd: 11, path: \"/Users/worker13/.chain-ops/devnet/stateless-validator/validator.redb\", read: true, write: true } }" not shutdown cleanly. Repairing
```
  This occurred because background tasks holding Arc<ValidatorDB> references could prevent the database from being dropped before the process exited.

### Changes

  **Enable redb Logging**

  - Added logging feature to the redb dependency in validator-core/Cargo.toml

  **Clean Shutdown Refactoring**

  - Replaced manual tokio runtime management with #[tokio::main] async main function
  - Refactored chain_sync() from an async function to a sync function that returns:
    - impl Future<Output = Result<()>> - the main synchronization loop
    - Vec<JoinHandle<Result<()>>> - all spawned background task handles
  - Changed validator_db parameter from Arc<ValidatorDB> to &Arc<ValidatorDB> to avoid transferring ownership
  - Added explicit shutdown sequence:
    a. Abort all background tasks via their handles
    b. Wait up to 1 second for tasks to complete
    c. Explicitly drop ValidatorDB to ensure clean database closure
  - Updated tests to match new chain_sync signature

 ### Files Changed

  | File                                | Changes                                       |
  |-------------------------------------|-----------------------------------------------|
  | Cargo.lock                          | Added log dependency to redb                  |
  | bin/stateless-validator/src/main.rs | Refactored main/chain_sync for clean shutdown |
  | validator-core/Cargo.toml           | Enabled logging feature for redb              |