### PR TITLE
chore:  Upgrade mega-evm from v1.2.3 to v1.2.5 & release 2.0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5003,7 +5003,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stateless-validator"
-version = "2.0.3"
+version = "2.0.4"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -5548,7 +5548,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "validator-core"
-version = "2.0.3"
+version = "2.0.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2892,8 +2892,8 @@ dependencies = [
 
 [[package]]
 name = "mega-evm"
-version = "1.2.3"
-source = "git+https://github.com/megaeth-labs/mega-evm.git?rev=v1.2.3#21b313827348e7d1c579488d555a7a38521a1a46"
+version = "1.2.5"
+source = "git+https://github.com/megaeth-labs/mega-evm.git?rev=v1.2.5#969af22c5d38ee24ceccedad04468c1980156162"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ op-alloy-rpc-types = { version = "0.18.12", default-features = false }
 revm = { version = "27.1.0", default-features = false }
 
 # megaeth 
-mega-evm = { git = "https://github.com/megaeth-labs/mega-evm.git", rev = "v1.2.3" }
+mega-evm = { git = "https://github.com/megaeth-labs/mega-evm.git", rev = "v1.2.5" }
 salt = { git = "https://github.com/megaeth-labs/salt.git", rev = "v1.0.0" }
 
 # reth

--- a/bin/stateless-validator/Cargo.toml
+++ b/bin/stateless-validator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stateless-validator"
-version = "2.0.3"
+version = "2.0.4"
 edition = "2024"
 
 [[bin]]

--- a/validator-core/Cargo.toml
+++ b/validator-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "validator-core"
-version = "2.0.3"
+version = "2.0.4"
 edition = "2024"
 
 [dependencies]


### PR DESCRIPTION
### Summary
This PR upgrades the `mega-evm` dependency and bumps the project version to 2.0.4.

### Changes

#### Dependency Upgrade
- Upgraded `mega-evm` from **v1.2.3** to **v1.2.5**
  - Updated in `Cargo.toml` workspace dependencies

#### Version Bump
- Bumped project version from **2.0.3** to **2.0.4**
  - `bin/stateless-validator/Cargo.toml`
  - `validator-core/Cargo.toml`

### Commits
| Commit | Message |
|--------|---------|
| `4046210` | chore: bump version to 2.0.4 |
| `2686640` | upgrade mega-evm from v1.2.3 to v1.2.5 |

### Files Changed
- `Cargo.toml` - Updated mega-evm dependency version
- `Cargo.lock` - Updated lock file
- `bin/stateless-validator/Cargo.toml` - Version bump
- `validator-core/Cargo.toml` - Version bump