### PR TITLE
chore: upgrade mega-evm to v1.3.1 to support rex2

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -30,6 +30,8 @@ jobs:
         # with:
         #   # default is -D warnings
         #   rustflags: "-A warnings"
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
       - run: cargo clippy
 
   fmt:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,6 +46,8 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           cache: false
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
 
       - name: Build
         id: build_step

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -27,6 +27,8 @@ jobs:
 
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
       - name: Run Test
         run: |
           cargo test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2892,8 +2892,8 @@ dependencies = [
 
 [[package]]
 name = "mega-evm"
-version = "1.2.5"
-source = "git+https://github.com/megaeth-labs/mega-evm.git?rev=v1.2.5#969af22c5d38ee24ceccedad04468c1980156162"
+version = "1.3.1"
+source = "git+https://github.com/megaeth-labs/mega-evm.git?rev=v1.3.1#29051039e1b80a2cef0743fc8262b7aae66153ae"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2907,6 +2907,7 @@ dependencies = [
  "bitflags",
  "delegate",
  "derive_more",
+ "mega-system-contracts",
  "once_cell",
  "op-alloy-consensus",
  "op-alloy-flz",
@@ -2914,6 +2915,18 @@ dependencies = [
  "revm",
  "serde",
  "thiserror 2.0.17",
+]
+
+[[package]]
+name = "mega-system-contracts"
+version = "1.3.1"
+source = "git+https://github.com/megaeth-labs/mega-evm.git?rev=v1.3.1#29051039e1b80a2cef0743fc8262b7aae66153ae"
+dependencies = [
+ "alloy-primitives",
+ "alloy-sol-types",
+ "semver 1.0.27",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -4675,6 +4688,10 @@ name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+dependencies = [
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "semver-parser"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ op-alloy-rpc-types = { version = "0.18.12", default-features = false }
 revm = { version = "27.1.0", default-features = false }
 
 # megaeth 
-mega-evm = { git = "https://github.com/megaeth-labs/mega-evm.git", rev = "v1.2.5" }
+mega-evm = { git = "https://github.com/megaeth-labs/mega-evm.git", rev = "v1.3.1" }
 salt = { git = "https://github.com/megaeth-labs/salt.git", rev = "v1.0.1" }
 
 # reth

--- a/validator-core/src/chain_spec.rs
+++ b/validator-core/src/chain_spec.rs
@@ -110,6 +110,8 @@ pub struct MegaethGenesisHardforks {
     pub rex_time: Option<u64>,
     /// Rex1 hardfork timestamp.
     pub rex_1_time: Option<u64>,
+    /// Rex2 hardfork timestamp.
+    pub rex_2_time: Option<u64>,
 }
 
 impl MegaethGenesisHardforks {
@@ -141,6 +143,10 @@ impl MegaethGenesisHardforks {
                 MegaHardfork::Rex1.boxed(),
                 self.rex_1_time.map(ForkCondition::Timestamp),
             ),
+            (
+                MegaHardfork::Rex2.boxed(),
+                self.rex_2_time.map(ForkCondition::Timestamp),
+            ),
         ]
         .into_iter()
         .filter_map(|(hardfork, condition)| condition.map(|c| (hardfork, c)))
@@ -157,6 +163,7 @@ pub static MEGA_MAINNET_HARDFORKS: std::sync::LazyLock<ChainHardforks> =
             (MegaHardfork::MiniRex2.boxed(), ForkCondition::Timestamp(0)),
             (MegaHardfork::Rex.boxed(), ForkCondition::Timestamp(0)),
             (MegaHardfork::Rex1.boxed(), ForkCondition::Timestamp(0)),
+            (MegaHardfork::Rex2.boxed(), ForkCondition::Timestamp(0)),
         ])
     });
 
@@ -238,7 +245,8 @@ mod tests {
           "miniRex1Time": 2,
           "miniRex2Time": 3,
           "rexTime": 4,
-          "rex1Time": 5
+          "rex1Time": 5,
+          "rex2Time": 6
         }
         "#;
         let fields = serde_json::from_str::<OtherFields>(genesis_info).unwrap();
@@ -248,5 +256,6 @@ mod tests {
         assert_eq!(hardforks.mini_rex_2_time, Some(3));
         assert_eq!(hardforks.rex_time, Some(4));
         assert_eq!(hardforks.rex_1_time, Some(5));
+        assert_eq!(hardforks.rex_2_time, Some(6));
     }
 }


### PR DESCRIPTION
## Summary

- Upgrade `mega-evm` dependency from v1.2.5 to v1.3.1 to enable Rex2 hardfork support
- Add `rex_2_time` configuration field to `MegaethGenesisHardforks` for Rex2 hardfork timestamp
- Register `MegaHardfork::Rex2` in the hardfork chain configuration

## Test plan

- [x] Existing tests updated to include Rex2 hardfork validation
- [x] Verify chain spec correctly parses `rex2Time` from genesis configuration
- [x] Confirm validator correctly handles blocks after Rex2 activation