### PR TITLE
perf: remove unnecessary clone in transaction execution loop

### DIFF
--- a/crates/stateless-core/src/executor.rs
+++ b/crates/stateless-core/src/executor.rs
@@ -601,4 +601,38 @@ mod tests {
             .unwrap_or_else(|e| panic!("validate_block failed for {number} ({hash}): {e:?}"));
         }
     }
+
+    /// Verifies that `replay_block` (which exercises `execute_transactions`) produces
+    /// receipts root, logs bloom, and gas used that match the block header.
+    #[test]
+    fn replay_block_output_matches_header() {
+        let fx = TestFixtures::mainnet();
+        let chain_spec = ChainSpec::from_genesis(fx.load_genesis().unwrap());
+        let paired = fx.paired_blocks();
+        let (_num, hash) = paired.first().expect("no paired mainnet fixtures");
+
+        let block = &fx.blocks[hash];
+        let salt_witness = fx.salt_witnesses[hash].clone();
+
+        let ext_env = WitnessExternalEnv::new(&salt_witness, block.header.number).unwrap();
+        let witness = salt::Witness::from(salt_witness);
+        witness.verify().unwrap();
+
+        let witness_db =
+            WitnessDatabase { header: &block.header, witness: &witness, contracts: &fx.contracts };
+
+        let (_accounts, output) = replay_block(
+            &chain_spec,
+            block,
+            &witness_db,
+            ext_env,
+            #[cfg(feature = "std")]
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(output.receipts_root, block.header.receipts_root, "receipts root mismatch");
+        assert_eq!(output.logs_bloom, block.header.logs_bloom, "logs bloom mismatch");
+        assert_eq!(output.gas_used, block.header.gas_used, "gas used mismatch");
+    }
 }

--- a/crates/stateless-core/src/executor.rs
+++ b/crates/stateless-core/src/executor.rs
@@ -357,16 +357,15 @@ fn execute_transactions<E, T>(
 where
     E: BlockExecutor<Transaction = T>,
     E::Receipt: Encodable2718 + TxReceipt,
-    T: Clone,
     OpTransaction<T>: TransactionResponse,
     for<'a> Recovered<&'a T>: ExecutableTx<E>,
 {
     executor.apply_pre_execution_changes().map_err(ValidationError::BlockReplayFailed)?;
 
     for tx in transactions {
-        let tx_envelope = tx.inner.clone().into_inner();
-        let recovered_tx = Recovered::new_unchecked(&tx_envelope, tx.from());
-        executor.execute_transaction(recovered_tx).map_err(ValidationError::BlockReplayFailed)?;
+        executor
+            .execute_transaction(tx.inner.inner.as_recovered_ref())
+            .map_err(ValidationError::BlockReplayFailed)?;
     }
 
     let execution_result =

--- a/crates/stateless-core/src/executor.rs
+++ b/crates/stateless-core/src/executor.rs
@@ -601,38 +601,4 @@ mod tests {
             .unwrap_or_else(|e| panic!("validate_block failed for {number} ({hash}): {e:?}"));
         }
     }
-
-    /// Verifies that `replay_block` (which exercises `execute_transactions`) produces
-    /// receipts root, logs bloom, and gas used that match the block header.
-    #[test]
-    fn replay_block_output_matches_header() {
-        let fx = TestFixtures::mainnet();
-        let chain_spec = ChainSpec::from_genesis(fx.load_genesis().unwrap());
-        let paired = fx.paired_blocks();
-        let (_num, hash) = paired.first().expect("no paired mainnet fixtures");
-
-        let block = &fx.blocks[hash];
-        let salt_witness = fx.salt_witnesses[hash].clone();
-
-        let ext_env = WitnessExternalEnv::new(&salt_witness, block.header.number).unwrap();
-        let witness = salt::Witness::from(salt_witness);
-        witness.verify().unwrap();
-
-        let witness_db =
-            WitnessDatabase { header: &block.header, witness: &witness, contracts: &fx.contracts };
-
-        let (_accounts, output) = replay_block(
-            &chain_spec,
-            block,
-            &witness_db,
-            ext_env,
-            #[cfg(feature = "std")]
-            None,
-        )
-        .unwrap();
-
-        assert_eq!(output.receipts_root, block.header.receipts_root, "receipts root mismatch");
-        assert_eq!(output.logs_bloom, block.header.logs_bloom, "logs bloom mismatch");
-        assert_eq!(output.gas_used, block.header.gas_used, "gas used mismatch");
-    }
 }


### PR DESCRIPTION
## Summary                                                                                              
                                                                                                          
  `execute_transactions` previously called `tx.inner.clone().into_inner()` on every                       
  transaction to obtain an owned `T`, solely to take a reference `&T` from it.                            
  This resulted in a heap allocation and full copy of the transaction data on every                       
  iteration of the hot execution loop, with the allocation being immediately discarded                    
  at the end of each loop body.
                                                                                                          
  The fix replaces this with `tx.inner.inner.as_recovered_ref()`, which converts
  `&Recovered<T>` to `Recovered<&T>` in-place by wrapping a pointer to the existing                       
  data.                                                     
  No allocation or copy is performed.                                                                     
   
  The `T: Clone` bound on `execute_transactions` is also removed, as it existed                           
  solely to support the now-removed clone.                  

  **Note:** The tracing executor (`tracing_executor.rs`) already accessed transaction                     
  data without cloning — this change brings `execute_transactions` in line with that
  existing pattern.                                                                                       
                                           