### PR TITLE
fix: update mega_setValidatedBlocks rpc params & response

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5026,6 +5026,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-provider",
  "alloy-rpc-types-eth",
+ "alloy-serde",
  "bincode 2.0.1",
  "clap",
  "eyre",

--- a/bin/stateless-validator/Cargo.toml
+++ b/bin/stateless-validator/Cargo.toml
@@ -13,6 +13,7 @@ alloy-genesis.workspace = true
 alloy-primitives.workspace = true
 alloy-provider.workspace = true
 alloy-rpc-types-eth.workspace = true
+alloy-serde.workspace = true
 
 # op
 op-alloy-network.workspace = true


### PR DESCRIPTION
## Summary

- Update `mega_setValidatedBlocks` RPC request parameters to use `U64` type for block numbers, ensuring proper hex-encoded quantity serialization per Ethereum JSON-RPC spec
- Update `SetValidatedBlocksResponse` struct to use `U64` for the `last_validated_block` number field for consistent deserialization
- Add documentation comments to `SetValidatedBlocksResponse` struct and its fields

## Test plan

- [x] Verify RPC calls to `mega_setValidatedBlocks` serialize block numbers as hex quantity strings (e.g., `"0x1a2b3c"` instead of `1714492`)
- [x] Verify responses from `mega_setValidatedBlocks` are correctly deserialized with the `U64` type
- [x] Test end-to-end validation flow with upstream node to confirm compatibility

## Related
https://github.com/megaeth-labs/mega-reth/pull/1383