### PR TITLE
refactor: extract shared logging into stateless-common crate

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -32,7 +32,7 @@ jobs:
         #   rustflags: "-A warnings"
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
-      - run: cargo clippy
+      - run: cargo clippy --workspace --all-targets --all-features
 
       - name: Run cargo-sort
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1611,8 +1611,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-link",
 ]
 
@@ -1914,10 +1916,10 @@ dependencies = [
  "salt",
  "serde",
  "serde_json",
+ "stateless-common",
  "tempfile",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.20",
  "validator-core",
 ]
 
@@ -5166,6 +5168,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rolling-file"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8395b4f860856b740f20a296ea2cd4d823e81a2658cf05ef61be22916026a906"
+dependencies = [
+ "chrono",
+]
+
+[[package]]
 name = "route-recognizer"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5812,6 +5823,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "stateless-common"
+version = "2.0.6"
+dependencies = [
+ "clap",
+ "eyre",
+ "rolling-file",
+ "tracing",
+ "tracing-appender",
+ "tracing-subscriber 0.3.20",
+]
+
+[[package]]
 name = "stateless-validator"
 version = "2.0.6"
 dependencies = [
@@ -5835,10 +5858,10 @@ dependencies = [
  "salt",
  "serde",
  "serde_json",
+ "stateless-common",
  "tempfile",
  "tokio",
  "tracing",
- "tracing-appender",
  "tracing-subscriber 0.3.20",
  "validator-core",
 ]
@@ -6323,6 +6346,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6341,12 +6374,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,11 @@
 
 [workspace]
-members = ["bin/debug-trace-server", "bin/stateless-validator", "crates/validator-core"]
+members = [
+    "bin/debug-trace-server",
+    "bin/stateless-validator",
+    "crates/stateless-common",
+    "crates/validator-core",
+]
 resolver = "2"
 
 [workspace.package]
@@ -49,6 +54,7 @@ op-alloy-network = { version = "0.18.12", default-features = false }
 op-alloy-rpc-types = { version = "0.18.12", default-features = false }
 rayon = "1.11"
 redb = "3.0.1"
+rolling-file = "0.2"
 
 # reth
 reth-ethereum-forks = { git = "https://github.com/paradigmxyz/reth", tag = "v1.6.0" }
@@ -68,7 +74,7 @@ thiserror = "2.0.16"
 tokio = { version = "1.46", features = ["rt-multi-thread", "signal"] }
 tracing = "0.1"
 tracing-appender = "0.2"
-tracing-subscriber = { version = "=0.3.20", features = ["fmt", "env-filter"] }
+tracing-subscriber = { version = "=0.3.20", features = ["fmt", "env-filter", "json"] }
 
 [profile.release]
 opt-level = 3

--- a/bin/debug-trace-server/Cargo.toml
+++ b/bin/debug-trace-server/Cargo.toml
@@ -42,9 +42,9 @@ tokio = { workspace = true, features = ["sync"] }
 
 # Logging and metrics
 tracing.workspace = true
-tracing-subscriber.workspace = true
 
 # Reuse validator-core
+stateless-common = { path = "../../crates/stateless-common" }
 validator-core = { path = "../../crates/validator-core" }
 
 [dev-dependencies]

--- a/bin/debug-trace-server/src/main.rs
+++ b/bin/debug-trace-server/src/main.rs
@@ -48,9 +48,9 @@ use alloy_rpc_types_eth::BlockId;
 use clap::Parser;
 use eyre::{anyhow, ensure, Result};
 use jsonrpsee::server::{RpcModule, Server};
+use stateless_common::logging::LogArgs;
 use tokio::task;
 use tracing::{debug, error, info, instrument, warn};
-use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 use validator_core::{
     chain_spec::ChainSpec, remote_chain_tracker, ChainSyncConfig, RpcClient, RpcClientConfig,
     ValidatorDB,
@@ -147,6 +147,10 @@ struct Args {
         default_value_t = DEFAULT_PRUNER_INTERVAL_SECS
     )]
     pruner_interval_secs: u64,
+
+    /// Logging configuration.
+    #[command(flatten)]
+    log: LogArgs,
 }
 
 /// Database filename for the validator's local storage.
