### PR TITLE
Refactor `get_witness_from_cloudflare` to decode base64+zstd witness payload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6585,6 +6585,7 @@ dependencies = [
  "alloy-rpc-types-trace",
  "alloy-serde",
  "alloy-trie",
+ "base64",
  "bincode 2.0.1",
  "dyn-clone",
  "eyre",
@@ -6610,6 +6611,7 @@ dependencies = [
  "thiserror 2.0.17",
  "tokio",
  "tracing",
+ "zstd",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ alloy-serde = { version = "1.0.23", default-features = false }
 alloy-trie = { version = "0.9.0", default-features = false }
 
 # misc
+base64 = "0.22"
 bincode = { version = "2.0", features = ["serde"] }
 clap = { version = "4.5", features = ["derive", "env"] }
 dyn-clone = "1.0"
@@ -78,6 +79,7 @@ tokio = { version = "1.46", features = ["rt-multi-thread", "signal"] }
 tracing = "0.1"
 tracing-appender = "0.2"
 tracing-subscriber = { version = "=0.3.20", features = ["fmt", "env-filter", "json"] }
+zstd = "0.13"
 
 [profile.release]
 opt-level = 3

--- a/crates/validator-core/Cargo.toml
+++ b/crates/validator-core/Cargo.toml
@@ -27,6 +27,7 @@ alloy-serde.workspace = true
 alloy-trie.workspace = true
 
 # misc
+base64.workspace = true
 bincode.workspace = true
 dyn-clone.workspace = true
 eyre.workspace = true
@@ -58,6 +59,7 @@ serde_json.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true
+zstd.workspace = true
 
 [features]
 test-bucket-resize = ["salt/test-bucket-resize"]

--- a/crates/validator-core/src/rpc_client.rs
+++ b/crates/validator-core/src/rpc_client.rs
@@ -7,6 +7,7 @@ use std::{collections::HashMap, sync::Arc, time::Instant};
 use alloy_primitives::{B256, Bytes, U64};
 use alloy_provider::{Provider, ProviderBuilder, RootProvider};
 use alloy_rpc_types_eth::{Block, BlockId, BlockNumberOrTag, Header};
+use base64::{Engine, engine::general_purpose::STANDARD as BASE64};
 use eyre::{Context, Result, ensure, eyre};
 use futures::future;
 use op_alloy_network::Optimism;
@@ -446,6 +447,9 @@ impl RpcClient {
     ///
     /// Single attempt, no retry (it's a KV lookup, either it exists or it doesn't).
     /// Returns error if Cloudflare provider is not configured.
+    ///
+    /// The Cloudflare KV endpoint returns a `"v0:<base64_encoded_data>"` string.
+    /// The base64 payload is zstd-compressed, bincode-serialized `(SaltWitness, MptWitness)`.
     pub async fn get_witness_from_cloudflare(
         &self,
         number: u64,
@@ -458,7 +462,7 @@ impl RpcClient {
 
         let start = Instant::now();
         let keys = WitnessRequestKeys { block_number: U64::from(number), block_hash: hash };
-        let result: Result<(SaltWitness, MptWitness)> = provider
+        let result: Result<String> = provider
             .client()
             .request("mega_getBlockWitness", (keys,))
             .await
@@ -474,7 +478,27 @@ impl RpcClient {
             trace!(block_number = number, %hash, error = %e, "Cloudflare worker mega_getBlockWitness failed");
         }
 
-        result
+        let encoded = result?;
+
+        let decode_start = Instant::now();
+        let (salt_witness, mpt_witness) =
+            tokio::task::spawn_blocking(move || -> Result<(SaltWitness, MptWitness)> {
+                let b64_data = encoded
+                    .strip_prefix("v0:")
+                    .ok_or_else(|| eyre!("Cloudflare witness missing 'v0:' prefix"))?;
+                let compressed = BASE64.decode(b64_data).context("base64 decode failed")?;
+                let decompressed =
+                    zstd::decode_all(compressed.as_slice()).context("zstd decompress failed")?;
+                let (witness, _): ((SaltWitness, MptWitness), _) =
+                    bincode::serde::decode_from_slice(&decompressed, bincode::config::legacy())
+                        .context("bincode deserialize failed")?;
+                Ok(witness)
+            })
+            .await
+            .context("decode task panicked")??;
+        trace!(block_number = number, %hash, decode_ms = decode_start.elapsed().as_millis(), "Cloudflare witness decoded");
+
+        Ok((salt_witness, mpt_witness))
     }
 
     /// Reports a range of validated blocks via the dedicated report endpoint.


### PR DESCRIPTION
## Summary

- Refactors `get_witness_from_cloudflare` to handle the updated Cloudflare KV response format, which now returns a `"v0:<base64_encoded_data>"` string instead of a directly deserialized tuple.
- The base64 payload is zstd-compressed, bincode-serialized `(SaltWitness, MptWitness)`. The decoding pipeline: strip `v0:` prefix -> base64 decode -> zstd decompress -> bincode deserialize.
- The CPU-intensive decode work is offloaded to `spawn_blocking` to avoid blocking the async runtime.
- Adds `base64` (v0.22) and `zstd` (v0.13) as new dependencies.

## Changes

- **`crates/validator-core/src/rpc_client.rs`**: Updated `get_witness_from_cloudflare` to receive a raw `String` from the RPC call, then decode it through base64 -> zstd -> bincode in a blocking task. Added trace logging for decode duration.
- **`Cargo.toml` / `crates/validator-core/Cargo.toml`**: Added `base64` and `zstd` workspace dependencies.

## Test plan

- [x] Verify `get_witness_from_cloudflare` correctly decodes a `v0:`-prefixed, base64-encoded, zstd-compressed witness payload.
- [x] cargo test