### PR TITLE
chore: Bump version to v2.0.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5901,7 +5901,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stateless-common"
-version = "2.0.6"
+version = "2.0.7"
 dependencies = [
  "clap",
  "eyre",
@@ -5913,7 +5913,7 @@ dependencies = [
 
 [[package]]
 name = "stateless-validator"
-version = "2.0.6"
+version = "2.0.7"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -6572,7 +6572,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "validator-core"
-version = "2.0.6"
+version = "2.0.7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.0.6"
+version = "2.0.7"
 edition = "2024"
 rust-version = "1.95"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
  Bump workspace version from 2.0.6 to 2.0.7 across all crates:
  - stateless-common
  - stateless-validator
  - validator-core
  
  **Note**: debug-trace-server still use version 0.1.0