### PR TITLE
perf: stack-allocate PlainKey encoding in hot EVM state read path

### DIFF
--- a/crates/stateless-core/src/data_types.rs
+++ b/crates/stateless-core/src/data_types.rs
@@ -71,6 +71,19 @@ impl PlainKey {
         }
     }
 
+    /// Encodes an account address into a stack-allocated 20-byte array.
+    pub fn encode_account(addr: Address) -> [u8; ACCOUNT_ADDRESS_LEN] {
+        addr.into_array()
+    }
+
+    /// Encodes an address + storage slot into a stack-allocated 52-byte array.
+    pub fn encode_storage(addr: Address, slot: B256) -> [u8; STORAGE_SLOT_KEY_LEN] {
+        let mut buf = [0u8; STORAGE_SLOT_KEY_LEN];
+        buf[..ACCOUNT_ADDRESS_LEN].copy_from_slice(addr.as_slice());
+        buf[ACCOUNT_ADDRESS_LEN..].copy_from_slice(slot.as_slice());
+        buf
+    }
+
     /// Decodes a byte slice into a PlainKey.
     ///
     /// Returns `PlainKey::Unknown` if the buffer length is neither 20 (account)

--- a/crates/stateless-core/src/database.rs
+++ b/crates/stateless-core/src/database.rs
@@ -94,7 +94,7 @@ where
     fn basic_ref(&self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
         trace!(?address, "basic_ref");
 
-        let raw_value = self.plain_value(&PlainKey::Account(address).encode())?;
+        let raw_value = self.plain_value(&PlainKey::encode_account(address))?;
 
         match raw_value.and_then(|v| match PlainValue::decode(&v) {
             PlainValue::Account(acc) => Some(acc),
@@ -130,7 +130,7 @@ where
     fn storage_ref(&self, address: Address, index: U256) -> Result<U256, Self::Error> {
         trace!(?address, index = %format_args!("{:#x}", index), "storage_ref");
 
-        let raw_value = self.plain_value(&PlainKey::Storage(address, index.into()).encode())?;
+        let raw_value = self.plain_value(&PlainKey::encode_storage(address, index.into()))?;
 
         Ok(raw_value
             .and_then(|v| match PlainValue::decode(&v) {
@@ -292,11 +292,11 @@ impl SaltEnv for WitnessExternalEnv {
     }
 
     fn bucket_id_for_account(account: Address) -> BucketId {
-        hasher::bucket_id(&PlainKey::Account(account).encode())
+        hasher::bucket_id(&PlainKey::encode_account(account))
     }
 
     fn bucket_id_for_slot(address: Address, key: U256) -> BucketId {
-        hasher::bucket_id(&PlainKey::Storage(address, key.into()).encode())
+        hasher::bucket_id(&PlainKey::encode_storage(address, key.into()))
     }
 }
 


### PR DESCRIPTION
## Summary
### Stack-allocate PlainKey encoding in hot EVM state read path
                                                                                                          
  - Add `PlainKey::encode_account()` and `PlainKey::encode_storage()` returning
    fixed-size stack arrays (`[u8; 20]` and `[u8; 52]`) instead of heap-allocated `Vec<u8>`               
  - Update the four hot-path callers in `database.rs` (`basic_ref`, `storage_ref`,
    `bucket_id_for_account`, `bucket_id_for_slot`) to use the new stack-allocating methods                
  - Eliminate a heap allocation on every EVM state read during block execution
                                                                                                          
  Account and storage key sizes are fixed by the Ethereum specification (20 and 52 bytes
  respectively), making stack arrays the correct choice. The existing `encode() -> Vec<u8>`               
  is retained for the `executor.rs` use-site where an owned allocation is still required.