### PR TITLE
chore: upgrade salt from v1.0.0 to v1.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1171,7 +1171,7 @@ checksum = "7b7e4c2464d97fe331d41de9d5db0def0a96f4d823b8b32a2efd503578988973"
 [[package]]
 name = "banderwagon"
 version = "0.1.0"
-source = "git+https://github.com/megaeth-labs/salt.git?rev=v1.0.0#affce3ecf3deb1791ea804fe5409c3e41b8d2883"
+source = "git+https://github.com/megaeth-labs/salt.git?rev=v1.0.1#f15f1b2cac046c874656f16af10b00db3174e733"
 dependencies = [
  "ark-ec 0.5.0 (git+https://github.com/megaeth-labs/algebra.git?rev=80ca69c37f79d5d00750edc1602af81b5f456695)",
  "ark-ed-on-bls12-381-bandersnatch",
@@ -2537,7 +2537,7 @@ dependencies = [
 [[package]]
 name = "ipa-multipoint"
 version = "0.1.0"
-source = "git+https://github.com/megaeth-labs/salt.git?rev=v1.0.0#affce3ecf3deb1791ea804fe5409c3e41b8d2883"
+source = "git+https://github.com/megaeth-labs/salt.git?rev=v1.0.1#f15f1b2cac046c874656f16af10b00db3174e733"
 dependencies = [
  "banderwagon",
  "hex",
@@ -4557,8 +4557,8 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "salt"
-version = "1.0.0"
-source = "git+https://github.com/megaeth-labs/salt.git?rev=v1.0.0#affce3ecf3deb1791ea804fe5409c3e41b8d2883"
+version = "1.0.1"
+source = "git+https://github.com/megaeth-labs/salt.git?rev=v1.0.1#f15f1b2cac046c874656f16af10b00db3174e733"
 dependencies = [
  "auto_impl",
  "banderwagon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ revm = { version = "27.1.0", default-features = false }
 
 # megaeth 
 mega-evm = { git = "https://github.com/megaeth-labs/mega-evm.git", rev = "v1.2.5" }
-salt = { git = "https://github.com/megaeth-labs/salt.git", rev = "v1.0.0" }
+salt = { git = "https://github.com/megaeth-labs/salt.git", rev = "v1.0.1" }
 
 # reth
 reth-ethereum-forks = { git = "https://github.com/paradigmxyz/reth", tag = "v1.6.0" }


### PR DESCRIPTION
### Summary

This PR upgrades the `salt` dependency from version `v1.0.0` to `v1.0.1`.

### Changes

- Updated `salt` dependency in `Cargo.toml` to point to revision `v1.0.1`
- Updated `Cargo.lock` with the new version and transitive dependencies:
  - `salt`: `1.0.0` → `1.0.1`
  - `banderwagon`: updated source revision
  - `ipa-multipoint`: updated source revision

### Files Changed

| File | Changes |
|------|---------|
| `Cargo.toml` | Updated `salt` git revision from `v1.0.0` to `v1.0.1` |
| `Cargo.lock` | Auto-generated lockfile updates reflecting the new dependency versions |

### Details

The `salt` library is sourced from `https://github.com/megaeth-labs/salt.git`. This update changes the pinned revision from:
- `affce3ecf3deb1791ea804fe5409c3e41b8d2883` (v1.0.0)

to:
- `f15f1b2cac046c874656f16af10b00db3174e733` (v1.0.1)

### Testing

- [x] Build passes
- [x] Existing tests pass