### PR TITLE
ci: add review thread resolution to Claude PR review

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -77,7 +77,7 @@ jobs:
           additional_permissions: |
             actions: read
           claude_args: |
-            --allowedTools "Read,Glob,Grep,mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr checks:*),Bash(gh label list:*),Bash(gh run view:*),Bash(gh run list:*),Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git blame:*),Bash(git status:*),Bash(ls:*),Bash(tree:*)"
+            --allowedTools "Read,Glob,Grep,mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr checks:*),Bash(gh label list:*),Bash(gh run view:*),Bash(gh run list:*),Bash(gh api:*),Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git blame:*),Bash(git status:*),Bash(ls:*),Bash(tree:*)"
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -19,6 +19,15 @@
 - No high-cardinality labels (no tx hashes or addresses as label values)
 - Prometheus naming conventions: `snake_case` with unit suffixes (`_seconds`, `_bytes`, `_total`)
 
+## Previous comments
+
+- Before writing new comments, check all previous review threads on this PR
+- If a previous comment has been addressed by the latest changes, resolve that thread using:
+  `gh api graphql -f query='mutation { resolveReviewThread(input:{threadId:"THREAD_ID"}) { thread { id } } }'`
+- To find thread IDs, query:
+  `gh api graphql -f query='{ repository(owner:"OWNER", name:"REPO") { pullRequest(number:NUMBER) { reviewThreads(first:50) { nodes { id isResolved comments(first:1) { nodes { body path } } } } } } }'`
+- Do not repeat feedback that has already been addressed
+
 ## Skip
 
 - Formatting-only changes already enforced by `cargo fmt`


### PR DESCRIPTION
## Summary

- Add thread resolution logic to the Claude `pr-review` CI job so it resolves previously addressed review threads instead of repeating stale feedback
- Move the thread resolution instructions into `REVIEW.md` (single source of truth) rather than inlining them in the YAML prompt
- Add `Bash(gh api:*)` to the pr-review allowedTools for GraphQL thread resolution mutations