### PR TITLE
feat: unified get witness rpc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5918,6 +5918,7 @@ dependencies = [
  "alloy-genesis",
  "alloy-primitives",
  "alloy-rpc-types-eth",
+ "base64",
  "bincode 2.0.1",
  "clap",
  "eyre",
@@ -5938,6 +5939,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber 0.3.20",
  "validator-core",
+ "zstd",
 ]
 
 [[package]]

--- a/bin/debug-trace-server/src/data_provider.rs
+++ b/bin/debug-trace-server/src/data_provider.rs
@@ -98,10 +98,6 @@ impl DataProvider {
         validator_db: Option<Arc<ValidatorDB>>,
         witness_timeout_secs: u64,
     ) -> Self {
-        if rpc_client.has_cloudflare_provider() {
-            debug!("Cloudflare witness fallback enabled via RpcClient");
-        }
-
         Self {
             rpc_client,
             validator_db,
@@ -444,40 +440,6 @@ impl DataProvider {
         Ok(BlockData { block, witness, contracts })
     }
 
-    /// Fetches witness data from Cloudflare KV via RpcClient.
-    ///
-    /// Single attempt, no retry (it's a KV lookup, either it exists or it doesn't).
-    async fn get_witness_from_cloudflare(
-        &self,
-        block_number: u64,
-        block_hash: B256,
-    ) -> Result<(SaltWitness, MptWitness)> {
-        let cf_metrics = WitnessSourceMetrics::new_for_source("cloudflare");
-        let start = std::time::Instant::now();
-        match self.rpc_client.get_witness_from_cloudflare(block_number, block_hash).await {
-            Ok(result) => {
-                cf_metrics.record_request(true, start.elapsed().as_secs_f64());
-                cf_metrics.record_size(estimate_witness_size(&result.0, &result.1));
-                trace!(
-                    block_number,
-                    block_hash = %block_hash,
-                    "Witness fetched from Cloudflare"
-                );
-                Ok(result)
-            }
-            Err(e) => {
-                cf_metrics.record_request(false, start.elapsed().as_secs_f64());
-                warn!(
-                    block_number,
-                    block_hash = %block_hash,
-                    error = %e,
-                    "Cloudflare witness fetch failed"
-                );
-                Err(e)
-            }
-        }
-    }
-
     /// Fetches witness data with height-based routing and fallback.
     ///
     /// Routing logic:
@@ -521,20 +483,7 @@ impl DataProvider {
                 }
                 Err(e) => {
                     wg_metrics.record_request(false, start.elapsed().as_secs_f64());
-                    // Timeout reached, try Cloudflare fallback
-                    if self.rpc_client.has_cloudflare_provider() {
-                        trace!(
-                            block_number,
-                            %e,
-                            "Witness endpoint timeout, falling back to Cloudflare"
-                        );
-                        let result =
-                            self.get_witness_from_cloudflare(block_number, block_hash).await?;
-                        DataSourceMetrics::new_for_source("cloudflare").record();
-                        Ok(result)
-                    } else {
-                        Err(e)
-                    }
+                    Err(e)
                 }
             }
         } else {
@@ -553,23 +502,9 @@ impl DataProvider {
                     DataSourceMetrics::new_for_source("witness_generator").record();
                     Ok(result)
                 }
-                Err(e) => {
+                Err(_) => {
                     wg_metrics.record_request(false, start.elapsed().as_secs_f64());
-                    // Single attempt failed, try Cloudflare fallback
-                    if self.rpc_client.has_cloudflare_provider() {
-                        trace!(
-                            block_number,
-                            %e,
-                            "Witness endpoint failed, falling back to Cloudflare"
-                        );
-                        let result =
-                            self.get_witness_from_cloudflare(block_number, block_hash).await?;
-                        DataSourceMetrics::new_for_source("cloudflare").record();
-                        Ok(result)
-                    } else {
-                        // No Cloudflare configured and witness fetch failed
-                        Err(eyre::eyre!("Block witness not found for block {}", block_number))
-                    }
+                    Err(eyre::eyre!("Block witness not found for block {}", block_number))
                 }
             }
         }

