### PR TITLE
feat: make database module public in validator-core

### DIFF
--- a/crates/validator-core/src/lib.rs
+++ b/crates/validator-core/src/lib.rs
@@ -23,7 +23,7 @@ pub use chain_sync::{
     ChainSyncConfig, DEFAULT_METRICS_PORT, FetchResult, fetch_blocks_batch, remote_chain_tracker,
 };
 pub use light_witness::{LightWitness, LightWitnessExecutor};
-mod database;
+pub mod database;
 pub mod validator_db;
 pub use validator_db::{ValidationDbError, ValidationDbResult, ValidatorDB};
 pub mod data_types;

--- a/crates/validator-core/src/lib.rs
+++ b/crates/validator-core/src/lib.rs
@@ -24,6 +24,7 @@ pub use chain_sync::{
 };
 pub use light_witness::{LightWitness, LightWitnessExecutor};
 pub mod database;
+pub use database::{WitnessDatabase, WitnessDatabaseError, WitnessExternalEnv};
 pub mod validator_db;
 pub use validator_db::{ValidationDbError, ValidationDbResult, ValidatorDB};
 pub mod data_types;


### PR DESCRIPTION
## Summary

Make the `database` module in `validator-core` public so downstream crates can use `WitnessDatabase` and `WitnessExternalEnv` directly for witness-backed EVM re-execution with their own executor (e.g., indexers, tracing services).

## Changes

- `crates/validator-core/src/lib.rs` line 26: `mod database` → `pub mod database`
- `crates/validator-core/src/lib.rs` line 27: add `pub use database::{WitnessDatabase, WitnessDatabaseError, WitnessExternalEnv};`