### PR TITLE
chore: modify max worker amount to 8

### DIFF
--- a/bin/stateless-validator/src/main.rs
+++ b/bin/stateless-validator/src/main.rs
@@ -173,13 +173,13 @@ pub struct ChainSyncConfig {
 impl Default for ChainSyncConfig {
     fn default() -> Self {
         Self {
-            concurrent_workers: num_cpus::get().min(16),
+            concurrent_workers: num_cpus::get().min(8),
             sync_poll_interval: Duration::from_secs(1),
             sync_target: None,
             tracker_lookahead_blocks: 80,
             tracker_poll_interval: Duration::from_millis(100),
             pruner_interval: Duration::from_secs(300),
-            pruner_blocks_to_keep: 3600,
+            pruner_blocks_to_keep: 1000,
             worker_idle_sleep: Duration::from_millis(500),
             worker_error_sleep: Duration::from_millis(1000),
             tracker_error_sleep: Duration::from_secs(1),
@@ -324,7 +324,7 @@ async fn run() -> Result<()> {
 
     // Create chain sync configuration
     let config = Arc::new(ChainSyncConfig {
-        concurrent_workers: num_cpus::get().min(16),
+        concurrent_workers: num_cpus::get().min(8),
         report_validation_results: args.report_validation_results,
         metrics_enabled: args.metrics_enabled,
         metrics_port: args.metrics_port,

--- a/bin/stateless-validator/src/main.rs
+++ b/bin/stateless-validator/src/main.rs
@@ -173,13 +173,13 @@ pub struct ChainSyncConfig {
 impl Default for ChainSyncConfig {
     fn default() -> Self {
         Self {
-            concurrent_workers: num_cpus::get(),
+            concurrent_workers: num_cpus::get().min(16),
             sync_poll_interval: Duration::from_secs(1),
             sync_target: None,
             tracker_lookahead_blocks: 80,
             tracker_poll_interval: Duration::from_millis(100),
             pruner_interval: Duration::from_secs(300),
-            pruner_blocks_to_keep: 1000,
+            pruner_blocks_to_keep: 3600,
             worker_idle_sleep: Duration::from_millis(500),
             worker_error_sleep: Duration::from_millis(1000),
             tracker_error_sleep: Duration::from_secs(1),
@@ -324,7 +324,7 @@ async fn run() -> Result<()> {
 
     // Create chain sync configuration
     let config = Arc::new(ChainSyncConfig {
-        concurrent_workers: num_cpus::get(),
+        concurrent_workers: num_cpus::get().min(16),
         report_validation_results: args.report_validation_results,
         metrics_enabled: args.metrics_enabled,
         metrics_port: args.metrics_port,


### PR DESCRIPTION
### Summary
Cap the maximum concurrent workers to 16, regardless of available CPU cores
Increase the blocks to keep from 1000 to 3600 for the pruner

The changes limit concurrent_workers to a maximum of 16 using .min(16) to prevent resource exhaustion on high-core-count machines, and increase pruner_blocks_to_keep from 1000 to 3600 to retain more historical blocks before pruning.