### PR TITLE
chore: upgrade mega-evm to v1.4.0 to support Rex3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3459,8 +3459,8 @@ dependencies = [
 
 [[package]]
 name = "mega-evm"
-version = "1.3.2"
-source = "git+https://github.com/megaeth-labs/mega-evm.git?rev=v1.3.2#2178906e35b085ffd2e96aa9895a423c1ca57255"
+version = "1.4.0"
+source = "git+https://github.com/megaeth-labs/mega-evm.git?rev=v1.4.0#be77c9aeb3b4f5da0c58ca2c09e78a0684117269"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3486,8 +3486,8 @@ dependencies = [
 
 [[package]]
 name = "mega-system-contracts"
-version = "1.3.2"
-source = "git+https://github.com/megaeth-labs/mega-evm.git?rev=v1.3.2#2178906e35b085ffd2e96aa9895a423c1ca57255"
+version = "1.4.0"
+source = "git+https://github.com/megaeth-labs/mega-evm.git?rev=v1.4.0#be77c9aeb3b4f5da0c58ca2c09e78a0684117269"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ futures = "0.3"
 lz4_flex = { version = "0.11", default-features = false }
 
 # megaeth 
-mega-evm = { git = "https://github.com/megaeth-labs/mega-evm.git", rev = "v1.3.2" }
+mega-evm = { git = "https://github.com/megaeth-labs/mega-evm.git", rev = "v1.4.0" }
 metrics = "0.24"
 metrics-derive = "0.1"
 metrics-exporter-prometheus = { version = "0.18", default-features = false, features = ["http-listener"] }

--- a/crates/validator-core/src/chain_spec.rs
+++ b/crates/validator-core/src/chain_spec.rs
@@ -107,6 +107,8 @@ pub struct MegaethGenesisHardforks {
     pub rex_1_time: Option<u64>,
     /// Rex2 hardfork timestamp.
     pub rex_2_time: Option<u64>,
+    /// Rex3 hardfork timestamp.
+    pub rex_3_time: Option<u64>,
 }
 
 impl MegaethGenesisHardforks {
@@ -124,6 +126,7 @@ impl MegaethGenesisHardforks {
             (MegaHardfork::Rex.boxed(), self.rex_time.map(ForkCondition::Timestamp)),
             (MegaHardfork::Rex1.boxed(), self.rex_1_time.map(ForkCondition::Timestamp)),
             (MegaHardfork::Rex2.boxed(), self.rex_2_time.map(ForkCondition::Timestamp)),
+            (MegaHardfork::Rex3.boxed(), self.rex_3_time.map(ForkCondition::Timestamp)),
         ]
         .into_iter()
         .filter_map(|(hardfork, condition)| condition.map(|c| (hardfork, c)))
@@ -141,6 +144,7 @@ pub static MEGA_MAINNET_HARDFORKS: std::sync::LazyLock<ChainHardforks> =
             (MegaHardfork::Rex.boxed(), ForkCondition::Timestamp(0)),
             (MegaHardfork::Rex1.boxed(), ForkCondition::Timestamp(0)),
             (MegaHardfork::Rex2.boxed(), ForkCondition::Timestamp(0)),
+            (MegaHardfork::Rex3.boxed(), ForkCondition::Timestamp(0)),
         ])
     });
 
@@ -191,7 +195,8 @@ mod tests {
           "miniRex2Time": 3,
           "rexTime": 4,
           "rex1Time": 5,
-          "rex2Time": 6
+          "rex2Time": 6,
+          "rex3Time": 7
         }
         "#;
         let fields = serde_json::from_str::<OtherFields>(genesis_info).unwrap();
@@ -202,5 +207,6 @@ mod tests {
         assert_eq!(hardforks.rex_time, Some(4));
         assert_eq!(hardforks.rex_1_time, Some(5));
         assert_eq!(hardforks.rex_2_time, Some(6));
+        assert_eq!(hardforks.rex_3_time, Some(7));
     }
 }


### PR DESCRIPTION
related: 
mega-reth:
https://github.com/megaeth-labs/mega-reth/pull/1476
support Rex2:
https://github.com/megaeth-labs/stateless-validator/pull/68/