### PR TITLE
perf(db): reduce write lock contention in task claim, chain growth, and validation completion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5568,6 +5568,7 @@ dependencies = [
  "mega-evm",
  "op-alloy-network",
  "op-alloy-rpc-types",
+ "rayon",
  "redb",
  "reth-ethereum-forks",
  "reth-optimism-chainspec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ futures = "0.3"
 metrics = "0.24"
 metrics-exporter-prometheus = { version = "0.18", default-features = false, features = ["http-listener"] }
 num_cpus = "1.17"
+rayon = "1.11"
 redb = "3.0.1"
 serde = { version = "1.0", default-features = false }
 serde_json = "1.0"

--- a/bin/stateless-validator/src/main.rs
+++ b/bin/stateless-validator/src/main.rs
@@ -501,6 +501,10 @@ async fn chain_sync(
             //    - If this occurs, it indicates either a bug in the validation pipeline or
             //      database corruption
             //
+            // 4. ValidationDbError::ValidationResultMismatch
+            //    - Validation result does not match the first remote chain entry
+            //    - Indicates database inconsistency or logic error in the pipeline
+            //
             // The chain sync process terminates immediately and returns the error to the caller.
             // Operators should investigate the root cause.
 

--- a/bin/stateless-validator/src/main.rs
+++ b/bin/stateless-validator/src/main.rs
@@ -783,7 +783,7 @@ async fn validate_one(
                 })
                 .collect::<Result<_>>()?;
 
-            validator_db.add_contract_codes(new_bytecodes.iter().map(|(_, bytecode)| bytecode))?;
+            validator_db.add_contract_codes(&new_bytecodes)?;
             contracts.extend(new_bytecodes);
 
             let pre_state_root = B256::from(witness.state_root()?);

--- a/validator-core/Cargo.toml
+++ b/validator-core/Cargo.toml
@@ -30,16 +30,17 @@ mega-evm.workspace = true
 salt.workspace = true
 
 # reth
-reth-ethereum-forks = { workspace = true }
-reth-optimism-chainspec = { workspace = true }
-reth-trie = { workspace = true }
-reth-trie-common = { workspace = true }
-reth-trie-sparse = { workspace = true }
+reth-ethereum-forks.workspace = true
+reth-optimism-chainspec.workspace = true
+reth-trie.workspace = true
+reth-trie-common.workspace = true
+reth-trie-sparse.workspace = true
 
 # misc
 bincode.workspace = true
 eyre.workspace = true
 dyn-clone.workspace = true
+rayon.workspace = true
 redb.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/validator-core/src/validator_db.rs
+++ b/validator-core/src/validator_db.rs
@@ -506,7 +506,8 @@ impl ValidatorDB {
                 if let Some(serialized) = validation_results.get(block_hash_bytes)? {
                     let result: ValidationResult = decode_from_slice(&serialized.value());
 
-                    if result.block_number != block_number || result.block_hash.0 != block_hash_bytes
+                    if result.block_number != block_number
+                        || result.block_hash.0 != block_hash_bytes
                     {
                         return Err(ValidationDbError::ValidationResultMismatch {
                             expected_block_number: block_number,
@@ -720,7 +721,11 @@ impl ValidatorDB {
                 None => (0u64, [0u8; 32]),
             };
 
-            task_list.range(range_start..)?.next().transpose()?.is_some()
+            task_list
+                .range(range_start..)?
+                .next()
+                .transpose()?
+                .is_some()
         };
 
         if !has_candidate {


### PR DESCRIPTION
Context

  - redb enforces a single-writer lock. Several hot paths were holding the write lock longer than necessary (task claim, chain advancement, validation completion),
    increasing contention across workers and the sync loop.

  What Changed

  - get_next_task: add a read-transaction fast path; keep the write transaction only for moving a task from TASK_LIST to ONGOING_TASKS. Load block data/witnesses in a read
    txn; on load failure, revert the claim.
  - grow_local_chain: add a read-transaction fast path; advance the chain using ValidationResult + remote-chain entry without decoding full block data under the write lock.
  - complete_validation: serialize the result before acquiring the write lock; write txn only performs insert/remove.
  - add_contract_codes: early-return on empty input to avoid unnecessary write transactions.
  - Add ValidationResultMismatch to make inconsistent remote entry vs. validation result explicit.

  Behavior

  - No protocol/validation semantics changes; only shorter write-lock hold times and clearer error classification.