@@ -167,15 +171,8 @@ fn parse_block_hash(hex_str: &str) -> Result<BlockHash> {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    tracing_subscriber::registry()
-        .with(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "debug_trace_server=info".into()),
-        )
-        .with(tracing_subscriber::fmt::layer())
-        .init();
-
     let args = Args::parse();
+    let _log_guard = args.log.init_tracing()?;
 
     info!(
         listen_addr = %args.addr,

--- a/bin/stateless-validator/Cargo.toml
+++ b/bin/stateless-validator/Cargo.toml
@@ -39,16 +39,16 @@ revm = { workspace = true, features = ["serde"] }
 salt.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+stateless-common = { path = "../../crates/stateless-common" }
 tokio.workspace = true
 tracing.workspace = true
-tracing-appender.workspace = true
-tracing-subscriber.workspace = true
 validator-core = { path = "../../crates/validator-core" }
 
 [dev-dependencies]
 jsonrpsee = { version = "0.26", features = ["server", "macros"] }
 jsonrpsee-types = { version = "0.26" }
 tempfile = "3.8"
+tracing-subscriber.workspace = true
 
 [features]
 test-bucket-resize = ["salt/test-bucket-resize", "validator-core/test-bucket-resize"]

--- a/bin/stateless-validator/src/main.rs
+++ b/bin/stateless-validator/src/main.rs
@@ -13,9 +13,9 @@ use eyre::{Result, anyhow, ensure};
 use futures::future;
 use revm::{primitives::KECCAK_EMPTY, state::Bytecode};
 use salt::SaltWitness;
+use stateless_common::logging::{LogArgs, migrate_legacy_env_vars};
 use tokio::{signal, task};
 use tracing::{debug, error, info, warn};
-use tracing_subscriber::{EnvFilter, Layer, fmt, layer::SubscriberExt, util::SubscriberInitExt};
 use validator_core::{
     ChainSyncConfig, RpcClient, RpcClientConfig, ValidatorDB,
     chain_spec::ChainSpec,
@@ -28,66 +28,6 @@ mod metrics;
 
 /// Database filename for the validator.
 const VALIDATOR_DB_FILENAME: &str = "validator.redb";
-
-/// Initialize logging system with environment variable configuration
-///
-/// Supports the following environment variables:
-/// - STATELESS_VALIDATOR_LOG_FILE_DIRECTORY: Directory for log files (optional, file logging
-///   disabled if not set)
-/// - STATELESS_VALIDATOR_LOG_FILE: Log level for file output (debug/info/warn/error), default:
-///   debug
-/// - STATELESS_VALIDATOR_LOG_STDOUT: Log level for stdout (debug/info/warn/error), default: info
-fn init_logging() -> Result<()> {
-    use tracing_appender::rolling::{RollingFileAppender, Rotation};
-
-    // Load environment configuration with defaults
-    let file_directory = std::env::var("STATELESS_VALIDATOR_LOG_FILE_DIRECTORY").ok();
-    let file_filter =
-        std::env::var("STATELESS_VALIDATOR_LOG_FILE").unwrap_or_else(|_| "debug".to_string());
-    let stdout_filter =
-        std::env::var("STATELESS_VALIDATOR_LOG_STDOUT").unwrap_or_else(|_| "info".to_string());
-
-    // Configure stdout layer with external crate filtering
-    let stdout_layer = fmt::layer()
-        .with_writer(std::io::stdout)
-        .with_filter(
-            EnvFilter::new("warn")
-                .add_directive(format!("validator_core={}", stdout_filter).parse()?)
-                .add_directive(format!("stateless_validator={}", stdout_filter).parse()?),
-        )
-        .boxed();
-
-    let subscriber = tracing_subscriber::registry().with(stdout_layer);
-
-    // Optionally add file layer if directory is specified
-    if let Some(log_dir) = &file_directory {
-        let log_path = PathBuf::from(log_dir);
-        std::fs::create_dir_all(&log_path)
-            .map_err(|e| anyhow!("Failed to create log directory {log_dir}: {e}"))?;
-
-        // Configure file layer with daily rotation and filter
-        let file_layer = fmt::layer()
-            .with_writer(RollingFileAppender::new(
-                Rotation::DAILY,
-                log_path,
-                "stateless-validator.log",
-            ))
-            .with_filter(
-                EnvFilter::new("warn")
-                    .add_directive(format!("validator_core={}", file_filter).parse()?)
-                    .add_directive(format!("stateless_validator={}", file_filter).parse()?),
-            )
-            .boxed();
-
-        subscriber.with(file_layer).init();
-        info!("[Logging] Initialized: stdout={stdout_filter}, file={file_filter} ({log_dir})");
-    } else {
-        subscriber.init();
-        info!("[Logging] Initialized: stdout={stdout_filter}, file logging disabled");
-    }
-
-    Ok(())
-}
 
 /// Convert hex string to BlockHash
 ///
@@ -172,14 +112,21 @@ struct CommandLineArgs {
     /// Port for Prometheus metrics HTTP endpoint.
     #[clap(long, env = "STATELESS_VALIDATOR_METRICS_PORT", default_value_t = metrics::DEFAULT_METRICS_PORT)]
     metrics_port: u16,
+
+    /// Logging configuration.
+    #[command(flatten)]
+    log: LogArgs,
 }
 
 fn main() -> Result<()> {
-    init_logging()?;
+    migrate_legacy_env_vars();
+    let args = CommandLineArgs::parse();
+    let _log_guard = args.log.init_tracing()?;
+
     let runtime = tokio::runtime::Runtime::new()
         .map_err(|e| anyhow!("Failed to build Tokio runtime: {e}"))?;
     let timeout = Duration::from_secs(1);
-    let result = runtime.block_on(run());
+    let result = runtime.block_on(run(args));
     let shutdown_start = Instant::now();
     runtime.shutdown_timeout(timeout);
     if shutdown_start.elapsed() >= timeout {
@@ -188,9 +135,8 @@ fn main() -> Result<()> {
     result
 }
 
-async fn run() -> Result<()> {
+async fn run(args: CommandLineArgs) -> Result<()> {
     let start = Instant::now();
-    let args = CommandLineArgs::parse();
 
     info!("[Main] Data directory: {}", args.data_dir);
     info!("[Main] RPC endpoint: {}", args.rpc_endpoint);
@@ -750,6 +696,7 @@ mod tests {
     };
     use op_alloy_rpc_types::Transaction;
     use serde::{Deserialize, Serialize, de::DeserializeOwned};
+    use tracing_subscriber::EnvFilter;
     use validator_core::withdrawals::MptWitness;
 
     use super::*;

--- a/crates/stateless-common/Cargo.toml
+++ b/crates/stateless-common/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "stateless-common"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+exclude.workspace = true
+
+[dependencies]
+clap.workspace = true
+eyre.workspace = true
+rolling-file.workspace = true
+tracing.workspace = true
+tracing-appender.workspace = true
+tracing-subscriber.workspace = true

--- a/crates/stateless-common/src/lib.rs
+++ b/crates/stateless-common/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod logging;

--- a/crates/stateless-common/src/logging.rs
+++ b/crates/stateless-common/src/logging.rs
@@ -92,6 +92,14 @@ pub struct LogArgs {
     #[arg(long = "log.file-directory", env = "STATELESS_LOG_FILE_DIRECTORY")]
     pub log_file_directory: Option<PathBuf>,
 
+    /// Log file name.
+    #[arg(
+        long = "log.file-name",
+        env = "STATELESS_LOG_FILE_NAME",
+        default_value = "stateless-validator.log"
+    )]
+    pub log_file_name: String,
+
     /// File log filter directives.
     #[arg(long = "log.file-filter", env = "STATELESS_LOG_FILE", default_value = "debug")]
     pub log_file_filter: String,
@@ -125,13 +133,14 @@ fn build_env_filter(filter: &str) -> Result<EnvFilter> {
 /// alive for the lifetime of the program to guarantee log flushing on exit.
 fn build_file_writer(
     dir: &PathBuf,
+    file_name: &str,
     max_size_mb: u64,
     max_files: usize,
 ) -> Result<(tracing_appender::non_blocking::NonBlocking, WorkerGuard)> {
     std::fs::create_dir_all(dir)
         .map_err(|e| anyhow!("Failed to create log directory {}: {e}", dir.display()))?;
 
-    let file_path = dir.join("stateless-validator.log");
+    let file_path = dir.join(file_name);
     let condition = RollingConditionBasic::new().max_size(max_size_mb * 1024 * 1024);
     let appender = BasicRollingFileAppender::new(file_path, condition, max_files)
         .map_err(|e| anyhow!("Failed to create rolling file appender: {e}"))?;
@@ -198,8 +207,12 @@ impl LogArgs {
 
         // --- optional file layer ---
         let (file_layer, guard) = if let Some(ref dir) = self.log_file_directory {
-            let (non_blocking, guard) =
-                build_file_writer(dir, self.log_file_max_size, self.log_file_max_files)?;
+            let (non_blocking, guard) = build_file_writer(
+                dir,
+                &self.log_file_name,
+                self.log_file_max_size,
+                self.log_file_max_files,
+            )?;
             let file_filter = build_env_filter(&self.log_file_filter)?;
 
             let layer: Box<dyn Layer<_> + Send + Sync> = match self.log_file_format {

--- a/crates/stateless-common/src/logging.rs
+++ b/crates/stateless-common/src/logging.rs
@@ -1,0 +1,244 @@
+use std::{fmt, path::PathBuf};
+
+use clap::{Args, ValueEnum};
+use eyre::{Result, anyhow};
+use rolling_file::{BasicRollingFileAppender, RollingConditionBasic};
+use tracing::info;
+use tracing_appender::non_blocking::WorkerGuard;
+use tracing_subscriber::{
+    EnvFilter, Layer, fmt as tracing_fmt, layer::SubscriberExt, util::SubscriberInitExt,
+};
+
+/// Log output format.
+#[derive(Debug, Clone, Copy, Default, ValueEnum)]
+pub enum LogFormat {
+    /// Human-readable format for console output.
+    #[default]
+    Terminal,
+    /// Structured JSON format (for loki/grafana ingestion).
+    Json,
+}
+
+impl fmt::Display for LogFormat {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Terminal => write!(f, "terminal"),
+            Self::Json => write!(f, "json"),
+        }
+    }
+}
+
+/// ANSI color mode for console output.
+///
+/// Colored output is useful for visual inspection in a terminal, while
+/// color-free output is better when redirecting stdout to a file or pipe.
+#[derive(Debug, Clone, Copy, Default, ValueEnum)]
+pub enum ColorMode {
+    /// Always emit ANSI color codes.
+    Always,
+    /// Detect TTY and emit colors only when connected to a terminal (default).
+    #[default]
+    Auto,
+    /// Never emit ANSI color codes.
+    Never,
+}
+
+impl ColorMode {
+    /// Resolve to a boolean indicating whether ANSI colors should be used for stdout.
+    fn use_color(self) -> bool {
+        match self {
+            Self::Always => true,
+            Self::Auto => std::io::IsTerminal::is_terminal(&std::io::stdout()),
+            Self::Never => false,
+        }
+    }
+}
+
+/// Logging configuration exposed as CLI arguments.
+///
+/// All flags can also be set via environment variables. When both are provided
+/// the CLI flag takes precedence (standard `clap` behavior).
+///
+/// # Example
+///
+/// Embed in your binary's top-level CLI struct with `#[command(flatten)]`:
+///
+/// ```ignore
+/// #[derive(clap::Parser)]
+/// struct Cli {
+///     #[command(flatten)]
+///     log: LogArgs,
+/// }
+/// ```
+#[derive(Debug, Clone, Args)]
+pub struct LogArgs {
+    /// Console log filter directives (e.g. "info", "debug").
+    #[arg(long = "log.stdout-filter", env = "STATELESS_LOG_STDOUT", default_value = "info")]
+    pub log_stdout_filter: String,
+
+    /// Console output format.
+    #[arg(
+        long = "log.stdout-format",
+        env = "STATELESS_LOG_STDOUT_FORMAT",
+        default_value = "terminal"
+    )]
+    pub log_stdout_format: LogFormat,
+
+    /// Color mode for console output.
+    #[arg(long = "log.color", env = "STATELESS_LOG_COLOR", default_value = "auto")]
+    pub log_color: ColorMode,
+
+    /// Directory for log files. File logging is disabled when unset.
+    #[arg(long = "log.file-directory", env = "STATELESS_LOG_FILE_DIRECTORY")]
+    pub log_file_directory: Option<PathBuf>,
+
+    /// File log filter directives.
+    #[arg(long = "log.file-filter", env = "STATELESS_LOG_FILE", default_value = "debug")]
+    pub log_file_filter: String,
+
+    /// File output format.
+    #[arg(long = "log.file-format", env = "STATELESS_LOG_FILE_FORMAT", default_value = "terminal")]
+    pub log_file_format: LogFormat,
+
+    /// Maximum log file size in megabytes before rotation.
+    #[arg(long = "log.file-max-size", env = "STATELESS_LOG_FILE_MAX_SIZE", default_value_t = 200)]
+    pub log_file_max_size: u64,
+
+    /// Maximum number of rotated log files to keep.
+    #[arg(long = "log.file-max-files", env = "STATELESS_LOG_FILE_MAX_FILES", default_value_t = 5)]
+    pub log_file_max_files: usize,
+}
+
+/// Build an [`EnvFilter`] from the given base directive, applying it to
+/// workspace crates while defaulting everything else to `warn`.
+fn build_env_filter(filter: &str) -> Result<EnvFilter> {
+    Ok(EnvFilter::new("warn")
+        .add_directive(format!("validator_core={filter}").parse()?)
+        .add_directive(format!("stateless_validator={filter}").parse()?)
+        .add_directive(format!("stateless_common={filter}").parse()?)
+        .add_directive(format!("debug_trace_server={filter}").parse()?))
+}
+
+/// Create a size-based rolling file appender wrapped in a non-blocking writer.
+///
+/// Returns the non-blocking writer and the [`WorkerGuard`] that **must** be held
+/// alive for the lifetime of the program to guarantee log flushing on exit.
+fn build_file_writer(
+    dir: &PathBuf,
+    max_size_mb: u64,
+    max_files: usize,
+) -> Result<(tracing_appender::non_blocking::NonBlocking, WorkerGuard)> {
+    std::fs::create_dir_all(dir)
+        .map_err(|e| anyhow!("Failed to create log directory {}: {e}", dir.display()))?;
+
+    let file_path = dir.join("stateless-validator.log");
+    let condition = RollingConditionBasic::new().max_size(max_size_mb * 1024 * 1024);
+    let appender = BasicRollingFileAppender::new(file_path, condition, max_files)
+        .map_err(|e| anyhow!("Failed to create rolling file appender: {e}"))?;
+
+    let (non_blocking, guard) = tracing_appender::non_blocking(appender);
+    Ok((non_blocking, guard))
+}
+
+/// Migrate legacy `STATELESS_VALIDATOR_LOG_*` env vars to the new `STATELESS_LOG_*` names.
+/// Only copies when the new var is not already set, so the new name always takes precedence.
+///
+/// Must be called **before** `clap::Parser::parse()` so that clap sees the migrated values.
+///
+/// # Safety
+///
+/// This mutates process-global environment state. Call it early in `main()` before
+/// spawning any threads or starting async runtimes.
+pub fn migrate_legacy_env_vars() {
+    const LEGACY_MAP: &[(&str, &str)] = &[
+        ("STATELESS_VALIDATOR_LOG_STDOUT", "STATELESS_LOG_STDOUT"),
+        ("STATELESS_VALIDATOR_LOG_FILE", "STATELESS_LOG_FILE"),
+        ("STATELESS_VALIDATOR_LOG_FILE_DIRECTORY", "STATELESS_LOG_FILE_DIRECTORY"),
+    ];
+    for &(old, new) in LEGACY_MAP {
+        if std::env::var(new).is_err() &&
+            let Ok(val) = std::env::var(old)
+        {
+            // SAFETY: called before any multithreaded runtime is started.
+            unsafe { std::env::set_var(new, val) };
+        }
+    }
+}
+
+impl LogArgs {
+    /// Initialize the global tracing subscriber based on the current configuration.
+    ///
+    /// Returns an `Option<WorkerGuard>` that **must** be held alive in `main()` —
+    /// dropping the guard flushes and closes the file writer. When file logging is
+    /// disabled the returned value is `None`.
+    pub fn init_tracing(&self) -> Result<Option<WorkerGuard>> {
+        let use_color = self.log_color.use_color();
+
+        // Force ANSI off when using JSON on stdout — color codes break JSON parsing.
+        let stdout_ansi = match self.log_stdout_format {
+            LogFormat::Json => false,
+            LogFormat::Terminal => use_color,
+        };
+
+        let stdout_filter = build_env_filter(&self.log_stdout_filter)?;
+
+        let stdout_layer: Box<dyn Layer<_> + Send + Sync> = match self.log_stdout_format {
+            LogFormat::Terminal => tracing_fmt::layer()
+                .with_ansi(stdout_ansi)
+                .with_writer(std::io::stdout)
+                .with_filter(stdout_filter)
+                .boxed(),
+            LogFormat::Json => tracing_fmt::layer()
+                .json()
+                .with_ansi(false)
+                .with_writer(std::io::stdout)
+                .with_filter(stdout_filter)
+                .boxed(),
+        };
+
+        // --- optional file layer ---
+        let (file_layer, guard) = if let Some(ref dir) = self.log_file_directory {
+            let (non_blocking, guard) =
+                build_file_writer(dir, self.log_file_max_size, self.log_file_max_files)?;
+            let file_filter = build_env_filter(&self.log_file_filter)?;
+
+            let layer: Box<dyn Layer<_> + Send + Sync> = match self.log_file_format {
+                LogFormat::Terminal => tracing_fmt::layer()
+                    .with_ansi(false)
+                    .with_writer(non_blocking)
+                    .with_filter(file_filter)
+                    .boxed(),
+                LogFormat::Json => tracing_fmt::layer()
+                    .json()
+                    .with_ansi(false)
+                    .with_writer(non_blocking)
+                    .with_filter(file_filter)
+                    .boxed(),
+            };
+
+            (Some(layer), Some(guard))
+        } else {
+            (None, None)
+        };
+
+        tracing_subscriber::registry().with(stdout_layer).with(file_layer).init();
+
+        match &self.log_file_directory {
+            Some(dir) => info!(
+                stdout_filter = %self.log_stdout_filter,
+                stdout_format = %self.log_stdout_format,
+                file_filter = %self.log_file_filter,
+                file_format = %self.log_file_format,
+                file_directory = %dir.display(),
+                "Logging initialized",
+            ),
+            None => info!(
+                stdout_filter = %self.log_stdout_filter,
+                stdout_format = %self.log_stdout_format,
+                "Logging initialized (file logging disabled)",
+            ),
+        }
+
+        Ok(guard)
+    }
+}


### PR DESCRIPTION
## Summary
- Add `stateless-common` crate with shared `LogArgs` providing configurable stdout/file logging, JSON format support, and rolling file appender
- Migrate `stateless-validator` and `debug-trace-server` to use shared `LogArgs` via `#[command(flatten)]`
- Add backward-compatible env var migration (`STATELESS_VALIDATOR_LOG_*` → `STATELESS_LOG_*`) so existing deployments don't break
- Update CI clippy to run with `--workspace --all-targets --all-features`

## Test plan
- [x] `cargo check --workspace` passes
- [x] `cargo clippy --workspace --all-targets --all-features` passes with no warnings
- [x] Verify `STATELESS_VALIDATOR_LOG_STDOUT=debug` still works without the new env var name
- [x] Verify setting both old and new env vars prefers the new one