--- a/bin/debug-trace-server/src/main.rs
+++ b/bin/debug-trace-server/src/main.rs
@@ -253,7 +253,6 @@ async fn main() -> Result<()> {
         &args.rpc_endpoint,
         &args.witness_endpoint,
         RpcClientConfig::trace_server(),
-        args.cloudflare_witness_endpoint.as_deref(),
         None,
     )?);
     let validator_db = init_validator_db(&args, &rpc_client).await?;

--- a/bin/stateless-validator/Cargo.toml
+++ b/bin/stateless-validator/Cargo.toml
@@ -42,10 +42,12 @@ tracing.workspace = true
 validator-core = { path = "../../crates/validator-core" }
 
 [dev-dependencies]
+base64.workspace = true
 jsonrpsee = { version = "0.26", features = ["server", "macros"] }
 jsonrpsee-types = { version = "0.26" }
 tempfile = "3.8"
 tracing-subscriber.workspace = true
+zstd.workspace = true
 
 [features]
 test-bucket-resize = ["salt/test-bucket-resize", "validator-core/test-bucket-resize"]

--- a/bin/stateless-validator/src/main.rs
+++ b/bin/stateless-validator/src/main.rs
@@ -709,6 +709,7 @@ mod tests {
 
     use alloy_primitives::{BlockHash, BlockNumber};
     use alloy_rpc_types_eth::Block;
+    use base64::{Engine, engine::general_purpose::STANDARD as BASE64};
     use eyre::Context;
     use jsonrpsee::{
         RpcModule,
@@ -720,7 +721,7 @@ mod tests {
     use op_alloy_rpc_types::Transaction;
     use serde::{Deserialize, Serialize, de::DeserializeOwned};
     use tracing_subscriber::EnvFilter;
-    use validator_core::withdrawals::MptWitness;
+    use validator_core::{rpc_client::WitnessRequestKeys, withdrawals::MptWitness};
 
     use super::*;
 
@@ -948,15 +949,11 @@ mod tests {
 
         module
             .register_method("mega_getBlockWitness", |params, context, _| {
-                // Parse two string parameters: block number (hex) and block hash
-                let (_block_number_hex, block_hash_hex): (String, String) =
-                    params.parse().map_err(|e| {
-                        make_rpc_error(INVALID_PARAMS_CODE, format!("Invalid params: {e}"))
-                    })?;
-
-                let block_hash = parse_block_hash(&block_hash_hex).map_err(|e| {
-                    make_rpc_error(INVALID_PARAMS_CODE, format!("Invalid block hash: {e}"))
+                // Parse the worker-compatible request object.
+                let (keys,): (WitnessRequestKeys,) = params.parse().map_err(|e| {
+                    make_rpc_error(INVALID_PARAMS_CODE, format!("Invalid params: {e}"))
                 })?;
+                let block_hash = BlockHash::from(keys.block_hash.0);
 
                 // Look up witness data by block hash
                 let salt_witness =
@@ -975,7 +972,27 @@ mod tests {
                         )
                     })?;
 
-                Ok::<_, ErrorObject<'static>>((salt_witness, mpt_witness))
+                let encoded = bincode::serde::encode_to_vec(
+                    &(salt_witness, mpt_witness),
+                    bincode::config::legacy(),
+                )
+                .map_err(|e| {
+                    make_rpc_error(
+                        CALL_EXECUTION_FAILED_CODE,
+                        format!("Failed to serialize witness for block {block_hash}: {e}"),
+                    )
+                })
+                .and_then(|raw| {
+                    zstd::encode_all(raw.as_slice(), 9).map_err(|e| {
+                        make_rpc_error(
+                            CALL_EXECUTION_FAILED_CODE,
+                            format!("Failed to compress witness for block {block_hash}: {e}"),
+                        )
+                    })
+                })
+                .map(|compressed| format!("v0:{}", BASE64.encode(compressed)))?;
+
+                Ok::<_, ErrorObject<'static>>(encoded)
             })
             .unwrap();
 

--- a/bin/stateless-validator/src/main.rs
+++ b/bin/stateless-validator/src/main.rs
@@ -161,7 +161,6 @@ async fn run(args: CommandLineArgs) -> Result<()> {
         &args.rpc_endpoint,
         &args.witness_endpoint,
         rpc_config,
-        None, // No Cloudflare fallback for validator
         args.report_validation_endpoint.as_deref(),
     )?);
     let validator_db = Arc::new(ValidatorDB::new(work_dir.join(VALIDATOR_DB_FILENAME))?);

--- a/crates/validator-core/src/rpc_client.rs
+++ b/crates/validator-core/src/rpc_client.rs
@@ -144,8 +144,6 @@ pub struct RpcClient {
     pub data_provider: RootProvider<Optimism>,
     /// Witness provider for fetching SALT witness data.
     pub witness_provider: RootProvider,
-    /// Optional Cloudflare witness provider for pruned/archived blocks.
-    cloudflare_witness_provider: Option<RootProvider>,
     /// Optional dedicated provider for reporting validated blocks.
     report_provider: Option<RootProvider<Optimism>>,
     /// Configuration controlling verification behavior
@@ -159,7 +157,7 @@ impl RpcClient {
     /// * `data_api` - HTTP URL of the standard JSON-RPC endpoint for blocks and contract data
     /// * `witness_api` - HTTP URL of the witness RPC endpoint for SALT witness data
     pub fn new(data_api: &str, witness_api: &str) -> Result<Self> {
-        Self::new_with_config(data_api, witness_api, RpcClientConfig::default(), None, None)
+        Self::new_with_config(data_api, witness_api, RpcClientConfig::default(), None)
     }
 
     /// Creates a new RPC client with custom configuration.
@@ -174,17 +172,8 @@ impl RpcClient {
         data_api: &str,
         witness_api: &str,
         config: RpcClientConfig,
-        cloudflare_witness_api: Option<&str>,
         report_api: Option<&str>,
     ) -> Result<Self> {
-        let cloudflare_witness_provider = cloudflare_witness_api
-            .map(|url| -> Result<RootProvider> {
-                Ok(ProviderBuilder::default().connect_http(
-                    url.parse().context("Failed to parse Cloudflare witness API URL")?,
-                ))
-            })
-            .transpose()?;
-
         let report_provider = report_api
             .map(|url| -> Result<RootProvider<Optimism>> {
                 Ok(ProviderBuilder::<_, _, Optimism>::default()
@@ -197,7 +186,6 @@ impl RpcClient {
                 .connect_http(data_api.parse().context("Failed to parse API URL")?),
             witness_provider: ProviderBuilder::default()
                 .connect_http(witness_api.parse().context("Failed to parse API URL")?),
-            cloudflare_witness_provider,
             report_provider,
             config,
         })
@@ -395,78 +383,13 @@ impl RpcClient {
     /// Gets execution witness data for a specific block.
     pub async fn get_witness(&self, number: u64, hash: B256) -> Result<(SaltWitness, MptWitness)> {
         let start = Instant::now();
-        // Format as hex strings - witness endpoint expects two string parameters
-        let block_number_hex = format!("0x{:x}", number);
-        let block_hash_hex = format!("{}", hash);
-        let result: Result<(SaltWitness, MptWitness)> = self
-            .witness_provider
-            .client()
-            .request("mega_getBlockWitness", (block_number_hex, block_hash_hex))
-            .await
-            .map_err(|e| eyre!("Failed to get witness for block {hash}: {e}"));
-
-        self.record_rpc(
-            RpcMethod::MegaGetBlockWitness,
-            result.is_ok(),
-            Some(start.elapsed().as_secs_f64()),
-        );
-
-        if let Err(ref e) = result {
-            trace!(block_number = number, %hash, error = %e, "Witness generator mega_getBlockWitness failed");
-        }
-
-        if let Ok((ref witness, ref mpt_witness)) = result &&
-            let Some(ref metrics) = self.config.metrics
-        {
-            // Estimate sizes without full serialization (approximate but efficient)
-            // SaltKey (8 bytes) + Option<SaltValue> (1 + 94 bytes) ≈ 103 bytes per entry
-            let kvs_count = witness.kvs.len();
-            let salt_kvs_size = kvs_count * 103;
-
-            // Proof: commitments (64 bytes each) + IPA proof (~576 bytes) + levels (5 bytes
-            // each)
-            let proof_size =
-                witness.proof.parents_commitments.len() * 64 + 576 + witness.proof.levels.len() * 5;
-            let salt_size = salt_kvs_size + proof_size;
-
-            // MptWitness: storage_root (32 bytes) + sum of state bytes
-            let mpt_size = 32 + mpt_witness.state.iter().map(|b| b.len()).sum::<usize>();
-
-            metrics.on_witness_fetch(salt_size, kvs_count, salt_kvs_size, mpt_size);
-        }
-
-        result
-    }
-
-    /// Returns whether a Cloudflare witness provider is configured.
-    pub fn has_cloudflare_provider(&self) -> bool {
-        self.cloudflare_witness_provider.is_some()
-    }
-
-    /// Gets execution witness data from the Cloudflare fallback endpoint.
-    ///
-    /// Single attempt, no retry (it's a KV lookup, either it exists or it doesn't).
-    /// Returns error if Cloudflare provider is not configured.
-    ///
-    /// The Cloudflare KV endpoint returns a `"v0:<base64_encoded_data>"` string.
-    /// The base64 payload is zstd-compressed, bincode-serialized `(SaltWitness, MptWitness)`.
-    pub async fn get_witness_from_cloudflare(
-        &self,
-        number: u64,
-        hash: B256,
-    ) -> Result<(SaltWitness, MptWitness)> {
-        let provider = self
-            .cloudflare_witness_provider
-            .as_ref()
-            .ok_or_else(|| eyre!("Cloudflare witness provider not configured"))?;
-
-        let start = Instant::now();
         let keys = WitnessRequestKeys { block_number: U64::from(number), block_hash: hash };
-        let result: Result<String> = provider
+        let result: Result<String> = self
+            .witness_provider
             .client()
             .request("mega_getBlockWitness", (keys,))
             .await
-            .map_err(|e| eyre!("Cloudflare witness fetch failed for block {}: {}", number, e));
+            .map_err(|e| eyre!("Witness fetch failed for block {}: {}", number, e));
 
         self.record_rpc(
             RpcMethod::MegaGetBlockWitness,
@@ -475,7 +398,7 @@ impl RpcClient {
         );
 
         if let Err(ref e) = result {
-            trace!(block_number = number, %hash, error = %e, "Cloudflare worker mega_getBlockWitness failed");
+            trace!(block_number = number, %hash, error = %e, "Worker mega_getBlockWitness failed");
         }
 
         let encoded = result?;
@@ -485,7 +408,7 @@ impl RpcClient {
             tokio::task::spawn_blocking(move || -> Result<(SaltWitness, MptWitness)> {
                 let b64_data = encoded
                     .strip_prefix("v0:")
-                    .ok_or_else(|| eyre!("Cloudflare witness missing 'v0:' prefix"))?;
+                    .ok_or_else(|| eyre!("Witness missing 'v0:' prefix"))?;
                 let compressed = BASE64.decode(b64_data).context("base64 decode failed")?;
                 let decompressed =
                     zstd::decode_all(compressed.as_slice()).context("zstd decompress failed")?;
@@ -619,46 +542,11 @@ mod tests {
     }
 
     #[test]
-    fn test_new_with_valid_url() {
-        let result = RpcClient::new("http://localhost:8545", "http://localhost:8546");
-        assert!(result.is_ok());
-        let client = result.unwrap();
-        assert!(!client.has_cloudflare_provider());
-    }
-
-    #[test]
-    fn test_new_with_cloudflare_provider() {
-        let result = RpcClient::new_with_config(
-            "http://localhost:8545",
-            "http://localhost:8546",
-            RpcClientConfig::default(),
-            Some("http://localhost:9546"),
-            None,
-        );
-        assert!(result.is_ok());
-        let client = result.unwrap();
-        assert!(client.has_cloudflare_provider());
-    }
-
-    #[test]
-    fn test_new_with_invalid_cloudflare_url() {
-        let result = RpcClient::new_with_config(
-            "http://localhost:8545",
-            "http://localhost:8546",
-            RpcClientConfig::default(),
-            Some("not a url"),
-            None,
-        );
-        assert!(result.is_err());
-    }
-
-    #[test]
     fn test_skip_block_verification() {
         let client = RpcClient::new_with_config(
             "http://localhost:8545",
             "http://localhost:8546",
             RpcClientConfig::validator(),
-            None,
             None,
         )
         .unwrap();
@@ -668,7 +556,6 @@ mod tests {
             "http://localhost:8545",
             "http://localhost:8546",
             RpcClientConfig::trace_server(),
-            None,
             None,
         )
         .unwrap();

--- a/crates/validator-core/src/rpc_client.rs
+++ b/crates/validator-core/src/rpc_client.rs
@@ -419,7 +419,26 @@ impl RpcClient {
             })
             .await
             .context("decode task panicked")??;
-        trace!(block_number = number, %hash, decode_ms = decode_start.elapsed().as_millis(), "Cloudflare witness decoded");
+        trace!(block_number = number, %hash, decode_ms = decode_start.elapsed().as_millis(), "Witness decoded");
+
+        if let Some(ref metrics) = self.config.metrics {
+            // Estimate sizes without full serialization (approximate but efficient)
+            // SaltKey (8 bytes) + Option<SaltValue> (1 + 94 bytes) ≈ 103 bytes per entry
+            let kvs_count = salt_witness.kvs.len();
+            let salt_kvs_size = kvs_count * 103;
+
+            // Proof: commitments (64 bytes each) + IPA proof (~576 bytes) + levels (5 bytes
+            // each)
+            let proof_size = salt_witness.proof.parents_commitments.len() * 64 +
+                576 +
+                salt_witness.proof.levels.len() * 5;
+            let salt_size = salt_kvs_size + proof_size;
+
+            // MptWitness: storage_root (32 bytes) + sum of state bytes
+            let mpt_size = 32 + mpt_witness.state.iter().map(|b| b.len()).sum::<usize>();
+
+            metrics.on_witness_fetch(salt_size, kvs_count, salt_kvs_size, mpt_size);
+        }
 
         Ok((salt_witness, mpt_witness))
     }


### PR DESCRIPTION
## Summary

This PR unifies the witness data fetching mechanism by consolidating the RPC interface and removing the Cloudflare KV fallback logic.

## Changes

### RPC Client Simplification
- **Removed Cloudflare fallback provider**: Eliminated the optional  from 
- **Unified witness endpoint**: All witness requests now go through a single  RPC method
- **Simplified API**: Removed  parameter from 
- **Removed redundant method**: Deleted  as it's no longer needed

### Data Provider Cleanup
- **Removed fallback logic**: Eliminated Cloudflare fallback attempts in 
- **Simplified error handling**: Direct error propagation without fallback attempts
- **Removed helper method**: Deleted  from DataProvider

### Binary Updates
- Updated  and  to use the simplified RpcClient API
- Removed Cloudflare endpoint configuration from command-line arguments

## Impact

- **Code reduction**: Removed ~180 lines of fallback logic and related code
- **Simplified architecture**: Single source of truth for witness data
- **Cleaner error handling**: No more complex fallback chains
- **Maintained functionality**: Core witness fetching remains intact through the unified endpoint

## Testing

- Existing unit tests updated to reflect the simplified API
- Removed tests specific to Cloudflare provider configuration