### PR TITLE
refactor: add storage trait abstraction for ValidatorDB and unit tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5952,6 +5952,7 @@ dependencies = [
  "salt",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.17",
  "tokio",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1357,145 +1357,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "boa_ast"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c340fe0f0b267787095cbe35240c6786ff19da63ec7b69367ba338eace8169b"
-dependencies = [
- "bitflags",
- "boa_interner",
- "boa_macros",
- "boa_string",
- "indexmap 2.12.1",
- "num-bigint 0.4.6",
- "rustc-hash",
-]
-
-[[package]]
-name = "boa_engine"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f620c3f06f51e65c0504ddf04978be1b814ac6586f0b45f6019801ab5efd37f9"
-dependencies = [
- "arrayvec",
- "bitflags",
- "boa_ast",
- "boa_gc",
- "boa_interner",
- "boa_macros",
- "boa_parser",
- "boa_profiler",
- "boa_string",
- "bytemuck",
- "cfg-if",
- "dashmap 6.1.0",
- "fast-float2",
- "hashbrown 0.15.5",
- "icu_normalizer 1.5.0",
- "indexmap 2.12.1",
- "intrusive-collections",
- "itertools 0.13.0",
- "num-bigint 0.4.6",
- "num-integer",
- "num-traits",
- "num_enum",
- "once_cell",
- "pollster",
- "portable-atomic",
- "rand 0.8.5",
- "regress",
- "rustc-hash",
- "ryu-js",
- "serde",
- "serde_json",
- "sptr",
- "static_assertions",
- "tap",
- "thin-vec",
- "thiserror 2.0.17",
- "time",
-]
-
-[[package]]
-name = "boa_gc"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2425c0b7720d42d73eaa6a883fbb77a5c920da8694964a3d79a67597ac55cce2"
-dependencies = [
- "boa_macros",
- "boa_profiler",
- "boa_string",
- "hashbrown 0.15.5",
- "thin-vec",
-]
-
-[[package]]
-name = "boa_interner"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42407a3b724cfaecde8f7d4af566df4b56af32a2f11f0956f5570bb974e7f749"
-dependencies = [
- "boa_gc",
- "boa_macros",
- "hashbrown 0.15.5",
- "indexmap 2.12.1",
- "once_cell",
- "phf",
- "rustc-hash",
- "static_assertions",
-]
-
-[[package]]
-name = "boa_macros"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fd3f870829131332587f607a7ff909f1af5fc523fd1b192db55fbbdf52e8d3c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.110",
- "synstructure",
-]
-
-[[package]]
-name = "boa_parser"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cc142dac798cdc6e2dbccfddeb50f36d2523bb977a976e19bdb3ae19b740804"
-dependencies = [
- "bitflags",
- "boa_ast",
- "boa_interner",
- "boa_macros",
- "boa_profiler",
- "fast-float2",
- "icu_properties 1.5.1",
- "num-bigint 0.4.6",
- "num-traits",
- "regress",
- "rustc-hash",
-]
-
-[[package]]
-name = "boa_profiler"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4064908e7cdf9b6317179e9b04dcb27f1510c1c144aeab4d0394014f37a0f922"
-
-[[package]]
-name = "boa_string"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7debc13fbf7997bf38bf8e9b20f1ad5e2a7d27a900e1f6039fe244ce30f589b5"
-dependencies = [
- "fast-float2",
- "paste",
- "rustc-hash",
- "sptr",
- "static_assertions",
-]
-
-[[package]]
 name = "borsh"
 version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1529,26 +1390,6 @@ name = "byte-slice-cast"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
-
-[[package]]
-name = "bytemuck"
-version = "1.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fbdf580320f38b612e485521afda1ee26d10cc9884efaaa750d383e13e3c5f4"
-dependencies = [
- "bytemuck_derive",
-]
-
-[[package]]
-name = "bytemuck_derive"
-version = "1.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.110",
-]
 
 [[package]]
 name = "byteorder"
@@ -1722,6 +1563,16 @@ name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2165,12 +2016,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fast-float2"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8eb564c5c7423d25c886fb561d1e4ee69f72354d16918afa32c08811f6b6a55"
-
-[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2505,8 +2350,6 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
- "allocator-api2",
- "equivalent",
  "foldhash 0.2.0",
  "serde",
  "serde_core",
@@ -2712,27 +2555,15 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
-dependencies = [
- "displaydoc",
- "yoke 0.7.5",
- "zerofrom",
- "zerovec 0.10.4",
-]
-
-[[package]]
-name = "icu_collections"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
 dependencies = [
  "displaydoc",
  "potential_utf",
- "yoke 0.8.1",
+ "yoke",
  "zerofrom",
- "zerovec 0.11.5",
+ "zerovec",
 ]
 
 [[package]]
@@ -2742,61 +2573,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
 dependencies = [
  "displaydoc",
- "litemap 0.8.1",
- "tinystr 0.8.2",
- "writeable 0.6.2",
- "zerovec 0.11.5",
-]
-
-[[package]]
-name = "icu_locid"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
-dependencies = [
- "displaydoc",
- "litemap 0.7.5",
- "tinystr 0.7.6",
- "writeable 0.5.5",
- "zerovec 0.10.4",
-]
-
-[[package]]
-name = "icu_locid_transform"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_locid_transform_data",
- "icu_provider 1.5.0",
- "tinystr 0.7.6",
- "zerovec 0.10.4",
-]
-
-[[package]]
-name = "icu_locid_transform_data"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7515e6d781098bf9f7205ab3fc7e9709d34554ae0b21ddbcb5febfa4bc7df11d"
-
-[[package]]
-name = "icu_normalizer"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
-dependencies = [
- "displaydoc",
- "icu_collections 1.5.0",
- "icu_normalizer_data 1.5.1",
- "icu_properties 1.5.1",
- "icu_provider 1.5.0",
- "smallvec",
- "utf16_iter",
- "utf8_iter",
- "write16",
- "zerovec 0.10.4",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
 ]
 
 [[package]]
@@ -2805,19 +2585,13 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
 dependencies = [
- "icu_collections 2.1.1",
- "icu_normalizer_data 2.1.1",
- "icu_properties 2.1.1",
- "icu_provider 2.1.1",
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
  "smallvec",
- "zerovec 0.11.5",
+ "zerovec",
 ]
-
-[[package]]
-name = "icu_normalizer_data"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e8338228bdc8ab83303f16b797e177953730f601a96c25d10cb3ab0daa0cb7"
 
 [[package]]
 name = "icu_normalizer_data"
@@ -2827,38 +2601,17 @@ checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
 
 [[package]]
 name = "icu_properties"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
-dependencies = [
- "displaydoc",
- "icu_collections 1.5.0",
- "icu_locid_transform",
- "icu_properties_data 1.5.1",
- "icu_provider 1.5.0",
- "tinystr 0.7.6",
- "zerovec 0.10.4",
-]
-
-[[package]]
-name = "icu_properties"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e93fcd3157766c0c8da2f8cff6ce651a31f0810eaa1c51ec363ef790bbb5fb99"
 dependencies = [
- "icu_collections 2.1.1",
+ "icu_collections",
  "icu_locale_core",
- "icu_properties_data 2.1.1",
- "icu_provider 2.1.1",
+ "icu_properties_data",
+ "icu_provider",
  "zerotrie",
- "zerovec 0.11.5",
+ "zerovec",
 ]
-
-[[package]]
-name = "icu_properties_data"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85fb8799753b75aee8d2a21d7c14d9f38921b54b3dbda10f5a3c7a7b82dba5e2"
 
 [[package]]
 name = "icu_properties_data"
@@ -2868,45 +2621,17 @@ checksum = "02845b3647bb045f1100ecd6480ff52f34c35f82d9880e029d329c21d1054899"
 
 [[package]]
 name = "icu_provider"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_provider_macros",
- "stable_deref_trait",
- "tinystr 0.7.6",
- "writeable 0.5.5",
- "yoke 0.7.5",
- "zerofrom",
- "zerovec 0.10.4",
-]
-
-[[package]]
-name = "icu_provider"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
- "writeable 0.6.2",
- "yoke 0.8.1",
+ "writeable",
+ "yoke",
  "zerofrom",
  "zerotrie",
- "zerovec 0.11.5",
-]
-
-[[package]]
-name = "icu_provider_macros"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.110",
+ "zerovec",
 ]
 
 [[package]]
@@ -2932,8 +2657,8 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
- "icu_normalizer 2.1.1",
- "icu_properties 2.1.1",
+ "icu_normalizer",
+ "icu_properties",
 ]
 
 [[package]]
@@ -2983,15 +2708,6 @@ dependencies = [
  "hashbrown 0.16.1",
  "serde",
  "serde_core",
-]
-
-[[package]]
-name = "intrusive-collections"
-version = "0.9.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "189d0897e4cbe8c75efedf3502c18c887b05046e59d28404d4d8e46cbc4d1e86"
-dependencies = [
- "memoffset",
 ]
 
 [[package]]
@@ -3287,6 +3003,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "kanal"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e3953adf0cd667798b396c2fa13552d6d9b3269d7dd1154c4c416442d1ff574"
+dependencies = [
+ "futures-core",
+ "lock_api",
+]
+
+[[package]]
 name = "keccak"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3388,12 +3114,6 @@ name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
-
-[[package]]
-name = "litemap"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
 
 [[package]]
 name = "litemap"
@@ -3503,15 +3223,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "metrics"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3618,9 +3329,9 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.14"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
 dependencies = [
  "libc",
  "log",
@@ -3675,7 +3386,6 @@ checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
- "serde",
 ]
 
 [[package]]
@@ -3764,15 +3474,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.110",
-]
-
-[[package]]
-name = "num_threads"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -3884,9 +3585,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.75"
+version = "0.10.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
+checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -3910,15 +3611,15 @@ dependencies = [
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.6"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.111"
+version = "0.9.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
 dependencies = [
  "cc",
  "libc",
@@ -4224,12 +3925,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
-name = "pollster"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
-
-[[package]]
 name = "portable-atomic"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4241,7 +3936,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
- "zerovec 0.11.5",
+ "zerovec",
 ]
 
 [[package]]
@@ -4361,9 +4056,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick_cache"
-version = "0.6.18"
+version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ada44a88ef953a3294f6eb55d2007ba44646015e18613d2f213016379203ef3"
+checksum = "5a70b1b8b47e31d0498ecbc3c5470bb931399a8bfed1fd79d1717a61ce7f96e3"
 dependencies = [
  "ahash",
  "equivalent",
@@ -4631,16 +4326,6 @@ name = "regex-syntax"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
-
-[[package]]
-name = "regress"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2057b2325e68a893284d1538021ab90279adac1139957ca2a74426c6f118fb48"
-dependencies = [
- "hashbrown 0.16.1",
- "memchr",
-]
 
 [[package]]
 name = "reqwest"
@@ -5116,26 +4801,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "revm-inspectors"
-version = "0.27.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2483827fec2c31db4ada14e0b5523c377d1084337d1dbe135faaf14c218ab1af"
-dependencies = [
- "alloy-primitives",
- "alloy-rpc-types-eth",
- "alloy-rpc-types-trace",
- "alloy-sol-types",
- "anstyle",
- "boa_engine",
- "boa_gc",
- "colorchoice",
- "revm",
- "serde",
- "serde_json",
- "thiserror 2.0.17",
-]
-
-[[package]]
 name = "revm-interpreter"
 version = "24.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5406,12 +5071,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
-name = "ryu-js"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd29631678d6fb0903b69223673e122c32e9ae559d0960a38d574695ebc0ea15"
-
-[[package]]
 name = "salt"
 version = "1.0.1"
 source = "git+https://github.com/megaeth-labs/salt.git?rev=v1.0.1#f15f1b2cac046c874656f16af10b00db3174e733"
@@ -5433,9 +5092,9 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
 ]
@@ -5528,12 +5187,12 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.11.1"
+version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+checksum = "d17b898a6d6948c3a8ee4372c17cb384f90d2e6e912ef00895b14fd7ab54ec38"
 dependencies = [
  "bitflags",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -5541,9 +5200,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.15.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -5888,12 +5547,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sptr"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b9b39299b249ad65f3b7e96443bad61c02ca5cd3589f46cb6d610a0fd6c0d6a"
-
-[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5926,20 +5579,20 @@ dependencies = [
  "alloy-provider",
  "alloy-rlp",
  "alloy-rpc-types-eth",
- "alloy-rpc-types-trace",
  "alloy-serde",
  "alloy-trie",
  "base64",
  "bincode 2.0.1",
+ "dashmap 6.1.0",
  "dyn-clone",
  "eyre",
  "futures",
+ "kanal",
  "lz4_flex",
  "mega-evm",
  "num_cpus",
  "op-alloy-network",
  "op-alloy-rpc-types",
- "rayon",
  "redb",
  "reth-ethereum-forks",
  "reth-optimism-chainspec",
@@ -5947,14 +5600,13 @@ dependencies = [
  "reth-trie-common",
  "reth-trie-sparse",
  "revm",
- "revm-inspectors",
- "rustc-hash",
  "salt",
  "serde",
  "serde_json",
  "tempfile",
  "thiserror 2.0.17",
  "tokio",
+ "tokio-util",
  "tracing",
  "zstd",
 ]
@@ -5973,6 +5625,7 @@ dependencies = [
  "futures",
  "jsonrpsee 0.26.0",
  "jsonrpsee-types 0.26.0",
+ "kanal",
  "metrics",
  "metrics-exporter-prometheus",
  "num_cpus",
@@ -6091,7 +5744,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
  "bitflags",
- "core-foundation",
+ "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
 
@@ -6123,12 +5776,6 @@ dependencies = [
  "rustix",
  "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "thin-vec"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "144f754d318415ac792f9d69fc87abbbfc043ce2ef041c60f16ad828f638717d"
 
 [[package]]
 name = "thiserror"
@@ -6196,10 +5843,7 @@ checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
 dependencies = [
  "deranged",
  "itoa",
- "js-sys",
- "libc",
  "num-conv",
- "num_threads",
  "powerfmt",
  "serde",
  "time-core",
@@ -6233,22 +5877,12 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
-dependencies = [
- "displaydoc",
- "zerovec 0.10.4",
-]
-
-[[package]]
-name = "tinystr"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
  "displaydoc",
- "zerovec 0.11.5",
+ "zerovec",
 ]
 
 [[package]]
@@ -6602,12 +6236,6 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
-
-[[package]]
-name = "utf16_iter"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
 
 [[package]]
 name = "utf8_iter"
@@ -7043,18 +6671,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
-name = "write16"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
-
-[[package]]
-name = "writeable"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
-
-[[package]]
 name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7071,37 +6687,13 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
-dependencies = [
- "serde",
- "stable_deref_trait",
- "yoke-derive 0.7.5",
- "zerofrom",
-]
-
-[[package]]
-name = "yoke"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
 dependencies = [
  "stable_deref_trait",
- "yoke-derive 0.8.1",
+ "yoke-derive",
  "zerofrom",
-]
-
-[[package]]
-name = "yoke-derive"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.110",
- "synstructure",
 ]
 
 [[package]]
@@ -7205,19 +6797,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
 dependencies = [
  "displaydoc",
- "yoke 0.8.1",
+ "yoke",
  "zerofrom",
-]
-
-[[package]]
-name = "zerovec"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
-dependencies = [
- "yoke 0.7.5",
- "zerofrom",
- "zerovec-derive 0.10.3",
 ]
 
 [[package]]
@@ -7226,20 +6807,9 @@ version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
 dependencies = [
- "yoke 0.8.1",
+ "yoke",
  "zerofrom",
- "zerovec-derive 0.11.2",
-]
-
-[[package]]
-name = "zerovec-derive"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.110",
+ "zerovec-derive",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,14 +17,11 @@ repository = "https://github.com/megaeth-labs/stateless-validator"
 exclude = [".github/"]
 
 [workspace.dependencies]
-# alloy
 alloy-consensus = { version = "1.0.23", default-features = false }
 alloy-eips = { version = "1.0.23", default-features = false }
 alloy-evm = { version = "0.15.0", default-features = false }
 alloy-genesis = { version = "1.0.23", default-features = false }
 alloy-hardforks = { version = "0.2.7" }
-
-# op
 alloy-op-evm = { version = "0.15.0", default-features = false }
 alloy-op-hardforks = { version = "0.2.7" }
 alloy-primitives = { version = "1.3.0", default-features = false }
@@ -37,17 +34,17 @@ alloy-rpc-types-eth = { version = "1.0.23", default-features = false }
 alloy-rpc-types-trace = { version = "1.0.23", default-features = false }
 alloy-serde = { version = "1.0.23", default-features = false }
 alloy-trie = { version = "0.9.0", default-features = false }
-
-# misc
 base64 = "0.22"
 bincode = { version = "2.0", features = ["serde"] }
 clap = { version = "4.5", features = ["derive", "env"] }
+dashmap = { version = "6", default-features = false }
 dyn-clone = "1.0"
 eyre = "0.6"
 futures = "0.3"
+http = "1"
+http-body = "1"
+kanal = { version = "0.1", default-features = false, features = ["async"] }
 lz4_flex = { version = "0.11", default-features = false }
-
-# megaeth 
 mega-evm = { git = "https://github.com/megaeth-labs/mega-evm.git", rev = "v1.4.1" }
 metrics = "0.24"
 metrics-derive = "0.1"
@@ -55,23 +52,14 @@ metrics-exporter-prometheus = { version = "0.18", default-features = false, feat
 num_cpus = "1.17"
 op-alloy-network = { version = "0.18.12", default-features = false }
 op-alloy-rpc-types = { version = "0.18.12", default-features = false }
-rayon = "1.11"
 redb = "3.0.1"
 rolling-file = "0.2"
-
-# reth
 reth-ethereum-forks = { git = "https://github.com/paradigmxyz/reth", tag = "v1.6.0" }
 reth-optimism-chainspec = { git = "https://github.com/paradigmxyz/reth", tag = "v1.6.0" }
 reth-trie = { git = "https://github.com/paradigmxyz/reth", tag = "v1.6.0" }
 reth-trie-common = { git = "https://github.com/paradigmxyz/reth", tag = "v1.6.0" }
 reth-trie-sparse = { git = "https://github.com/paradigmxyz/reth", tag = "v1.6.0" }
-
-# revm
-http = "1"
-http-body = "1"
 revm = { version = "27.1.0", default-features = false }
-revm-inspectors = { version = "0.27.1", features = ["std", "js-tracer"] }
-rustc-hash = "2.0"
 salt = { git = "https://github.com/megaeth-labs/salt.git", rev = "v1.0.1" }
 serde = { version = "1.0", default-features = false }
 serde_json = "1.0"

--- a/bin/stateless-validator/Cargo.toml
+++ b/bin/stateless-validator/Cargo.toml
@@ -22,6 +22,7 @@ bincode.workspace = true
 clap = { workspace = true, features = ["env"] }
 eyre.workspace = true
 futures.workspace = true
+kanal.workspace = true
 metrics.workspace = true
 metrics-exporter-prometheus.workspace = true
 num_cpus.workspace = true

--- a/bin/stateless-validator/src/main.rs
+++ b/bin/stateless-validator/src/main.rs
@@ -3,7 +3,7 @@ use std::{
     future::Future,
     path::PathBuf,
     sync::Arc,
-    time::{Duration, Instant, SystemTime},
+    time::{Duration, Instant},
 };
 
 use alloy_genesis::Genesis;
@@ -16,11 +16,11 @@ use revm::{primitives::KECCAK_EMPTY, state::Bytecode};
 use salt::SaltWitness;
 use stateless_common::logging::{LogArgs, migrate_legacy_env_vars};
 use stateless_core::{
-    ChainSyncConfig, FetchResult, RpcClient, RpcClientConfig, ValidatorDB,
+    ChainSyncConfig, ContractCache, PersistentStore, RpcClient, RpcClientConfig,
     chain_spec::ChainSpec,
     data_types::{PlainKey, PlainValue},
-    executor::{ValidationResult, validate_block},
-    remote_chain_tracker,
+    executor::validate_block,
+    memory_db::{ChainTip, ValidatedBlock, ValidationFailure},
 };
 use tokio::{signal, task, task::JoinHandle};
 use tokio_util::sync::CancellationToken;
@@ -31,8 +31,8 @@ mod metrics;
 /// Handles to all spawned background tasks, awaited during shutdown.
 type BackgroundTasks = Vec<JoinHandle<Result<()>>>;
 
-/// Database filename for the validator.
-const VALIDATOR_DB_FILENAME: &str = "validator.redb";
+/// Database filename for the persistent store.
+const MEMORY_DB_FILENAME: &str = "memory.redb";
 
 /// Convert hex string to BlockHash
 ///
@@ -43,34 +43,21 @@ fn parse_block_hash(hex_str: &str) -> Result<BlockHash> {
     Ok(BlockHash::from_slice(&hash_bytes))
 }
 
-/// Loads or creates a ChainSpec from either the database or a genesis file.
-///
-/// This function implements the following logic:
-/// 1. If `genesis_file` is provided: load from file, store in DB, return ChainSpec
-/// 2. If `genesis_file` is None: load from DB
-/// 3. If neither source available: return error
-///
-/// # Arguments
-/// * `validator_db` - Database to load/store genesis configuration
-/// * `genesis_file` - Optional path to genesis JSON file
-///
-/// # Returns
-/// * `Ok(ChainSpec)` - Successfully loaded chain specification
-/// * `Err(eyre::Error)` - Failed to load genesis from any source
+/// Loads or creates a ChainSpec from either the persistent store or a genesis file.
 fn load_or_create_chain_spec(
-    validator_db: &ValidatorDB,
+    store: &PersistentStore,
     genesis_file: Option<&str>,
 ) -> Result<ChainSpec> {
     let genesis = match genesis_file {
         Some(path) => {
             info!("[ChainSpec] Loading genesis from file: {path}");
             let genesis = serde_json::from_str::<Genesis>(&std::fs::read_to_string(path)?)?;
-            validator_db.store_genesis(&genesis)?;
+            store.store_genesis(&genesis)?;
             genesis
         }
         None => {
             info!("[ChainSpec] Loading genesis from database");
-            validator_db.load_genesis()?.ok_or_else(|| {
+            store.load_genesis()?.ok_or_else(|| {
                 anyhow!("No genesis config found. Please provide --genesis-file on first run.")
             })?
         }
@@ -156,11 +143,11 @@ async fn main() -> Result<()> {
         None, // No Cloudflare fallback for validator
         args.report_validation_endpoint.as_deref(),
     )?);
-    let validator_db = Arc::new(ValidatorDB::new(work_dir.join(VALIDATOR_DB_FILENAME))?);
+    let store = Arc::new(PersistentStore::new(work_dir.join(MEMORY_DB_FILENAME))?);
+    let contract_cache = Arc::new(ContractCache::new(Arc::clone(&store)));
 
     // Load chain spec from file (first run) or database (subsequent runs)
-    let chain_spec =
-        Arc::new(load_or_create_chain_spec(&validator_db, args.genesis_file.as_deref())?);
+    let chain_spec = Arc::new(load_or_create_chain_spec(&store, args.genesis_file.as_deref())?);
     info!("[Main] Chain spec loaded successfully");
 
     // Handle optional start block initialization
@@ -178,25 +165,24 @@ async fn main() -> Result<()> {
             }
         };
 
-        validator_db
-            .reset_anchor_block(
-                header.number,
-                header.hash,
-                header.state_root,
-                header
-                    .withdrawals_root
-                    .ok_or_else(|| anyhow!("Block {} is missing withdrawals_root", block_hash))?,
-            )
-            .map_err(|e| anyhow!("Failed to reset anchor: {}", e))?;
+        let anchor = ChainTip {
+            block_number: header.number,
+            block_hash: header.hash,
+            post_state_root: header.state_root,
+            post_withdrawals_root: header
+                .withdrawals_root
+                .ok_or_else(|| anyhow!("Block {} is missing withdrawals_root", block_hash))?,
+        };
+        store.reset_to_anchor(&anchor)?;
 
         info!(
             "[Main] Successfully initialized from block {} (number: {})",
             header.hash, header.number
         );
     } else {
-        // If no start block was provided, ensure we have an existing canonical chain
+        // If no start block was provided, ensure we have an existing canonical tip
         ensure!(
-            validator_db.get_local_tip()?.is_some(),
+            store.get_canonical_tip()?.is_some(),
             "No trusted starting point found. Specify a trusted block with --start-block <blockhash>"
         );
         info!("[Main] Continuing from existing canonical chain");
@@ -210,15 +196,21 @@ async fn main() -> Result<()> {
         metrics_port: args.metrics_port,
         ..ChainSyncConfig::default()
     });
-    info!("[Main] Number of concurrent tasks: {}", config.concurrent_workers);
+    info!("[Main] Number of concurrent workers: {}", config.concurrent_workers);
     info!(
         "[Main] Validation result reporting: {}",
         if config.report_validation_results { "enabled" } else { "disabled" }
     );
 
     let shutdown_token = CancellationToken::new();
-    let (validator_logic, bg_tasks) =
-        chain_sync(client.clone(), &validator_db, config, chain_spec, shutdown_token.clone())?;
+    let (validator_logic, bg_tasks) = chain_sync(
+        client.clone(),
+        Arc::clone(&store),
+        contract_cache,
+        config,
+        chain_spec,
+        shutdown_token.clone(),
+    )?;
 
     let mut sigterm = signal::unix::signal(signal::unix::SignalKind::terminate())
         .map_err(|e| anyhow!("Failed to register SIGTERM handler: {e}"))?;
@@ -269,7 +261,6 @@ async fn main() -> Result<()> {
     }
 
     info!("[Main] Shutdown complete.");
-
     info!("[Main] Total execution time: {:?}", start.elapsed());
 
     // Propagate the validator error (if any) after shutdown completes,
@@ -277,392 +268,245 @@ async fn main() -> Result<()> {
     if let Some(res) = validator_result { res } else { Ok(()) }
 }
 
-/// Chain synchronizer entry point - orchestrates the complete chain synchronization pipeline
-///
-/// Implements a multi-phase startup process for stateless block validation:
-/// 1. **Task Recovery** - Recovers interrupted validation tasks from previous crashes
-/// 2. **Remote Chain Tracking** - Spawns background tracker to maintain block lookahead
-/// 3. **Validation Reporter** - Optionally spawns background task to report validated blocks to a
-///    dedicated report endpoint (when `report_validation_endpoint` is provided)
-/// 4. **History Pruning** - Spawns background pruner to manage storage overhead
-/// 5. **Validation Workers** - Spawns configured number of parallel validation workers
-/// 6. **Main Sync Loop** - Continuously advances canonical chain as blocks are validated
-///
-/// Runs indefinitely unless a sync target is configured. Background components operate
-/// independently while the main thread advances the canonical chain.
-///
-/// # Arguments
-/// * `client` - RPC client for communicating with remote blockchain node
-/// * `validator_db` - Database interface for task coordination and chain state management
-/// * `config` - Configuration including worker count, polling intervals, optional sync target, and
-///   validation reporting
-/// * `chain_spec` - Chain specification defining the EVM rules and parameters
-///
-/// # Returns
-/// * `Ok((main_loop, bg_tasks))` - Main sync loop future and handles to all background tasks
-/// * `Err(eyre::Error)` - On critical failures during task recovery
+// ---------------------------------------------------------------------------
+// Pipeline orchestration
+// ---------------------------------------------------------------------------
+
+/// Sets up the streaming validation pipeline:
+/// 1. Fetcher task: fetches blocks from RPC, sends to channel
+/// 2. N worker tasks: validate blocks, send results to channel
+/// 3. Advancer task (main loop): collects results in order, advances canonical chain
+/// 4. Optional reporter task: reports validated blocks upstream
 fn chain_sync(
     client: Arc<RpcClient>,
-    validator_db: &Arc<ValidatorDB>,
+    store: Arc<PersistentStore>,
+    contract_cache: Arc<ContractCache>,
     config: Arc<ChainSyncConfig>,
     chain_spec: Arc<ChainSpec>,
     shutdown: CancellationToken,
 ) -> Result<(impl Future<Output = Result<()>>, BackgroundTasks)> {
-    info!("[Chain Sync] Starting with {} validation workers", config.concurrent_workers);
+    let initial_tip = store
+        .get_canonical_tip()?
+        .ok_or_else(|| anyhow!("No canonical tip found — run with --start-block first"))?;
 
-    // Step 1: Recover any interrupted tasks from previous crashes
-    info!("[Chain Sync] Recovering interrupted validation tasks from previous runs...");
-    validator_db
-        .recover_interrupted_tasks()
-        .map_err(|e| anyhow!("Failed to recover interrupted tasks: {}", e))?;
-    info!("[Chain Sync] Task recovery completed");
+    let start_block = initial_tip.block_number + 1;
+    info!(
+        "[Pipeline] Starting from block {start_block} with {} workers",
+        config.concurrent_workers
+    );
+
+    // Create kanal channels
+    let (fetch_tx, fetch_rx) = kanal::bounded(config.fetch_channel_capacity);
+    let (result_tx, result_rx) = kanal::bounded(config.result_channel_capacity);
 
     let mut bg_tasks: BackgroundTasks = Vec::new();
 
-    // Step 2: Spawn remote chain tracker
-    // Safe to cancel externally: all DB writes in remote_chain_tracker are
-    // atomic transactions, and in-flight RPC data can be re-fetched on restart.
-    info!("[Chain Sync] Starting remote chain tracker...");
+    // Task 1: Block fetcher
     bg_tasks.push(task::spawn({
-        let (client, db, config, shutdown) = (
-            Arc::clone(&client),
-            Arc::clone(validator_db),
-            Arc::clone(&config),
-            shutdown.clone(),
-        );
+        let client = Arc::clone(&client);
+        let config = Arc::clone(&config);
+        let shutdown = shutdown.clone();
         async move {
-            tokio::select! {
-                res = remote_chain_tracker(client, db, config, Some(metrics::on_chain_reorg), None::<fn(&FetchResult)>) => res,
-                _ = shutdown.cancelled() => { info!("[Tracker] Shutting down gracefully"); Ok(()) }
-            }
+            stateless_core::block_fetcher(client, fetch_tx, start_block, config, shutdown).await
         }
     }));
 
-    // Step 3: Spawn validation reporter (optional, based on config)
+    // Task 2: N validation workers
+    for worker_id in 0..config.concurrent_workers {
+        let fetch_rx = fetch_rx.clone();
+        let result_tx = result_tx.clone();
+        let client = Arc::clone(&client);
+        let contract_cache = Arc::clone(&contract_cache);
+        let chain_spec = Arc::clone(&chain_spec);
+        let shutdown = shutdown.clone();
+
+        bg_tasks.push(task::spawn(validation_worker(
+            worker_id,
+            client,
+            contract_cache,
+            chain_spec,
+            fetch_rx,
+            result_tx,
+            shutdown,
+        )));
+    }
+    // Drop the original sender/receiver so channel closes when all workers finish
+    drop(fetch_rx);
+    drop(result_tx);
+
+    // Task 3: Optional validation reporter
     if config.report_validation_results {
-        info!("[Chain Sync] Starting validation reporter...");
+        info!("[Pipeline] Starting validation reporter...");
         bg_tasks.push(task::spawn(validation_reporter(
             Arc::clone(&client),
-            Arc::clone(validator_db),
+            Arc::clone(&store),
             Arc::clone(&config),
             shutdown.clone(),
         )));
     } else {
-        info!("[Chain Sync] Validation reporter disabled (validation reporting not enabled)");
+        info!("[Pipeline] Validation reporter disabled");
     }
 
-    // Step 4: Spawn history pruner
-    bg_tasks.push(task::spawn(history_pruner(
-        Arc::clone(validator_db),
-        Arc::clone(&config),
-        shutdown.clone(),
-    )));
-
-    // Step 5: Spawn validation workers as tokio tasks
-    info!("[Chain Sync] Spawning {} validation workers...", config.concurrent_workers);
-    for worker_id in 0..config.concurrent_workers {
-        bg_tasks.push(task::spawn(validation_worker(
-            worker_id,
-            Arc::clone(&client),
-            Arc::clone(validator_db),
-            Arc::clone(&config),
-            Arc::clone(&chain_spec),
-            shutdown.clone(),
-        )));
-    }
-    info!("[Chain Sync] All validation workers started");
-
-    // Step 6: Return main chain synchronizer loop as a future
-    info!("[Chain Sync] Starting main synchronizer loop...");
-
-    let validator_db = Arc::clone(validator_db);
-    let main_loop = async move {
-        loop {
-            if shutdown.is_cancelled() {
-                info!("[Chain Sync] Shutting down gracefully");
-                return Ok(());
-            }
-
-            if let Some(target) = config.sync_target &&
-                let Ok(Some((local_block_number, _))) = validator_db.get_local_tip() &&
-                local_block_number >= target
-            {
-                debug!("[Chain Sync] Reached sync target height {target}, terminating");
-                return Ok(());
-            }
-
-            if let Err(e) = async {
-                // Advance the canonical chain with newly validated blocks
-                let mut blocks_advanced = 0;
-                while validator_db.grow_local_chain()? {
-                    blocks_advanced += 1;
-                }
-
-                if blocks_advanced > 0 {
-                    debug!("[Chain Sync] Advanced canonical chain by {blocks_advanced} blocks");
-                } else {
-                    // No work to do, wait a bit before polling again
-                    tokio::select! {
-                        _ = tokio::time::sleep(config.sync_poll_interval) => {}
-                        _ = shutdown.cancelled() => {}
-                    }
-                }
-
-                // Update chain height metrics
-                if let (Ok(Some((local_tip, _))), Ok(remote_tip)) =
-                    (validator_db.get_local_tip(), validator_db.get_remote_tip())
-                {
-                    let remote_height = remote_tip.map(|(n, _)| n).unwrap_or(local_tip);
-                    metrics::set_chain_heights(local_tip, remote_height);
-
-                    let earliest = validator_db
-                        .get_earliest_local_block()
-                        .ok()
-                        .flatten()
-                        .map(|(n, _)| n)
-                        .unwrap_or(0);
-                    metrics::set_db_block_range(earliest, local_tip);
-                }
-
-                Ok::<(), eyre::Error>(())
-            }
-            .await
-            {
-                // NOTE: We do NOT retry on errors here. All errors from grow_local_chain()
-                // represent non-retriable conditions:
-                //
-                // 1. ValidationDbError::FailedValidation
-                //    - Block validation failed, or state/withdrawals root mismatch
-                //    - These are deterministic failures; the block will never become valid on retry
-                //
-                // 2. ValidationDbError::Database
-                //    - Database I/O errors, corruption, disk full, permission denied
-                //    - These are persistent infrastructure issues requiring operator intervention
-                //    - Retrying won't help; the underlying issue must be fixed
-                //
-                // 3. ValidationDbError::MissingData
-                //    - Block data, witness, or validation result not found in database
-                //    - This should NEVER occur in normal operation because block data and witnesses
-                //      are written atomically during validation
-                //    - If this occurs, it indicates either a bug in the validation pipeline or
-                //      database corruption
-                //
-                // 4. ValidationDbError::ValidationResultMismatch
-                //    - Validation result does not match the first remote chain entry
-                //    - Indicates database inconsistency or logic error in the pipeline
-                //
-                // The chain sync process terminates immediately and returns the error to the
-                // caller. Operators should investigate the root cause.
-
-                error!("[Chain Sync] Failed to advance canonical chain: {}", e);
-                return Err(e);
-            }
-        }
-    };
+    // Main loop = chain advancer
+    let main_loop = stateless_core::chain_advancer(result_rx, store, initial_tip, shutdown);
 
     Ok((main_loop, bg_tasks))
 }
 
-/// Validation worker that continuously processes blocks from the task queue
-///
-/// Runs in an infinite loop, claiming validation tasks from ValidatorDB and processing
-/// them via `validate_one()`. Infrastructure errors (database, RPC failures) are logged
-/// and contained.
-///
-/// # Arguments
-/// * `worker_id` - Worker identifier for logging
-/// * `client` - RPC client for fetching data on demand
-/// * `validator_db` - Database interface for task coordination
-/// * `config` - Configuration for worker behavior
-/// * `chain_spec` - Chain specification defining the EVM rules and parameters
-///
-/// # Returns
-/// * Never returns under normal operation - runs indefinitely until externally terminated
+// ---------------------------------------------------------------------------
+// Validation worker
+// ---------------------------------------------------------------------------
+
+/// Validation worker that receives blocks from the fetch channel, validates them,
+/// and sends results to the advancer channel.
 async fn validation_worker(
     worker_id: usize,
     client: Arc<RpcClient>,
-    validator_db: Arc<ValidatorDB>,
-    config: Arc<ChainSyncConfig>,
+    contract_cache: Arc<ContractCache>,
     chain_spec: Arc<ChainSpec>,
+    fetch_rx: kanal::Receiver<stateless_core::ValidationTask>,
+    result_tx: kanal::Sender<std::result::Result<ValidatedBlock, ValidationFailure>>,
     shutdown: CancellationToken,
 ) -> Result<()> {
-    info!("[Worker {}] Started", worker_id);
+    info!("[Worker {worker_id}] Started");
+    let fetch_rx = fetch_rx.to_async();
+    let result_tx = result_tx.to_async();
+
     loop {
-        if shutdown.is_cancelled() {
-            break;
-        }
-        // NOTE: shutdown is not preemptive during `validate_one`. If a cancellation arrives
-        // while a block is being validated (which runs on a blocking thread via spawn_blocking),
-        // the worker will finish the current block before checking the token again at the top
-        // of this loop or in the idle/error select! branches below.
-        match validate_one(worker_id, &client, &validator_db, chain_spec.clone()).await {
-            Ok(true) => {}
-            Ok(false) => tokio::select! {
-                _ = tokio::time::sleep(config.worker_idle_sleep) => {}
-                _ = shutdown.cancelled() => break,
-            },
-            Err(e) => {
-                if shutdown.is_cancelled() {
-                    warn!(worker_id, error = %e, "[Worker] Error during shutdown, stopping");
+        // Receive next task from shared fetch channel
+        let task = tokio::select! {
+            r = fetch_rx.recv() => match r {
+                Ok(task) => task,
+                Err(_) => {
+                    info!("[Worker {worker_id}] Fetch channel closed, stopping");
                     break;
                 }
-                error!("[Worker {worker_id}] Error during task processing: {e}");
-                tokio::select! {
-                    _ = tokio::time::sleep(config.worker_error_sleep) => {}
-                    _ = shutdown.cancelled() => break,
-                }
+            },
+            _ = shutdown.cancelled() => {
+                info!("[Worker {worker_id}] Shutting down gracefully");
+                break;
             }
-        }
-    }
-    info!("[Worker {worker_id}] Shutting down gracefully");
-    Ok(())
-}
+        };
 
-/// Processes a single validation task
-///
-/// This function encapsulates the workflow for processing one validation task,
-/// including task acquisition, contract code fetching, block validation, and
-/// result storage. All errors are propagated to the caller for centralized error
-/// handling.
-///
-/// # Arguments
-/// * `worker_id` - Worker identifier for logging
-/// * `client` - RPC client for fetching contract bytecode from remote nodes
-/// * `validator_db` - Database for tasks and data
-/// * `chain_spec` - Chain specification defining the EVM rules and parameters
-///
-/// # Returns
-/// * `Ok(true)` - Task was processed (validation success/failure stored in DB)
-/// * `Ok(false)` - No tasks available, no work performed
-/// * `Err(eyre::Error)` - Infrastructure error (DB/RPC failures)
-async fn validate_one(
-    worker_id: usize,
-    client: &RpcClient,
-    validator_db: &ValidatorDB,
-    chain_spec: Arc<ChainSpec>,
-) -> Result<bool> {
-    match validator_db.get_next_task()? {
-        Some((block, witness, mpt_witness)) => {
-            let block_number = block.header.number;
-            let tx_count = block.transactions.len() as u64;
-            let gas_used = block.header.gas_used;
-            debug!("[Worker {}] Validating block {}", worker_id, block_number);
+        let block_number = task.block.header.number;
+        let block_hash = task.block.header.hash;
+        let tx_count = task.block.transactions.len() as u64;
+        let gas_used = task.block.header.gas_used;
+        debug!("[Worker {worker_id}] Validating block {block_number}");
 
-            let start = Instant::now();
+        let start = Instant::now();
 
-            // Prepare the contract map to be used by validation
-            let codehashes = extract_contract_codes(&witness);
+        // Resolve contract codes
+        let codehashes = extract_contract_codes(&task.salt_witness);
+        let (mut contracts, missing_contracts) =
+            contract_cache.get(&codehashes.iter().copied().collect::<Vec<_>>())?;
 
-            let (mut contracts, missing_contracts) = validator_db.get_contract_codes(codehashes)?;
+        metrics::on_contract_cache_read(contracts.len() as u64, missing_contracts.len() as u64);
 
-            metrics::on_contract_cache_read(contracts.len() as u64, missing_contracts.len() as u64);
-
-            // Fetch missing contract codes via RPC concurrently and update the local DB
-            let codes = future::try_join_all(
-                missing_contracts.iter().map(|&hash| async move { client.get_code(hash).await }),
-            )
+        if !missing_contracts.is_empty() {
+            let codes = future::try_join_all(missing_contracts.iter().map(|&hash| {
+                let client = Arc::clone(&client);
+                async move { client.get_code(hash).await }
+            }))
             .await?;
 
-            // Validate all fetched bytecodes match expected hashes
             let new_bytecodes: Vec<_> = missing_contracts
                 .into_iter()
                 .zip(codes.iter())
                 .map(|(code_hash, bytes)| {
                     let bytecode = Bytecode::new_raw(bytes.clone());
                     let computed_hash = bytecode.hash_slow();
-
                     ensure!(
                         computed_hash == code_hash,
                         "RPC provider returned bytecode with unexpected codehash: expected {code_hash:?}, got {computed_hash:?}",
                     );
-
                     Ok((computed_hash, bytecode))
                 })
                 .collect::<Result<_>>()?;
 
-            validator_db.add_contract_codes(&new_bytecodes)?;
+            contract_cache.insert(&new_bytecodes)?;
             contracts.extend(new_bytecodes);
-
-            let pre_state_root = B256::from(witness.state_root()?);
-            let post_state_root = block.header.state_root;
-            let pre_withdrawals_root = mpt_witness.storage_root;
-            let block_hash = block.header.hash;
-            let post_withdrawals_root = block
-                .header
-                .withdrawals_root
-                .ok_or(eyre::eyre!("Withdrawals root not found in block {block_hash}"))?;
-
-            // Validate in a blocking thread so async tasks (reporter, tracker, etc.) stay
-            // responsive.
-            let validation_result = task::spawn_blocking(move || {
-                validate_block(&chain_spec, &block, witness, mpt_witness, &contracts, None)
-            })
-            .await
-            .map_err(|e| eyre::eyre!("Validation task failed: {e}"))?;
-
-            let (success, error_message) = match &validation_result {
-                Ok(stats) => {
-                    info!("[Worker {worker_id}] Successfully validated block {block_number}");
-                    metrics::on_validation_success(
-                        start.elapsed().as_secs_f64(),
-                        stats.witness_verification_time,
-                        stats.block_replay_time,
-                        stats.salt_update_time,
-                        tx_count,
-                        gas_used,
-                        stats.state_reads,
-                        stats.state_writes,
-                    );
-                    (true, None)
-                }
-                Err(e) => {
-                    error!("[Worker {worker_id}] Failed to validate block {block_number}: {e}");
-                    (false, Some(e.to_string()))
-                }
-            };
-            metrics::on_worker_task_done(worker_id, success);
-
-            validator_db.complete_validation(ValidationResult {
-                pre_state_root,
-                post_state_root,
-                pre_withdrawals_root,
-                post_withdrawals_root,
-                block_number,
-                block_hash,
-                success,
-                error_message,
-                completed_at: SystemTime::now(),
-            })?;
-
-            Ok(true)
         }
-        None => Ok(false),
+
+        // Extract state roots before moving data into spawn_blocking
+        let pre_state_root = B256::from(task.salt_witness.state_root()?);
+        let post_state_root = task.block.header.state_root;
+        let pre_withdrawals_root = task.mpt_witness.storage_root;
+        let post_withdrawals_root = task
+            .block
+            .header
+            .withdrawals_root
+            .ok_or(eyre::eyre!("Withdrawals root not found in block {block_hash}"))?;
+
+        // Validate in a blocking thread
+        let chain_spec_clone = Arc::clone(&chain_spec);
+        let validation_result = task::spawn_blocking(move || {
+            validate_block(
+                &chain_spec_clone,
+                &task.block,
+                task.salt_witness,
+                task.mpt_witness,
+                &contracts,
+                None,
+            )
+        })
+        .await
+        .map_err(|e| eyre::eyre!("Validation task panicked: {e}"))?;
+
+        let result = match &validation_result {
+            Ok(stats) => {
+                info!("[Worker {worker_id}] Successfully validated block {block_number}");
+                metrics::on_validation_success(
+                    start.elapsed().as_secs_f64(),
+                    stats.witness_verification_time,
+                    stats.block_replay_time,
+                    stats.salt_update_time,
+                    tx_count,
+                    gas_used,
+                    stats.state_reads,
+                    stats.state_writes,
+                );
+                metrics::on_worker_task_done(worker_id, true);
+                Ok(ValidatedBlock {
+                    block_number,
+                    block_hash,
+                    post_state_root,
+                    post_withdrawals_root,
+                    pre_state_root,
+                    pre_withdrawals_root,
+                })
+            }
+            Err(e) => {
+                error!("[Worker {worker_id}] Failed to validate block {block_number}: {e}");
+                metrics::on_worker_task_done(worker_id, false);
+                Err(ValidationFailure { block_number, block_hash, error: e.to_string() })
+            }
+        };
+
+        if result_tx.send(result).await.is_err() {
+            info!("[Worker {worker_id}] Result channel closed, stopping");
+            break;
+        }
     }
+    Ok(())
 }
 
-/// Reports validated blocks to the dedicated report endpoint
+// ---------------------------------------------------------------------------
+// Validation reporter (reads from PersistentStore)
+// ---------------------------------------------------------------------------
+
+/// Reports validated blocks to the dedicated report endpoint.
 ///
-/// Periodically monitors the canonical chain and reports the complete validated range
-/// (first to last block) to the report endpoint via `mega_setValidatedBlocks` RPC.
-/// Only reports when new blocks have been validated.
-///
-/// # Arguments
-/// * `client` - RPC client with a configured report provider
-/// * `validator_db` - Database interface for reading canonical chain
-/// * `config` - Configuration containing sync_poll_interval
-///
-/// # Returns
-/// * `Ok(())` - Never returns under normal operation
-/// * `Err(eyre::Error)` - Terminates if validation gap detected (upstream's last validated block <
-///   local chain start)
+/// Periodically reads the canonical tip from PersistentStore and reports the
+/// validated range to the upstream node.
 async fn validation_reporter(
     client: Arc<RpcClient>,
-    validator_db: Arc<ValidatorDB>,
+    store: Arc<PersistentStore>,
     config: Arc<ChainSyncConfig>,
     shutdown: CancellationToken,
 ) -> Result<()> {
     info!("[Reporter] Starting validation reporter");
-    let mut last_reported_block = (0u64, BlockHash::ZERO);
+    let mut last_reported_block = 0u64;
 
     loop {
         tokio::select! {
@@ -673,109 +517,58 @@ async fn validation_reporter(
             }
         }
 
-        // Get canonical chain bounds
-        let (first_block, last_block) =
-            match (validator_db.get_anchor_block(), validator_db.get_local_tip()) {
-                (Ok(Some(first)), Ok(Some(last))) => (first, last),
-                _ => continue,
-            };
+        // Get anchor and canonical tip
+        let (anchor, tip) = match (store.get_anchor_block(), store.get_canonical_tip()) {
+            (Ok(Some(a)), Ok(Some(t))) => (a, t),
+            _ => continue,
+        };
 
         // Skip if no new blocks
-        if last_block == last_reported_block {
+        if tip.block_number == last_reported_block {
             continue;
         }
 
         // Report validated range to upstream
         let result = client
             .set_validated_blocks(
-                (first_block.0, B256::from(first_block.1.0)),
-                (last_block.0, B256::from(last_block.1.0)),
+                (anchor.block_number, B256::from(anchor.block_hash.0)),
+                (tip.block_number, B256::from(tip.block_hash.0)),
             )
             .await;
 
         match result {
             Ok(response) if response.accepted => {
-                debug!("[Reporter] Reported blocks successfully: {first_block:?} - {last_block:?}");
-                last_reported_block = last_block;
+                debug!(
+                    "[Reporter] Reported blocks: anchor={} tip={}",
+                    anchor.block_number, tip.block_number
+                );
+                last_reported_block = tip.block_number;
             }
             Ok(response) => {
-                // Check for validation gap
-                if response.last_validated_block.0 < first_block.0 {
-                    debug!(
-                        "[Reporter] Validation gap detected: upstream at block {}, but local chain starts at {}. Cannot advance validation.",
-                        response.last_validated_block.0, first_block.0
-                    );
+                if response.last_validated_block.0 < anchor.block_number {
                     return Err(anyhow!(
-                        "Validation gap detected: upstream at block {}, but local chain starts at {}. Cannot advance validation.",
+                        "Validation gap detected: upstream at block {}, but local chain starts at {}",
                         response.last_validated_block.0,
-                        first_block.0
+                        anchor.block_number
                     ));
                 }
-                debug!(
-                    "[Reporter] Report rejected for blocks {first_block:?}-{last_block:?}, upstream at {:?}",
-                    response.last_validated_block
-                );
                 error!(
-                    "[Reporter] Report rejected for blocks {first_block:?}-{last_block:?}, upstream at {:?}",
+                    "[Reporter] Report rejected, upstream at {:?}",
                     response.last_validated_block
                 );
             }
             Err(e) => {
-                debug!("[Reporter] Failed to report blocks: {e}");
                 error!("[Reporter] Failed to report blocks: {e}");
             }
         }
     }
 }
 
-/// Periodically prunes old block data to maintain constant storage overhead
-///
-/// Runs in an infinite loop, removing blocks older than `blocks_to_keep` from the
-/// local chain tip at regular intervals. Pruning errors are logged but don't stop
-/// the pruner from continuing.
-///
-/// # Arguments
-/// * `validator_db` - Database interface for pruning operations
-/// * `config` - Configuration for pruning behavior
-///
-/// # Returns
-/// * Never returns under normal operation - runs indefinitely until externally terminated
-async fn history_pruner(
-    validator_db: Arc<ValidatorDB>,
-    config: Arc<ChainSyncConfig>,
-    shutdown: CancellationToken,
-) -> Result<()> {
-    info!("[Pruner] Starting with interval {:?}", config.pruner_interval);
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
 
-    loop {
-        if let Ok(Some((current_tip, _))) = validator_db.get_local_tip() {
-            let prune_before = current_tip.saturating_sub(config.pruner_blocks_to_keep);
-            match validator_db.prune_history(prune_before) {
-                Ok(blocks_pruned) if blocks_pruned > 0 => {
-                    debug!("[Pruner] Pruned {blocks_pruned} blocks before block {prune_before}");
-                    metrics::on_blocks_pruned(blocks_pruned);
-                }
-                Err(e) => warn!("[Pruner] Failed to prune old block data: {e}"),
-                _ => {}
-            }
-
-            // Update DB block range metrics
-            let earliest =
-                validator_db.get_earliest_local_block().ok().flatten().map(|(n, _)| n).unwrap_or(0);
-            metrics::set_db_block_range(earliest, current_tip);
-        }
-
-        tokio::select! {
-            _ = tokio::time::sleep(config.pruner_interval) => {}
-            _ = shutdown.cancelled() => {
-                info!("[Pruner] Shutting down gracefully");
-                return Ok(());
-            }
-        }
-    }
-}
-
-/// Returns all contract addresses and their code hashes from the witness.
+/// Returns all contract code hashes from the witness.
 ///
 /// Filters witness data to find accounts with non-empty bytecode, which are
 /// needed for contract code fetching during block execution.
@@ -792,6 +585,10 @@ fn extract_contract_codes(salt_witness: &SaltWitness) -> HashSet<B256> {
         })
         .collect()
 }
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
 
 #[cfg(test)]
 mod tests {
@@ -986,11 +783,11 @@ mod tests {
             .collect()
     }
 
-    /// Create a temporary ValidatorDB with the anchor set to the first block in test data.
-    fn setup_test_db(data: &TestData) -> Result<Arc<ValidatorDB>> {
+    /// Create a temporary PersistentStore with the anchor set to the first block in test data.
+    fn setup_test_store(data: &TestData) -> Result<Arc<PersistentStore>> {
         let temp_dir = tempfile::tempdir()?;
-        let validator_db = ValidatorDB::new(temp_dir.path().join(VALIDATOR_DB_FILENAME))?;
-        // Intentionally leak the temp dir — ValidatorDB holds a path into it.
+        let store = PersistentStore::new(temp_dir.path().join(MEMORY_DB_FILENAME))?;
+        // Intentionally leak the temp dir — PersistentStore holds a path into it.
         // The OS will clean it up when the test process exits.
         std::mem::forget(temp_dir);
 
@@ -1000,14 +797,16 @@ mod tests {
             .header
             .withdrawals_root
             .ok_or_else(|| anyhow!("Block {block_hash} missing withdrawals_root"))?;
-        validator_db.reset_anchor_block(
-            block_num,
-            block_hash,
-            block.header.state_root,
-            withdrawals_root,
-        )?;
 
-        Ok(Arc::new(validator_db))
+        let anchor = ChainTip {
+            block_number: block_num,
+            block_hash,
+            post_state_root: block.header.state_root,
+            post_withdrawals_root: withdrawals_root,
+        };
+        store.reset_to_anchor(&anchor)?;
+
+        Ok(Arc::new(store))
     }
 
     /// Start a mock RPC server backed by pre-loaded test data.
@@ -1160,7 +959,7 @@ mod tests {
         (server.start(module), url)
     }
 
-    /// Synthetic data integration test: validates consecutive blocks via chain_sync.
+    /// Synthetic data integration test: validates consecutive blocks via the streaming pipeline.
     #[tokio::test]
     async fn integration_test() {
         init_test_logging();
@@ -1169,12 +968,12 @@ mod tests {
 
         let genesis_file = format!("{SYNTHETIC_DATA_DIR}/genesis.json");
         let sync_target = Some(data.max_block().0);
-        let validator_db = setup_test_db(&data).unwrap();
+        let store = setup_test_store(&data).unwrap();
+        let contract_cache = Arc::new(ContractCache::new(Arc::clone(&store)));
         let (handle, url) = setup_mock_rpc_server(data).await;
         let client = Arc::new(RpcClient::new(&url, &url).unwrap());
 
-        let chain_spec =
-            Arc::new(load_or_create_chain_spec(&validator_db, Some(&genesis_file)).unwrap());
+        let chain_spec = Arc::new(load_or_create_chain_spec(&store, Some(&genesis_file)).unwrap());
 
         let config = Arc::new(ChainSyncConfig {
             concurrent_workers: 1,
@@ -1184,13 +983,12 @@ mod tests {
 
         let shutdown = CancellationToken::new();
         let (main_loop, bg_tasks) =
-            chain_sync(client.clone(), &validator_db, config, chain_spec, shutdown.clone())
+            chain_sync(client.clone(), store, contract_cache, config, chain_spec, shutdown.clone())
                 .unwrap();
         main_loop.await.unwrap();
 
         shutdown.cancel();
         let _ = tokio::time::timeout(Duration::from_secs(1), future::join_all(bg_tasks)).await;
-        drop(validator_db);
 
         handle.stop().unwrap();
         info!("Mock RPC server has been shut down.");

--- a/bin/stateless-validator/src/metrics.rs
+++ b/bin/stateless-validator/src/metrics.rs
@@ -5,7 +5,6 @@
 
 use std::net::SocketAddr;
 
-use alloy_primitives::B256;
 use eyre::Result;
 use metrics::{counter, describe_counter, describe_gauge, describe_histogram, gauge, histogram};
 use metrics_exporter_prometheus::PrometheusBuilder;
@@ -61,10 +60,6 @@ pub mod names {
 
     // Chain
     metric!(LOCAL_CHAIN_HEIGHT, "local_chain_height");
-    metric!(REMOTE_CHAIN_HEIGHT, "remote_chain_height");
-    metric!(VALIDATION_LAG, "validation_lag");
-    metric!(REORGS_DETECTED, "reorgs_detected_total");
-    metric!(REORG_DEPTH, "reorg_depth");
 
     // RPC
     metric!(RPC_REQUESTS_TOTAL, "rpc_requests_total");
@@ -73,12 +68,9 @@ pub mod names {
     metric!(CODE_FETCH_TIME, "code_fetch_time_seconds");
     metric!(WITNESS_FETCH_RPC_TIME, "witness_fetch_rpc_time_seconds");
 
-    // Database
+    // Contract cache
     metric!(CONTRACT_CACHE_HITS, "contract_cache_hits_total");
     metric!(CONTRACT_CACHE_MISSES, "contract_cache_misses_total");
-    metric!(BLOCKS_PRUNED, "blocks_pruned_total");
-    metric!(DB_EARLIEST_BLOCK, "db_earliest_block");
-    metric!(DB_LATEST_BLOCK, "db_latest_block");
 
     // Witness
     metric!(SALT_WITNESS_SIZE, "salt_witness_size_bytes");
@@ -118,10 +110,6 @@ fn register_metric_descriptions() {
 
     // Chain
     describe_gauge!(names::LOCAL_CHAIN_HEIGHT, "Local chain height");
-    describe_gauge!(names::REMOTE_CHAIN_HEIGHT, "Remote chain height");
-    describe_gauge!(names::VALIDATION_LAG, "Blocks pending validation (remote - local)");
-    describe_counter!(names::REORGS_DETECTED, "Chain reorgs detected");
-    describe_histogram!(names::REORG_DEPTH, "Reorg depth");
 
     // RPC
     describe_counter!(names::RPC_REQUESTS_TOTAL, "RPC requests made");
@@ -130,12 +118,9 @@ fn register_metric_descriptions() {
     describe_histogram!(names::CODE_FETCH_TIME, "Code fetch time (s)");
     describe_histogram!(names::WITNESS_FETCH_RPC_TIME, "Witness RPC fetch time (s)");
 
-    // Database
+    // Contract cache
     describe_counter!(names::CONTRACT_CACHE_HITS, "Contract cache hits");
     describe_counter!(names::CONTRACT_CACHE_MISSES, "Contract cache misses");
-    describe_counter!(names::BLOCKS_PRUNED, "Blocks pruned from history");
-    describe_gauge!(names::DB_EARLIEST_BLOCK, "Earliest block number in validator DB");
-    describe_gauge!(names::DB_LATEST_BLOCK, "Latest block number in validator DB");
 
     // Witness
     describe_histogram!(names::SALT_WITNESS_SIZE, "Salt witness size (bytes)");
@@ -195,15 +180,9 @@ pub fn on_worker_task_done(worker_id: usize, success: bool) {
 }
 
 // Chain metrics
-pub fn set_chain_heights(local: u64, remote: u64) {
+#[allow(dead_code)]
+pub fn set_chain_height(local: u64) {
     gauge!(names::LOCAL_CHAIN_HEIGHT).set(local as f64);
-    gauge!(names::REMOTE_CHAIN_HEIGHT).set(remote as f64);
-    gauge!(names::VALIDATION_LAG).set((remote.saturating_sub(local)) as f64);
-}
-
-pub fn on_chain_reorg(reverted_hashes: &[B256]) {
-    counter!(names::REORGS_DETECTED).increment(1);
-    histogram!(names::REORG_DEPTH).record(reverted_hashes.len() as f64);
 }
 
 // RPC metrics
@@ -237,15 +216,6 @@ pub fn on_contract_cache_read(hits: u64, misses: u64) {
     if misses > 0 {
         counter!(names::CONTRACT_CACHE_MISSES).increment(misses);
     }
-}
-
-pub fn on_blocks_pruned(count: u64) {
-    counter!(names::BLOCKS_PRUNED).increment(count);
-}
-
-pub fn set_db_block_range(earliest: u64, latest: u64) {
-    gauge!(names::DB_EARLIEST_BLOCK).set(earliest as f64);
-    gauge!(names::DB_LATEST_BLOCK).set(latest as f64);
 }
 
 /// Record witness fetch metrics.

--- a/crates/stateless-core/Cargo.toml
+++ b/crates/stateless-core/Cargo.toml
@@ -22,16 +22,17 @@ alloy-primitives.workspace = true
 alloy-provider.workspace = true
 alloy-rlp.workspace = true
 alloy-rpc-types-eth.workspace = true
-alloy-rpc-types-trace.workspace = true
 alloy-serde.workspace = true
 alloy-trie.workspace = true
 
 # misc
 base64.workspace = true
 bincode.workspace = true
+dashmap.workspace = true
 dyn-clone.workspace = true
 eyre.workspace = true
 futures.workspace = true
+kanal.workspace = true
 lz4_flex.workspace = true
 
 # megaeth 
@@ -39,7 +40,6 @@ mega-evm.workspace = true
 num_cpus.workspace = true
 op-alloy-network.workspace = true
 op-alloy-rpc-types.workspace = true
-rayon.workspace = true
 redb.workspace = true
 
 # reth
@@ -51,13 +51,12 @@ reth-trie-sparse.workspace = true
 
 # revm
 revm.workspace = true
-revm-inspectors.workspace = true
-rustc-hash.workspace = true
 salt.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
+tokio-util.workspace = true
 tracing.workspace = true
 zstd.workspace = true
 

--- a/crates/stateless-core/Cargo.toml
+++ b/crates/stateless-core/Cargo.toml
@@ -61,5 +61,8 @@ tokio.workspace = true
 tracing.workspace = true
 zstd.workspace = true
 
+[dev-dependencies]
+tempfile = "3"
+
 [features]
 test-bucket-resize = ["salt/test-bucket-resize"]

--- a/crates/stateless-core/src/chain_sync.rs
+++ b/crates/stateless-core/src/chain_sync.rs
@@ -17,7 +17,11 @@ use op_alloy_rpc_types::Transaction;
 use salt::SaltWitness;
 use tracing::{Instrument, debug, error, info, info_span, instrument, warn};
 
-use crate::{RpcClient, ValidatorDB, withdrawals::MptWitness};
+use crate::{
+    RpcClient,
+    storage_traits::{ChainState, TaskQueue},
+    withdrawals::MptWitness,
+};
 
 /// Default metrics port for Prometheus endpoint.
 pub const DEFAULT_METRICS_PORT: u16 = 9090;
@@ -111,12 +115,15 @@ pub struct FetchResult {
 /// * `Ok(FetchResult)` - Result containing fetch statistics
 /// * `Err(eyre::Error)` - On critical failures
 #[instrument(skip_all, name = "chain_sync")]
-pub async fn fetch_blocks_batch(
+pub async fn fetch_blocks_batch<DB>(
     client: &RpcClient,
-    db: &ValidatorDB,
+    db: &DB,
     config: &ChainSyncConfig,
     block_error_counts: &mut HashMap<u64, usize>,
-) -> Result<FetchResult> {
+) -> Result<FetchResult>
+where
+    DB: ChainState + TaskQueue,
+{
     let batch_start = Instant::now();
 
     // Calculate how far behind our local chain is from remote
@@ -370,7 +377,8 @@ pub async fn fetch_blocks_batch(
     let add_tasks_elapsed = db_start.elapsed();
 
     let grow_chain_start = Instant::now();
-    db.grow_remote_chain(tasks.iter().map(|(block, _, _)| &block.header))?;
+    let headers: Vec<_> = tasks.iter().map(|(block, _, _)| block.header.clone()).collect();
+    db.grow_remote_chain(&headers)?;
     let grow_chain_elapsed = grow_chain_start.elapsed();
 
     info!(
@@ -436,14 +444,15 @@ pub async fn fetch_blocks_batch(
 ///
 /// # Returns
 /// * Never returns under normal operation - runs indefinitely until externally terminated
-pub async fn remote_chain_tracker<F, G>(
+pub async fn remote_chain_tracker<DB, F, G>(
     client: Arc<RpcClient>,
-    db: Arc<ValidatorDB>,
+    db: Arc<DB>,
     config: Arc<ChainSyncConfig>,
     on_reorg: Option<F>,
     on_fetch: Option<G>,
 ) -> Result<()>
 where
+    DB: ChainState + TaskQueue + Send + Sync + 'static,
     F: Fn(&[B256]) + Send + Sync,
     G: Fn(&FetchResult) + Send + Sync,
 {
@@ -453,7 +462,7 @@ where
     let mut block_error_counts: HashMap<u64, usize> = HashMap::new();
 
     loop {
-        match fetch_blocks_batch(&client, &db, &config, &mut block_error_counts).await {
+        match fetch_blocks_batch(&client, &*db, &config, &mut block_error_counts).await {
             Ok(result) => {
                 // Call reorg callback if a reorg occurred
                 if !result.reverted_hashes.is_empty() &&
@@ -489,9 +498,9 @@ where
 /// The algorithm first exponentially expands backward to find a known-matching block,
 /// then binary searches in that range.
 #[instrument(skip(client, db), name = "find_divergence")]
-async fn find_divergence_point(
+async fn find_divergence_point<DB: ChainState>(
     client: &RpcClient,
-    db: &ValidatorDB,
+    db: &DB,
     mismatch_block: u64,
 ) -> Result<u64> {
     let earliest_local = db.get_earliest_local_block()?.expect("Local chain cannot be empty");

--- a/crates/stateless-core/src/chain_sync.rs
+++ b/crates/stateless-core/src/chain_sync.rs
@@ -10,18 +10,12 @@ use std::{
 };
 
 use alloy_primitives::B256;
-use alloy_rpc_types_eth::{Block, BlockId};
-use eyre::{Result, anyhow};
+use alloy_rpc_types_eth::BlockId;
+use eyre::Result;
 use futures::future;
-use op_alloy_rpc_types::Transaction;
-use salt::SaltWitness;
-use tracing::{Instrument, debug, error, info, info_span, instrument, warn};
+use tracing::{Instrument, debug, error, info, info_span, warn};
 
-use crate::{
-    RpcClient,
-    storage_traits::{ChainState, TaskQueue},
-    withdrawals::MptWitness,
-};
+use crate::RpcClient;
 
 /// Default metrics port for Prometheus endpoint.
 pub const DEFAULT_METRICS_PORT: u16 = 9090;
@@ -59,12 +53,23 @@ pub struct ChainSyncConfig {
     /// Enable for debug-trace-server where blocks are trusted from upstream RPC.
     /// Disable for stateless-validator where validation workers advance the tip.
     pub auto_advance_local_tip: bool,
+
+    // --- Streaming pipeline settings (used by block_fetcher / chain_advancer) ---
+    /// Channel capacity for the fetch→worker pipeline.
+    pub fetch_channel_capacity: usize,
+    /// Channel capacity for the worker→advancer pipeline.
+    pub result_channel_capacity: usize,
+    /// Number of blocks to fetch in parallel per batch.
+    pub fetcher_batch_size: usize,
+    /// Maximum RPC retry backoff for the fetcher.
+    pub fetcher_max_backoff: Duration,
 }
 
 impl Default for ChainSyncConfig {
     fn default() -> Self {
+        let workers = num_cpus::get();
         Self {
-            concurrent_workers: num_cpus::get(),
+            concurrent_workers: workers,
             sync_poll_interval: Duration::from_secs(1),
             sync_target: None,
             tracker_lookahead_blocks: 80,
@@ -78,6 +83,10 @@ impl Default for ChainSyncConfig {
             metrics_enabled: false,
             metrics_port: DEFAULT_METRICS_PORT,
             auto_advance_local_tip: false,
+            fetch_channel_capacity: 2 * workers,
+            result_channel_capacity: 2 * workers,
+            fetcher_batch_size: workers,
+            fetcher_max_backoff: Duration::from_secs(30),
         }
     }
 }
@@ -97,465 +106,258 @@ pub struct FetchResult {
     pub remote_chain_height: Option<u64>,
 }
 
-/// Fetches a batch of blocks from RPC and stores them in the database.
+// ===========================================================================
+// Streaming pipeline functions (used by stateless-validator memory-based mode)
+// ===========================================================================
+
+use std::collections::BTreeMap;
+
+use tokio_util::sync::CancellationToken;
+
+use crate::memory_db::{
+    ChainTip, PersistentStore, ValidatedBlock, ValidationFailure, ValidationTask,
+};
+
+/// Continuously fetches blocks from RPC and sends them through a channel.
 ///
-/// This function encapsulates the core logic from remote_chain_tracker:
-/// - Calculate gap between local tip and remote tip
-/// - Stop if gap >= tracker_lookahead_blocks
-/// - Fetch blocks in parallel with witness data
-/// - Store in ValidatorDB via add_validation_tasks() and grow_remote_chain()
+/// Fetches blocks sequentially starting from `start_block`, sending each
+/// `ValidationTask` to the channel. Backpressure is provided by the bounded channel.
 ///
-/// # Arguments
-/// * `client` - RPC client for fetching blocks from remote blockchain
-/// * `db` - Database interface for chain management
-/// * `config` - Configuration for tracker behavior
-/// * `block_error_counts` - Mutable map tracking error counts per block
-///
-/// # Returns
-/// * `Ok(FetchResult)` - Result containing fetch statistics
-/// * `Err(eyre::Error)` - On critical failures
-#[instrument(skip_all, name = "chain_sync")]
-pub async fn fetch_blocks_batch<DB>(
-    client: &RpcClient,
-    db: &DB,
-    config: &ChainSyncConfig,
-    block_error_counts: &mut HashMap<u64, usize>,
-) -> Result<FetchResult>
-where
-    DB: ChainState + TaskQueue,
-{
-    let batch_start = Instant::now();
-
-    // Calculate how far behind our local chain is from remote
-    let db_tip_start = Instant::now();
-    let local_tip = db.get_local_tip()?.ok_or_else(|| anyhow!("Local chain is empty"))?;
-    let remote_tip = db.get_remote_tip()?.unwrap_or(local_tip);
-    let db_tip_elapsed = db_tip_start.elapsed();
-
-    debug!(
-        local_tip = local_tip.0,
-        remote_tip = remote_tip.0,
-        db_tip_ms = db_tip_elapsed.as_millis() as u64,
-        "Got tips from DB"
-    );
-
-    // Check if local data is too stale (chain has moved far ahead)
-    // This happens when service was stopped for a long time
-    // Only applies in auto_advance mode (debug-trace-server) to avoid affecting stateless-validator
-    if config.auto_advance_local_tip {
-        let chain_latest = client.get_latest_block_number().await?;
-        let stale_threshold = config.pruner_blocks_to_keep;
-        if chain_latest > remote_tip.0 + stale_threshold {
-            warn!(
-                local_remote_tip = remote_tip.0,
-                chain_latest = chain_latest,
-                stale_threshold = stale_threshold,
-                "Local data is too stale, resetting to latest block"
-            );
-
-            // Fetch latest block header and reset anchor
-            let latest_header = client.get_header(BlockId::latest(), false).await?;
-            db.reset_anchor_block(
-                latest_header.number,
-                latest_header.hash,
-                latest_header.state_root,
-                latest_header.withdrawals_root.unwrap_or_default(),
-            )?;
-
-            info!(
-                new_anchor = latest_header.number,
-                block_hash = %latest_header.hash,
-                "Reset to latest block due to stale data"
-            );
-
-            return Ok(FetchResult {
-                blocks_fetched: 0,
-                should_wait: false,
-                had_error: false,
-                reverted_hashes: Vec::new(),
-                remote_chain_height: Some(chain_latest),
-            });
-        }
-    }
-
-    let gap = remote_tip.0.saturating_sub(local_tip.0);
-
-    // Detect and resolve chain reorgs (uses header-only RPC for efficiency)
-    match client.get_block_hash(remote_tip.0).await {
-        Ok(hash) if hash != remote_tip.1 => {
-            warn!(
-                block_number = remote_tip.0,
-                expected_hash = %remote_tip.1,
-                actual_hash = %hash,
-                "Hash mismatch detected, resolving chain divergence"
-            );
-
-            match find_divergence_point(client, db, remote_tip.0).await {
-                Ok(rollback_to) => {
-                    let reorg_depth = remote_tip.0.saturating_sub(rollback_to);
-                    warn!(
-                        rollback_to = rollback_to,
-                        reorg_depth = reorg_depth,
-                        "Rolling back chain"
-                    );
-
-                    // Collect block hashes before rollback for cache invalidation
-                    let mut reverted_hashes = Vec::with_capacity(reorg_depth as usize);
-                    for block_num in (rollback_to + 1)..=remote_tip.0 {
-                        if let Ok(Some(hash)) = db.get_block_hash(block_num) {
-                            reverted_hashes.push(hash);
-                        }
-                    }
-
-                    db.rollback_chain(rollback_to)?;
-                    return Ok(FetchResult {
-                        blocks_fetched: 0,
-                        should_wait: false,
-                        had_error: false,
-                        reverted_hashes,
-                        remote_chain_height: None,
-                    });
-                }
-                Err(e) => {
-                    error!(error = %e, "Failed to find divergence point");
-                    return Err(e);
-                }
-            }
-        }
-        Err(e) => {
-            warn!(
-                block_hash = %remote_tip.1,
-                error = %e,
-                "Network error validating tip"
-            );
-        }
-        _ => {}
-    }
-
-    // In auto-advance mode, promote existing remote chain blocks to canonical chain first
-    // This handles the case where we have pending blocks from a previous run
-    if config.auto_advance_local_tip && gap > 0 {
-        let promoted = gap.min(config.tracker_lookahead_blocks);
-        for _ in 0..promoted {
-            if !db.promote_remote_to_canonical()? {
-                break;
-            }
-        }
-        // Don't return early - continue to fetch more blocks
-    }
-
-    // Stop if we already have sufficient lookahead (only for validation mode)
-    // In auto-advance mode, we always want to fetch more blocks
-    if !config.auto_advance_local_tip && gap >= config.tracker_lookahead_blocks {
-        return Ok(FetchResult {
-            blocks_fetched: 0,
-            should_wait: true,
-            had_error: false,
-            reverted_hashes: Vec::new(),
-            remote_chain_height: None,
-        });
-    }
-
-    // Calculate how many blocks to fetch (bounded by latest available)
-    let latest_start = Instant::now();
-    let chain_latest = client.get_latest_block_number().await?;
-    let latest_elapsed = latest_start.elapsed();
-
-    debug!(
-        chain_latest = chain_latest,
-        remote_tip = remote_tip.0,
-        latest_fetch_ms = latest_elapsed.as_millis() as u64,
-        "Got chain latest"
-    );
-
-    let blocks_to_fetch =
-        (config.tracker_lookahead_blocks - gap).min(chain_latest.saturating_sub(remote_tip.0));
-
-    if blocks_to_fetch == 0 {
-        debug!(
-            chain_latest = chain_latest,
-            remote_tip = remote_tip.0,
-            gap = gap,
-            "No blocks to fetch - at chain tip"
-        );
-        return Ok(FetchResult {
-            blocks_fetched: 0,
-            should_wait: true,
-            had_error: false,
-            reverted_hashes: Vec::new(),
-            remote_chain_height: Some(chain_latest),
-        });
-    }
-
-    let start_block = remote_tip.0 + 1;
-
+/// On RPC error, retries with exponential backoff. On channel closure or shutdown, returns.
+pub async fn block_fetcher(
+    client: Arc<RpcClient>,
+    tx: kanal::Sender<ValidationTask>,
+    start_block: u64,
+    config: Arc<ChainSyncConfig>,
+    shutdown: CancellationToken,
+) -> Result<()> {
+    let tx = tx.to_async();
     info!(
         start_block = start_block,
-        end_block = start_block + blocks_to_fetch - 1,
-        blocks_to_fetch = blocks_to_fetch,
-        chain_latest = chain_latest,
-        gap_behind = chain_latest.saturating_sub(start_block),
-        "Starting block fetch batch"
+        batch_size = config.fetcher_batch_size,
+        "Starting block fetcher"
     );
 
-    // Fetch blocks in parallel
-    let fetch_start = Instant::now();
-    let tasks =
-        future::join_all((start_block..start_block + blocks_to_fetch).map(|block_number| {
+    let mut next_block = start_block;
+    let mut backoff = Duration::from_secs(1);
+    let mut block_error_counts: HashMap<u64, usize> = HashMap::new();
+
+    loop {
+        if shutdown.is_cancelled() {
+            info!("[Fetcher] Shutting down gracefully");
+            return Ok(());
+        }
+
+        // Check sync target
+        if let Some(target) = config.sync_target &&
+            next_block > target
+        {
+            info!(target = target, "[Fetcher] Reached sync target, stopping");
+            return Ok(());
+        }
+
+        // Wait until there's data to fetch (check chain latest)
+        let chain_latest = match client.get_latest_block_number().await {
+            Ok(n) => n,
+            Err(e) => {
+                warn!(error = %e, "[Fetcher] Failed to get chain latest, retrying");
+                tokio::select! {
+                    _ = tokio::time::sleep(backoff) => {}
+                    _ = shutdown.cancelled() => return Ok(()),
+                }
+                backoff = (backoff * 2).min(config.fetcher_max_backoff);
+                continue;
+            }
+        };
+
+        if next_block > chain_latest {
+            // At chain tip, wait for new blocks
+            tokio::select! {
+                _ = tokio::time::sleep(config.tracker_poll_interval) => {}
+                _ = shutdown.cancelled() => return Ok(()),
+            }
+            continue;
+        }
+
+        // Calculate batch size
+        let blocks_available = chain_latest - next_block + 1;
+        let batch_size = (config.fetcher_batch_size as u64).min(blocks_available);
+
+        debug!(
+            next_block = next_block,
+            batch_size = batch_size,
+            chain_latest = chain_latest,
+            "[Fetcher] Fetching batch"
+        );
+
+        // Fetch blocks in parallel
+        let fetch_start = Instant::now();
+        let results = future::join_all((next_block..next_block + batch_size).map(|block_number| {
             let client = client.clone();
             async move {
                 let block_hash = client.get_block_hash(block_number).await?;
                 let (salt_witness, mpt_witness) =
                     client.get_witness(block_number, block_hash).await?;
                 let block = client.get_block(BlockId::Number(block_number.into()), true).await?;
-
-                Ok::<(Block<Transaction>, SaltWitness, MptWitness), eyre::Error>((
-                    block,
-                    salt_witness,
-                    mpt_witness,
-                ))
+                Ok::<_, eyre::Error>(ValidationTask { block, salt_witness, mpt_witness })
             }
             .instrument(info_span!("fetch_block", block_number = block_number))
         }))
-        .await
-        .into_iter()
-        .enumerate()
-        // Stop on first error to maintain block sequence contiguity
-        .take_while(|(i, result)| match result {
-            Ok(_) => {
-                block_error_counts.remove(&(start_block + *i as u64));
-                true
-            }
-            Err(e) => {
-                let block_number = start_block + *i as u64;
-                let count = block_error_counts.entry(block_number).or_insert(0);
-                *count += 1;
+        .await;
 
-                // Only log errors after repeated failures (witness delay is expected)
-                if *count > 5 {
-                    error!(
-                        block_number = block_number,
-                        attempt = *count,
-                        error = %e,
-                        "Block fetch error (repeated)"
-                    );
+        // Process results in order, stop on first error
+        let mut fetched = 0u64;
+        for (i, result) in results.into_iter().enumerate() {
+            match result {
+                Ok(task) => {
+                    block_error_counts.remove(&(next_block + i as u64));
+
+                    // Send to channel (blocks if full — backpressure)
+                    if tx.send(task).await.is_err() {
+                        info!("[Fetcher] Channel closed, stopping");
+                        return Ok(());
+                    }
+                    fetched += 1;
                 }
-                false
+                Err(e) => {
+                    let block_number = next_block + i as u64;
+                    let count = block_error_counts.entry(block_number).or_insert(0);
+                    *count += 1;
+                    if *count > 5 {
+                        error!(
+                            block_number = block_number,
+                            attempt = *count,
+                            error = %e,
+                            "[Fetcher] Block fetch error (repeated)"
+                        );
+                    }
+                    break;
+                }
             }
-        })
-        .filter_map(|(_, result)| result.ok())
-        .collect::<Vec<_>>();
-
-    let fetched_count = tasks.len() as u64;
-    let had_error = fetched_count < blocks_to_fetch;
-    let fetch_elapsed = fetch_start.elapsed();
-
-    info!(
-        blocks_fetched = fetched_count,
-        blocks_requested = blocks_to_fetch,
-        fetch_ms = fetch_elapsed.as_millis() as u64,
-        had_error = had_error,
-        "Parallel fetch completed"
-    );
-
-    // Store block data and witnesses
-    // In stateless-validator mode: add to validation task queue
-    // In debug-trace-server mode: only store data for trace RPCs (no validation)
-    let db_start = Instant::now();
-    if config.auto_advance_local_tip {
-        // Convert SaltWitness to LightWitness for efficient storage
-        let light_tasks: Vec<_> = tasks
-            .iter()
-            .map(|(block, salt_witness, _)| {
-                (block.clone(), crate::LightWitness::from(salt_witness.clone()))
-            })
-            .collect();
-        db.store_block_data(&light_tasks)?;
-    } else {
-        db.add_validation_tasks(&tasks)?;
-    }
-    let add_tasks_elapsed = db_start.elapsed();
-
-    let grow_chain_start = Instant::now();
-    let headers: Vec<_> = tasks.iter().map(|(block, _, _)| block.header.clone()).collect();
-    db.grow_remote_chain(&headers)?;
-    let grow_chain_elapsed = grow_chain_start.elapsed();
-
-    info!(
-        add_tasks_ms = add_tasks_elapsed.as_millis() as u64,
-        grow_chain_ms = grow_chain_elapsed.as_millis() as u64,
-        "DB operations completed"
-    );
-
-    // Auto-advance local tip if configured (for debug-trace-server mode)
-    // This skips validation and trusts blocks from upstream RPC
-    if config.auto_advance_local_tip && fetched_count > 0 {
-        let new_local_tip = start_block + fetched_count - 1;
-        let promote_start = Instant::now();
-        for _ in 0..fetched_count {
-            db.promote_remote_to_canonical()?;
         }
-        let promote_elapsed = promote_start.elapsed();
 
-        // Get the earliest block in DB for logging
-        let earliest = db.get_earliest_local_block()?.map(|(n, _)| n).unwrap_or(0);
-
-        // Calculate blocks per second using total batch time
-        let total_elapsed = batch_start.elapsed();
-        let total_ms = total_elapsed.as_millis() as f64;
-        let blocks_per_sec =
-            if total_ms > 0.0 { (fetched_count as f64 * 1000.0) / total_ms } else { 0.0 };
-
-        info!(
-            db_start = earliest,
-            db_end = new_local_tip,
-            synced_blocks = fetched_count,
-            total_ms = total_ms as u64,
-            fetch_ms = fetch_elapsed.as_millis() as u64,
-            db_write_ms = (add_tasks_elapsed.as_millis() + grow_chain_elapsed.as_millis()) as u64,
-            promote_ms = promote_elapsed.as_millis() as u64,
-            blocks_per_sec = format!("{:.2}", blocks_per_sec),
-            "Chain synced"
-        );
+        if fetched > 0 {
+            let elapsed = fetch_start.elapsed();
+            info!(
+                blocks = fetched,
+                start = next_block,
+                end = next_block + fetched - 1,
+                ms = elapsed.as_millis() as u64,
+                "[Fetcher] Batch sent to pipeline"
+            );
+            next_block += fetched;
+            backoff = Duration::from_secs(1); // reset backoff on success
+        } else {
+            // All blocks in batch failed, backoff
+            tokio::select! {
+                _ = tokio::time::sleep(backoff) => {}
+                _ = shutdown.cancelled() => return Ok(()),
+            }
+            backoff = (backoff * 2).min(config.fetcher_max_backoff);
+        }
     }
-
-    Ok(FetchResult {
-        blocks_fetched: fetched_count,
-        should_wait: false,
-        had_error,
-        reverted_hashes: Vec::new(),
-        remote_chain_height: Some(chain_latest),
-    })
 }
 
-/// Remote chain tracker that maintains a lookahead of unvalidated blocks.
+/// Collects validation results and advances the canonical chain in block-number order.
 ///
-/// Runs in an infinite loop, monitoring the gap between local canonical tip and remote
-/// tip to maintain a sufficient buffer of unvalidated blocks for validation workers.
-/// Infrastructure errors (RPC failures, network issues) are logged and contained.
+/// Receives results from workers (potentially out of order), buffers them,
+/// and advances the canonical tip in strict sequence. Batches multiple consecutive
+/// blocks into a single persistence write.
 ///
-/// # Arguments
-/// * `client` - RPC client for fetching blocks from remote blockchain
-/// * `validator_db` - Database interface for chain management
-/// * `config` - Configuration for tracker behavior
-/// * `on_reorg` - Optional callback invoked when a chain reorg is detected, receives reverted block
-///   hashes
-/// * `on_fetch` - Optional callback invoked after each successful fetch batch with the result
-///
-/// # Returns
-/// * Never returns under normal operation - runs indefinitely until externally terminated
-pub async fn remote_chain_tracker<DB, F, G>(
-    client: Arc<RpcClient>,
-    db: Arc<DB>,
-    config: Arc<ChainSyncConfig>,
-    on_reorg: Option<F>,
-    on_fetch: Option<G>,
-) -> Result<()>
-where
-    DB: ChainState + TaskQueue + Send + Sync + 'static,
-    F: Fn(&[B256]) + Send + Sync,
-    G: Fn(&FetchResult) + Send + Sync,
-{
-    info!(lookahead_blocks = config.tracker_lookahead_blocks, "Starting remote chain tracker");
+/// If any validation fails, returns `Err` immediately (process should exit).
+pub async fn chain_advancer(
+    rx: kanal::Receiver<std::result::Result<ValidatedBlock, ValidationFailure>>,
+    store: Arc<PersistentStore>,
+    initial_tip: ChainTip,
+    shutdown: CancellationToken,
+) -> Result<()> {
+    let rx = rx.to_async();
+    let mut next_expected = initial_tip.block_number + 1;
+    let mut current_tip = initial_tip;
+    let mut buffer: BTreeMap<u64, ValidatedBlock> = BTreeMap::new();
 
-    // Track error counts for each block
-    let mut block_error_counts: HashMap<u64, usize> = HashMap::new();
+    info!(start_block = next_expected, "[Advancer] Starting chain advancer");
 
     loop {
-        match fetch_blocks_batch(&client, &*db, &config, &mut block_error_counts).await {
-            Ok(result) => {
-                // Call reorg callback if a reorg occurred
-                if !result.reverted_hashes.is_empty() &&
-                    let Some(ref callback) = on_reorg
-                {
-                    callback(&result.reverted_hashes);
+        // Receive next result
+        let result = tokio::select! {
+            r = rx.recv() => match r {
+                Ok(r) => r,
+                Err(_) => {
+                    info!("[Advancer] Channel closed, stopping");
+                    return Ok(());
                 }
-
-                // Call fetch callback with the result
-                if let Some(ref callback) = on_fetch {
-                    callback(&result);
-                }
-
-                if result.had_error {
-                    tokio::time::sleep(config.tracker_error_sleep).await;
-                } else if result.should_wait || result.blocks_fetched == 0 {
-                    tokio::time::sleep(config.tracker_poll_interval).await;
-                }
+            },
+            _ = shutdown.cancelled() => {
+                info!("[Advancer] Shutting down gracefully");
+                return Ok(());
             }
-            Err(e) => {
-                warn!(error = %e, "Sync iteration failed");
-                tokio::time::sleep(config.tracker_error_sleep).await;
+        };
+
+        match result {
+            Err(failure) => {
+                error!(
+                    block_number = failure.block_number,
+                    block_hash = %failure.block_hash,
+                    error = %failure.error,
+                    "[Advancer] Validation failed, terminating"
+                );
+                return Err(eyre::eyre!(
+                    "Block {} ({}) validation failed: {}",
+                    failure.block_number,
+                    failure.block_hash,
+                    failure.error
+                ));
+            }
+            Ok(validated) => {
+                debug!(
+                    block_number = validated.block_number,
+                    "[Advancer] Received validated block"
+                );
+                buffer.insert(validated.block_number, validated);
             }
         }
-    }
-}
 
-/// Finds where the local chain diverges from the remote RPC node using exponential search.
-///
-/// Uses exponential search to efficiently locate where the local canonical chain diverges
-/// from the remote chain. Exponential search is more efficient than binary search for reorgs
-/// since they typically occur near the chain tip (non-uniform distribution).
-/// The algorithm first exponentially expands backward to find a known-matching block,
-/// then binary searches in that range.
-#[instrument(skip(client, db), name = "find_divergence")]
-async fn find_divergence_point<DB: ChainState>(
-    client: &RpcClient,
-    db: &DB,
-    mismatch_block: u64,
-) -> Result<u64> {
-    let earliest_local = db.get_earliest_local_block()?.expect("Local chain cannot be empty");
+        // Drain consecutive blocks from buffer
+        let mut advanced = 0u64;
+        while let Some(validated) = buffer.remove(&next_expected) {
+            // Verify state root continuity
+            if validated.pre_state_root != current_tip.post_state_root {
+                return Err(eyre::eyre!(
+                    "Block {} pre_state_root mismatch: expected {:?}, got {:?}",
+                    validated.block_number,
+                    current_tip.post_state_root,
+                    validated.pre_state_root
+                ));
+            }
+            if validated.pre_withdrawals_root != current_tip.post_withdrawals_root {
+                return Err(eyre::eyre!(
+                    "Block {} pre_withdrawals_root mismatch: expected {:?}, got {:?}",
+                    validated.block_number,
+                    current_tip.post_withdrawals_root,
+                    validated.pre_withdrawals_root
+                ));
+            }
 
-    // Safety check: verify earliest block matches remote chain
-    let earliest_remote_hash = client.get_block_hash(earliest_local.0).await?;
-    if earliest_remote_hash != earliest_local.1 {
-        return Err(anyhow!(
-            "Catastrophic reorg: earliest local block {} hash mismatch (local: {:?}, remote: {:?})",
-            earliest_local.0,
-            earliest_local.1,
-            earliest_remote_hash
-        ));
-    }
+            current_tip = ChainTip {
+                block_number: validated.block_number,
+                block_hash: validated.block_hash,
+                post_state_root: validated.post_state_root,
+                post_withdrawals_root: validated.post_withdrawals_root,
+            };
+            next_expected += 1;
+            advanced += 1;
+        }
 
-    // Exponential search: find a matching block by exponentially increasing distance from tip
-    let mut step = 1u64;
-    let mut last_mismatch = mismatch_block;
-    let mut search_start = earliest_local.0;
-
-    while last_mismatch > earliest_local.0 {
-        let check_block = last_mismatch.saturating_sub(step).max(earliest_local.0);
-        let local_hash = db.get_block_hash(check_block)?.unwrap();
-        let remote_hash = client.get_block_hash(check_block).await?;
-
-        if remote_hash == local_hash {
-            // Found a matching block, search between here and last_mismatch
-            search_start = check_block;
-            break;
-        } else {
-            // Keep expanding backwards
-            last_mismatch = check_block;
-            step *= 2;
+        // Batch-persist the new tip if any blocks were advanced
+        if advanced > 0 {
+            store.set_canonical_tip(&current_tip)?;
+            info!(
+                tip = current_tip.block_number,
+                advanced = advanced,
+                buffered = buffer.len(),
+                "[Advancer] Chain advanced"
+            );
         }
     }
-
-    // Binary search between search_start and last_mismatch
-    let (mut left, mut right, mut last_matching) = (search_start, last_mismatch, search_start);
-    while left <= right {
-        let mid = left + (right - left) / 2;
-        let local_hash = db.get_block_hash(mid)?.unwrap();
-        let remote_hash = client.get_block_hash(mid).await?;
-        if remote_hash == local_hash {
-            last_matching = mid;
-            left = mid + 1;
-        } else {
-            right = mid.saturating_sub(1);
-        }
-    }
-
-    debug!(
-        divergence_point = last_matching,
-        mismatch_block = mismatch_block,
-        "Found divergence point"
-    );
-
-    Ok(last_matching)
 }

--- a/crates/stateless-core/src/database.rs
+++ b/crates/stateless-core/src/database.rs
@@ -22,10 +22,7 @@ use salt::{
 };
 use tracing::trace;
 
-use crate::{
-    data_types::{PlainKey, PlainValue},
-    light_witness::LightWitness,
-};
+use crate::data_types::{PlainKey, PlainValue};
 
 /// Error type for witness database operations
 #[derive(Debug, Clone)]
@@ -247,23 +244,6 @@ impl WitnessExternalEnv {
         })?;
 
         Ok((bucket_id, meta.capacity))
-    }
-
-    /// Creates a new external environment provider from a LightWitness.
-    ///
-    /// This is the fast version of `new()` that works with `LightWitness`
-    /// for improved deserialization performance.
-    pub fn from_light_witness(
-        light_witness: &LightWitness,
-        block_number: BlockNumber,
-    ) -> Result<Self, WitnessDatabaseError> {
-        let bucket_capacities = light_witness
-            .kvs
-            .range(METADATA_KEYS_RANGE)
-            .map(|(key, value)| Self::parse_metadata_entry(key, value))
-            .collect::<Result<HashMap<_, _>, _>>()?;
-
-        Ok(Self { block_number, bucket_capacities })
     }
 }
 

--- a/crates/stateless-core/src/lib.rs
+++ b/crates/stateless-core/src/lib.rs
@@ -18,27 +18,26 @@
 
 pub mod chain_spec;
 pub mod chain_sync;
-pub mod light_witness;
 pub use chain_sync::{
-    ChainSyncConfig, DEFAULT_METRICS_PORT, FetchResult, fetch_blocks_batch, remote_chain_tracker,
+    ChainSyncConfig, DEFAULT_METRICS_PORT, FetchResult, block_fetcher, chain_advancer,
 };
-pub use light_witness::{LightWitness, LightWitnessExecutor};
 pub mod database;
+pub mod light_witness;
 pub use database::{WitnessDatabase, WitnessDatabaseError, WitnessExternalEnv};
+pub mod data_types;
+pub use data_types::{PlainKey, PlainValue};
+pub mod memory_db;
+pub use light_witness::{LightWitness, LightWitnessExecutor};
+pub use memory_db::{
+    ChainTip, ContractCache, PersistentStore, ValidatedBlock, ValidationFailure, ValidationTask,
+};
 pub mod storage_traits;
 pub use storage_traits::{BlockDataStore, ChainState, TaskQueue, ValidationResultStore};
 pub mod validator_db;
 pub use validator_db::{ValidationDbError, ValidationDbResult, ValidatorDB};
-pub mod data_types;
-pub use data_types::{PlainKey, PlainValue};
 pub mod executor;
 pub use executor::{
     ValidationError, ValidationResult, ValidationStats, replay_block, validate_block,
-};
-pub mod tracing_executor;
-pub use tracing_executor::{
-    extract_code_hashes, parity_trace_block, parity_trace_transaction, trace_block,
-    trace_transaction,
 };
 pub mod rpc_client;
 pub mod withdrawals;

--- a/crates/stateless-core/src/lib.rs
+++ b/crates/stateless-core/src/lib.rs
@@ -25,6 +25,8 @@ pub use chain_sync::{
 pub use light_witness::{LightWitness, LightWitnessExecutor};
 pub mod database;
 pub use database::{WitnessDatabase, WitnessDatabaseError, WitnessExternalEnv};
+pub mod storage_traits;
+pub use storage_traits::{BlockDataStore, ChainState, TaskQueue, ValidationResultStore};
 pub mod validator_db;
 pub use validator_db::{ValidationDbError, ValidationDbResult, ValidatorDB};
 pub mod data_types;

--- a/crates/stateless-core/src/memory_db.rs
+++ b/crates/stateless-core/src/memory_db.rs
@@ -1,0 +1,531 @@
+//! Memory-based pipeline database for stateless validation.
+//!
+//! This module provides a lightweight persistence layer and in-memory data structures
+//! for the streaming validation pipeline. Only three categories of data are persisted:
+//! - **Anchor block**: The trusted starting point for validation
+//! - **Canonical tip**: The last successfully validated block
+//! - **Contracts**: Immutable bytecode cache (content-addressed, grows monotonically)
+//!
+//! Block and witness data flows through in-memory channels and is never written to disk.
+
+use std::{collections::HashMap, path::Path, sync::Arc};
+
+use alloy_genesis::Genesis;
+use alloy_primitives::{B256, BlockHash, BlockNumber};
+use alloy_rpc_types_eth::Block;
+use dashmap::DashMap;
+use eyre::Result;
+use op_alloy_rpc_types::Transaction;
+use redb::{Database, ReadableDatabase, TableDefinition};
+use revm::state::Bytecode;
+use salt::SaltWitness;
+
+use crate::withdrawals::MptWitness;
+
+// ---------------------------------------------------------------------------
+// redb table definitions (4 tables total)
+// ---------------------------------------------------------------------------
+
+/// Trusted anchor block. Singleton key "anchor".
+/// Value: (block_number, block_hash, post_state_root, post_withdrawals_root)
+#[allow(clippy::type_complexity)]
+const ANCHOR_BLOCK: TableDefinition<&str, (u64, [u8; 32], [u8; 32], [u8; 32])> =
+    TableDefinition::new("anchor_block");
+
+/// Last successfully validated block. Singleton key "tip".
+/// Value: (block_number, block_hash, post_state_root, post_withdrawals_root)
+#[allow(clippy::type_complexity)]
+const CANONICAL_TIP: TableDefinition<&str, (u64, [u8; 32], [u8; 32], [u8; 32])> =
+    TableDefinition::new("canonical_tip");
+
+/// Contract bytecode cache. Key: code_hash, Value: bincode+lz4 serialized Bytecode.
+const CONTRACTS: TableDefinition<[u8; 32], Vec<u8>> = TableDefinition::new("contracts");
+
+/// Genesis configuration (write-once). Singleton key "genesis", Value: JSON bytes.
+const GENESIS_CONFIG: TableDefinition<&str, Vec<u8>> = TableDefinition::new("genesis_config");
+
+// ---------------------------------------------------------------------------
+// ChainTip — shared type for anchor and canonical tip
+// ---------------------------------------------------------------------------
+
+/// Represents a point on the chain with its state roots.
+///
+/// Used for both the trusted anchor block and the canonical chain tip.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChainTip {
+    pub block_number: BlockNumber,
+    pub block_hash: BlockHash,
+    pub post_state_root: B256,
+    pub post_withdrawals_root: B256,
+}
+
+impl ChainTip {
+    fn to_tuple(&self) -> (u64, [u8; 32], [u8; 32], [u8; 32]) {
+        (self.block_number, self.block_hash.0, self.post_state_root.0, self.post_withdrawals_root.0)
+    }
+
+    fn from_tuple(t: (u64, [u8; 32], [u8; 32], [u8; 32])) -> Self {
+        Self {
+            block_number: t.0,
+            block_hash: BlockHash::from(t.1),
+            post_state_root: B256::from(t.2),
+            post_withdrawals_root: B256::from(t.3),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Pipeline data types
+// ---------------------------------------------------------------------------
+
+/// Block with all data needed for validation, flowing through the fetch→worker channel.
+pub struct ValidationTask {
+    pub block: Block<Transaction>,
+    pub salt_witness: SaltWitness,
+    pub mpt_witness: MptWitness,
+}
+
+/// Result of successfully validating a block, flowing through the worker→advancer channel.
+#[derive(Debug, Clone)]
+pub struct ValidatedBlock {
+    pub block_number: BlockNumber,
+    pub block_hash: BlockHash,
+    pub post_state_root: B256,
+    pub post_withdrawals_root: B256,
+    pub pre_state_root: B256,
+    pub pre_withdrawals_root: B256,
+}
+
+/// Validation failure sent from worker to advancer.
+#[derive(Debug)]
+pub struct ValidationFailure {
+    pub block_number: BlockNumber,
+    pub block_hash: BlockHash,
+    pub error: String,
+}
+
+// ---------------------------------------------------------------------------
+// Serialization helpers (bincode + lz4, matching validator_db.rs format)
+// ---------------------------------------------------------------------------
+
+const BINCODE_LZ4_MARKER: u8 = 0x02;
+
+fn encode_bytecode(bytecode: &Bytecode) -> Result<Vec<u8>> {
+    let encoded = bincode::serde::encode_to_vec(bytecode, bincode::config::standard())
+        .map_err(|e| eyre::eyre!("bincode encode: {e}"))?;
+    let compressed = lz4_flex::compress_prepend_size(&encoded);
+    let mut result = Vec::with_capacity(1 + compressed.len());
+    result.push(BINCODE_LZ4_MARKER);
+    result.extend(compressed);
+    Ok(result)
+}
+
+fn decode_bytecode(bytes: &[u8]) -> Bytecode {
+    assert!(!bytes.is_empty(), "cannot deserialize empty bytecode data");
+    match bytes[0] {
+        BINCODE_LZ4_MARKER => {
+            let decompressed = lz4_flex::decompress_size_prepended(&bytes[1..])
+                .expect("lz4 decompression must succeed");
+            let (decoded, _) =
+                bincode::serde::decode_from_slice(&decompressed, bincode::config::standard())
+                    .expect("bytecode deserialization must succeed");
+            decoded
+        }
+        0x01 => {
+            // standard (uncompressed) format
+            let (decoded, _) =
+                bincode::serde::decode_from_slice(&bytes[1..], bincode::config::standard())
+                    .expect("bytecode deserialization must succeed");
+            decoded
+        }
+        _ => {
+            // legacy format
+            let (decoded, _) = bincode::serde::decode_from_slice(bytes, bincode::config::legacy())
+                .expect("bytecode deserialization must succeed");
+            decoded
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// PersistentStore
+// ---------------------------------------------------------------------------
+
+/// Minimal persistent storage backed by redb.
+///
+/// Only stores data that must survive restarts: anchor block, canonical tip,
+/// contract bytecodes, and genesis configuration.
+pub struct PersistentStore {
+    database: Database,
+}
+
+impl PersistentStore {
+    /// Creates or opens a persistent store at the given path.
+    pub fn new(db_path: impl AsRef<Path>) -> Result<Self> {
+        let database = Database::create(db_path)?;
+
+        // Initialize all tables
+        let write_txn = database.begin_write()?;
+        {
+            let _ = write_txn.open_table(ANCHOR_BLOCK)?;
+            let _ = write_txn.open_table(CANONICAL_TIP)?;
+            let _ = write_txn.open_table(CONTRACTS)?;
+            let _ = write_txn.open_table(GENESIS_CONFIG)?;
+        }
+        write_txn.commit()?;
+
+        Ok(Self { database })
+    }
+
+    // -- Anchor block --
+
+    /// Returns the stored anchor block, or `None` if not set.
+    pub fn get_anchor_block(&self) -> Result<Option<ChainTip>> {
+        let read_txn = self.database.begin_read()?;
+        let table = read_txn.open_table(ANCHOR_BLOCK)?;
+        Ok(table.get("anchor")?.map(|v| ChainTip::from_tuple(v.value())))
+    }
+
+    /// Stores the anchor block.
+    pub fn set_anchor_block(&self, tip: &ChainTip) -> Result<()> {
+        let write_txn = self.database.begin_write()?;
+        {
+            let mut table = write_txn.open_table(ANCHOR_BLOCK)?;
+            table.insert("anchor", tip.to_tuple())?;
+        }
+        write_txn.commit()?;
+        Ok(())
+    }
+
+    // -- Canonical tip --
+
+    /// Returns the last validated canonical tip, or `None` if not set.
+    pub fn get_canonical_tip(&self) -> Result<Option<ChainTip>> {
+        let read_txn = self.database.begin_read()?;
+        let table = read_txn.open_table(CANONICAL_TIP)?;
+        Ok(table.get("tip")?.map(|v| ChainTip::from_tuple(v.value())))
+    }
+
+    /// Updates the canonical tip to the given validated block.
+    pub fn set_canonical_tip(&self, tip: &ChainTip) -> Result<()> {
+        let write_txn = self.database.begin_write()?;
+        {
+            let mut table = write_txn.open_table(CANONICAL_TIP)?;
+            table.insert("tip", tip.to_tuple())?;
+        }
+        write_txn.commit()?;
+        Ok(())
+    }
+
+    // -- Contracts --
+
+    /// Retrieves cached contract bytecodes.
+    ///
+    /// Returns `(found, missing)` where `found` maps code hashes to bytecodes
+    /// and `missing` lists code hashes not in the cache.
+    pub fn get_contracts(&self, hashes: &[B256]) -> Result<(HashMap<B256, Bytecode>, Vec<B256>)> {
+        let read_txn = self.database.begin_read()?;
+        let table = read_txn.open_table(CONTRACTS)?;
+
+        let mut found = HashMap::new();
+        let mut missing = Vec::new();
+
+        for &hash in hashes {
+            match table.get(hash.0)? {
+                Some(data) => {
+                    found.insert(hash, decode_bytecode(data.value().as_slice()));
+                }
+                None => missing.push(hash),
+            }
+        }
+
+        Ok((found, missing))
+    }
+
+    /// Stores contract bytecodes in the cache.
+    pub fn add_contracts(&self, codes: &[(B256, Bytecode)]) -> Result<()> {
+        if codes.is_empty() {
+            return Ok(());
+        }
+        let write_txn = self.database.begin_write()?;
+        {
+            let mut table = write_txn.open_table(CONTRACTS)?;
+            for (hash, bytecode) in codes {
+                let encoded = encode_bytecode(bytecode)?;
+                table.insert(hash.0, encoded)?;
+            }
+        }
+        write_txn.commit()?;
+        Ok(())
+    }
+
+    // -- Genesis --
+
+    /// Persists the genesis configuration as JSON.
+    pub fn store_genesis(&self, genesis: &Genesis) -> Result<()> {
+        let json_bytes = serde_json::to_vec(genesis)?;
+        let write_txn = self.database.begin_write()?;
+        {
+            let mut table = write_txn.open_table(GENESIS_CONFIG)?;
+            table.insert("genesis", json_bytes)?;
+        }
+        write_txn.commit()?;
+        Ok(())
+    }
+
+    /// Loads the genesis configuration, or `None` if not stored yet.
+    pub fn load_genesis(&self) -> Result<Option<Genesis>> {
+        let read_txn = self.database.begin_read()?;
+        let table = read_txn.open_table(GENESIS_CONFIG)?;
+        match table.get("genesis")? {
+            Some(data) => {
+                let genesis: Genesis = serde_json::from_slice(data.value().as_slice())?;
+                Ok(Some(genesis))
+            }
+            None => Ok(None),
+        }
+    }
+
+    // -- Reset --
+
+    /// Resets the store to a new anchor, setting the canonical tip to match the anchor.
+    pub fn reset_to_anchor(&self, anchor: &ChainTip) -> Result<()> {
+        let write_txn = self.database.begin_write()?;
+        {
+            let mut anchor_table = write_txn.open_table(ANCHOR_BLOCK)?;
+            anchor_table.insert("anchor", anchor.to_tuple())?;
+
+            let mut tip_table = write_txn.open_table(CANONICAL_TIP)?;
+            tip_table.insert("tip", anchor.to_tuple())?;
+        }
+        write_txn.commit()?;
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ContractCache — DashMap with persistent write-through
+// ---------------------------------------------------------------------------
+
+/// In-memory contract bytecode cache backed by persistent storage.
+///
+/// Reads check the in-memory `DashMap` first, falling back to the persistent store.
+/// Writes go to both memory and disk (write-through).
+pub struct ContractCache {
+    memory: DashMap<B256, Bytecode>,
+    store: Arc<PersistentStore>,
+}
+
+impl ContractCache {
+    /// Creates a new contract cache backed by the given persistent store.
+    pub fn new(store: Arc<PersistentStore>) -> Self {
+        Self { memory: DashMap::new(), store }
+    }
+
+    /// Retrieves contract bytecodes, checking memory first then persistent store.
+    ///
+    /// Returns `(found, missing)`.
+    pub fn get(&self, hashes: &[B256]) -> Result<(HashMap<B256, Bytecode>, Vec<B256>)> {
+        let mut found = HashMap::new();
+        let mut not_in_memory = Vec::new();
+
+        for &hash in hashes {
+            if let Some(entry) = self.memory.get(&hash) {
+                found.insert(hash, entry.value().clone());
+            } else {
+                not_in_memory.push(hash);
+            }
+        }
+
+        if not_in_memory.is_empty() {
+            return Ok((found, Vec::new()));
+        }
+
+        // Check persistent store for remaining
+        let (from_disk, missing) = self.store.get_contracts(&not_in_memory)?;
+
+        // Populate memory cache with disk hits
+        for (hash, bytecode) in &from_disk {
+            self.memory.insert(*hash, bytecode.clone());
+        }
+        found.extend(from_disk);
+
+        Ok((found, missing))
+    }
+
+    /// Adds contract bytecodes to both memory cache and persistent store (write-through).
+    pub fn insert(&self, codes: &[(B256, Bytecode)]) -> Result<()> {
+        if codes.is_empty() {
+            return Ok(());
+        }
+
+        // Write to persistent store first
+        self.store.add_contracts(codes)?;
+
+        // Then update memory cache
+        for (hash, bytecode) in codes {
+            self.memory.insert(*hash, bytecode.clone());
+        }
+
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_store() -> (tempfile::TempDir, PersistentStore) {
+        let dir = tempfile::tempdir().unwrap();
+        let store = PersistentStore::new(dir.path().join("test.redb")).unwrap();
+        (dir, store)
+    }
+
+    #[test]
+    fn test_anchor_block_roundtrip() {
+        let (_dir, store) = temp_store();
+
+        assert!(store.get_anchor_block().unwrap().is_none());
+
+        let tip = ChainTip {
+            block_number: 42,
+            block_hash: BlockHash::from([1u8; 32]),
+            post_state_root: B256::from([2u8; 32]),
+            post_withdrawals_root: B256::from([3u8; 32]),
+        };
+        store.set_anchor_block(&tip).unwrap();
+
+        let loaded = store.get_anchor_block().unwrap().unwrap();
+        assert_eq!(loaded, tip);
+    }
+
+    #[test]
+    fn test_canonical_tip_roundtrip() {
+        let (_dir, store) = temp_store();
+
+        assert!(store.get_canonical_tip().unwrap().is_none());
+
+        let tip = ChainTip {
+            block_number: 100,
+            block_hash: BlockHash::from([10u8; 32]),
+            post_state_root: B256::from([20u8; 32]),
+            post_withdrawals_root: B256::from([30u8; 32]),
+        };
+        store.set_canonical_tip(&tip).unwrap();
+
+        let loaded = store.get_canonical_tip().unwrap().unwrap();
+        assert_eq!(loaded, tip);
+
+        // Update tip
+        let tip2 = ChainTip { block_number: 101, ..tip };
+        store.set_canonical_tip(&tip2).unwrap();
+        let loaded2 = store.get_canonical_tip().unwrap().unwrap();
+        assert_eq!(loaded2.block_number, 101);
+    }
+
+    #[test]
+    fn test_contracts_roundtrip() {
+        let (_dir, store) = temp_store();
+
+        let hash1 = B256::from([1u8; 32]);
+        let hash2 = B256::from([2u8; 32]);
+        let hash3 = B256::from([3u8; 32]);
+
+        let bytecode1 = Bytecode::new_raw(alloy_primitives::Bytes::from_static(&[0x60, 0x00]));
+        let bytecode2 = Bytecode::new_raw(alloy_primitives::Bytes::from_static(&[0x60, 0x01]));
+
+        store.add_contracts(&[(hash1, bytecode1.clone()), (hash2, bytecode2.clone())]).unwrap();
+
+        let (found, missing) = store.get_contracts(&[hash1, hash2, hash3]).unwrap();
+        assert_eq!(found.len(), 2);
+        assert_eq!(missing, vec![hash3]);
+        assert_eq!(found[&hash1].bytes_slice(), bytecode1.bytes_slice());
+        assert_eq!(found[&hash2].bytes_slice(), bytecode2.bytes_slice());
+    }
+
+    #[test]
+    fn test_genesis_roundtrip() {
+        let (_dir, store) = temp_store();
+
+        assert!(store.load_genesis().unwrap().is_none());
+
+        let genesis = Genesis::default();
+        store.store_genesis(&genesis).unwrap();
+
+        let loaded = store.load_genesis().unwrap().unwrap();
+        assert_eq!(loaded.config.chain_id, genesis.config.chain_id);
+    }
+
+    #[test]
+    fn test_reset_to_anchor() {
+        let (_dir, store) = temp_store();
+
+        let anchor = ChainTip {
+            block_number: 50,
+            block_hash: BlockHash::from([5u8; 32]),
+            post_state_root: B256::from([6u8; 32]),
+            post_withdrawals_root: B256::from([7u8; 32]),
+        };
+
+        // Set an advanced tip
+        let tip = ChainTip { block_number: 100, ..anchor.clone() };
+        store.set_canonical_tip(&tip).unwrap();
+
+        // Reset to anchor
+        store.reset_to_anchor(&anchor).unwrap();
+
+        let loaded_anchor = store.get_anchor_block().unwrap().unwrap();
+        let loaded_tip = store.get_canonical_tip().unwrap().unwrap();
+        assert_eq!(loaded_anchor, anchor);
+        assert_eq!(loaded_tip, anchor);
+    }
+
+    #[test]
+    fn test_contract_cache_memory_hit() {
+        let (_dir, store) = temp_store();
+        let cache = ContractCache::new(Arc::new(store));
+
+        let hash = B256::from([1u8; 32]);
+        let bytecode = Bytecode::new_raw(alloy_primitives::Bytes::from_static(&[0x60, 0x00]));
+
+        cache.insert(&[(hash, bytecode.clone())]).unwrap();
+
+        // Should hit memory, not disk
+        let (found, missing) = cache.get(&[hash]).unwrap();
+        assert_eq!(found.len(), 1);
+        assert!(missing.is_empty());
+        assert_eq!(found[&hash].bytes_slice(), bytecode.bytes_slice());
+    }
+
+    #[test]
+    fn test_contract_cache_disk_fallback() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.redb");
+
+        let hash = B256::from([1u8; 32]);
+        let bytecode = Bytecode::new_raw(alloy_primitives::Bytes::from_static(&[0x60, 0x00]));
+
+        // Write directly to persistent store
+        {
+            let store = PersistentStore::new(&db_path).unwrap();
+            store.add_contracts(&[(hash, bytecode.clone())]).unwrap();
+        }
+
+        // Create new cache (empty memory) backed by same store
+        let store = Arc::new(PersistentStore::new(&db_path).unwrap());
+        let cache = ContractCache::new(store);
+
+        // Should fall back to disk
+        let (found, missing) = cache.get(&[hash]).unwrap();
+        assert_eq!(found.len(), 1);
+        assert!(missing.is_empty());
+
+        // Second lookup should hit memory
+        let (found2, _) = cache.get(&[hash]).unwrap();
+        assert_eq!(found2.len(), 1);
+    }
+}

--- a/crates/stateless-core/src/storage_traits.rs
+++ b/crates/stateless-core/src/storage_traits.rs
@@ -1,0 +1,141 @@
+//! Storage trait abstractions for `ValidatorDB`.
+//!
+//! These traits decouple consumers from the concrete `redb`-backed `ValidatorDB` implementation,
+//! enabling alternative backends (e.g., in-memory for testing) without changing consumer code.
+
+use std::collections::HashMap;
+
+use alloy_genesis::Genesis;
+use alloy_primitives::{B256, BlockHash, BlockNumber};
+use alloy_rpc_types_eth::{Block, Header};
+use op_alloy_rpc_types::Transaction;
+use revm::state::Bytecode;
+use salt::SaltWitness;
+
+use crate::{
+    executor::ValidationResult, light_witness::LightWitness, validator_db::ValidationDbResult,
+    withdrawals::MptWitness,
+};
+
+/// Chain state management: tips, growth, rollback, genesis, anchor, and pruning.
+///
+/// Encapsulates the full lifecycle of chain state from initialization (genesis/anchor)
+/// through synchronization (remote/local chain growth) to maintenance (rollback/pruning).
+pub trait ChainState {
+    /// Returns the highest block in the local canonical chain, or `None` if empty.
+    fn get_local_tip(&self) -> ValidationDbResult<Option<(BlockNumber, BlockHash)>>;
+
+    /// Returns the highest block in the remote (unvalidated) chain, or `None` if empty.
+    fn get_remote_tip(&self) -> ValidationDbResult<Option<(BlockNumber, BlockHash)>>;
+
+    /// Extends the remote chain with a consecutive sequence of unvalidated block headers.
+    ///
+    /// Each header's parent hash must match the current remote chain tip.
+    fn grow_remote_chain(&self, headers: &[Header]) -> ValidationDbResult<()>;
+
+    /// Extends the canonical chain with the next validated block from the remote chain.
+    ///
+    /// Returns `true` if a block was advanced, `false` if no work to do.
+    fn grow_local_chain(&self) -> ValidationDbResult<bool>;
+
+    /// Promotes the first remote chain block to canonical without validation.
+    ///
+    /// Used by debug-trace-server where blocks are trusted from upstream RPC.
+    /// Returns `true` if a block was promoted, `false` if remote chain is empty.
+    fn promote_remote_to_canonical(&self) -> ValidationDbResult<bool>;
+
+    /// Rolls back both canonical and remote chains to the given block number.
+    fn rollback_chain(&self, to_block: BlockNumber) -> ValidationDbResult<()>;
+
+    /// Looks up a block hash by number in canonical chain first, then remote chain.
+    fn get_block_hash(&self, block_number: BlockNumber) -> ValidationDbResult<Option<BlockHash>>;
+
+    /// Returns the earliest (lowest) block in the canonical chain.
+    fn get_earliest_local_block(&self) -> ValidationDbResult<Option<(BlockNumber, BlockHash)>>;
+
+    /// Resets the chain to start from a trusted anchor block, clearing all chain state.
+    fn reset_anchor_block(
+        &self,
+        block_number: BlockNumber,
+        block_hash: BlockHash,
+        post_state_root: B256,
+        post_withdrawals_root: B256,
+    ) -> ValidationDbResult<()>;
+
+    /// Returns the stored anchor block, or `None` if not set.
+    fn get_anchor_block(&self) -> ValidationDbResult<Option<(BlockNumber, BlockHash)>>;
+
+    /// Persists the genesis configuration.
+    fn store_genesis(&self, genesis: &Genesis) -> ValidationDbResult<()>;
+
+    /// Loads the genesis configuration, or `None` if not stored yet.
+    fn load_genesis(&self) -> ValidationDbResult<Option<Genesis>>;
+
+    /// Removes chain data older than the given block number.
+    ///
+    /// Returns the number of blocks pruned.
+    fn prune_history(&self, before_block: BlockNumber) -> ValidationDbResult<u64>;
+}
+
+/// Validation task lifecycle: creation, claiming, and recovery.
+///
+/// Manages the queue of blocks pending validation, including both the full-validation
+/// path (stateless-validator) and the data-only path (debug-trace-server).
+pub trait TaskQueue {
+    /// Queues blocks with full witness data for validation workers.
+    fn add_validation_tasks(
+        &self,
+        tasks: &[(Block<Transaction>, SaltWitness, MptWitness)],
+    ) -> ValidationDbResult<()>;
+
+    /// Stores block data and light witnesses without creating validation tasks.
+    ///
+    /// Used by debug-trace-server where blocks are served for tracing, not validated.
+    fn store_block_data(
+        &self,
+        tasks: &[(Block<Transaction>, LightWitness)],
+    ) -> ValidationDbResult<()>;
+
+    /// Atomically claims the next pending validation task.
+    ///
+    /// Returns `None` when no tasks are available.
+    fn get_next_task(
+        &self,
+    ) -> ValidationDbResult<Option<(Block<Transaction>, SaltWitness, MptWitness)>>;
+
+    /// Moves interrupted (in-progress) tasks back to the pending queue.
+    fn recover_interrupted_tasks(&self) -> ValidationDbResult<()>;
+}
+
+/// Block and witness data retrieval, plus contract bytecode cache.
+pub trait BlockDataStore {
+    /// Retrieves block data and light witness for a given block hash.
+    fn get_block_and_witness(
+        &self,
+        block_hash: BlockHash,
+    ) -> ValidationDbResult<(Block<Transaction>, LightWitness)>;
+
+    /// Retrieves cached contract bytecodes.
+    ///
+    /// Returns `(found, missing)` where `found` maps code hashes to bytecodes and
+    /// `missing` lists code hashes not present in the cache.
+    fn get_contract_codes(
+        &self,
+        code_hashes: &[B256],
+    ) -> ValidationDbResult<(HashMap<B256, Bytecode>, Vec<B256>)>;
+
+    /// Stores contract bytecodes in the cache.
+    fn add_contract_codes(&self, bytecodes: &[(B256, Bytecode)]) -> ValidationDbResult<()>;
+}
+
+/// Validation result storage and lookup.
+pub trait ValidationResultStore {
+    /// Records a completed validation and removes the task from the in-progress queue.
+    fn complete_validation(&self, result: ValidationResult) -> ValidationDbResult<()>;
+
+    /// Retrieves the validation result for a block, or `None` if not yet validated.
+    fn get_validation_result(
+        &self,
+        block_hash: BlockHash,
+    ) -> ValidationDbResult<Option<ValidationResult>>;
+}

--- a/crates/stateless-core/src/validator_db.rs
+++ b/crates/stateless-core/src/validator_db.rs
@@ -337,6 +337,7 @@ impl ValidatorDB {
             let _validation_results = write_txn.open_table(VALIDATION_RESULTS)?;
             let _block_records = write_txn.open_table(BLOCK_RECORDS)?;
             let _contracts = write_txn.open_table(CONTRACTS)?;
+            let _genesis_config = write_txn.open_table(GENESIS_CONFIG)?;
             let _anchor_block = write_txn.open_table(ANCHOR_BLOCK)?;
         }
         write_txn.commit()?;
@@ -1325,4 +1326,360 @@ fn encode_block_to_vec(block: &Block<Transaction>) -> Result<Vec<u8>> {
 fn decode_block_from_slice(bytes: &[u8]) -> Block<Transaction> {
     serde_json::from_slice(bytes)
         .expect("deserialization of previously stored block data must succeed")
+}
+
+// ---------------------------------------------------------------------------
+// Storage trait implementations
+// ---------------------------------------------------------------------------
+
+use crate::storage_traits::{BlockDataStore, ChainState, TaskQueue, ValidationResultStore};
+
+impl ChainState for ValidatorDB {
+    fn get_local_tip(&self) -> ValidationDbResult<Option<(BlockNumber, BlockHash)>> {
+        self.get_local_tip()
+    }
+
+    fn get_remote_tip(&self) -> ValidationDbResult<Option<(BlockNumber, BlockHash)>> {
+        self.get_remote_tip()
+    }
+
+    fn grow_remote_chain(&self, headers: &[Header]) -> ValidationDbResult<()> {
+        self.grow_remote_chain(headers)
+    }
+
+    fn grow_local_chain(&self) -> ValidationDbResult<bool> {
+        self.grow_local_chain()
+    }
+
+    fn promote_remote_to_canonical(&self) -> ValidationDbResult<bool> {
+        self.promote_remote_to_canonical()
+    }
+
+    fn rollback_chain(&self, to_block: BlockNumber) -> ValidationDbResult<()> {
+        self.rollback_chain(to_block)
+    }
+
+    fn get_block_hash(&self, block_number: BlockNumber) -> ValidationDbResult<Option<BlockHash>> {
+        self.get_block_hash(block_number)
+    }
+
+    fn get_earliest_local_block(&self) -> ValidationDbResult<Option<(BlockNumber, BlockHash)>> {
+        self.get_earliest_local_block()
+    }
+
+    fn reset_anchor_block(
+        &self,
+        block_number: BlockNumber,
+        block_hash: BlockHash,
+        post_state_root: B256,
+        post_withdrawals_root: B256,
+    ) -> ValidationDbResult<()> {
+        self.reset_anchor_block(block_number, block_hash, post_state_root, post_withdrawals_root)
+    }
+
+    fn get_anchor_block(&self) -> ValidationDbResult<Option<(BlockNumber, BlockHash)>> {
+        self.get_anchor_block()
+    }
+
+    fn store_genesis(&self, genesis: &Genesis) -> ValidationDbResult<()> {
+        self.store_genesis(genesis)
+    }
+
+    fn load_genesis(&self) -> ValidationDbResult<Option<Genesis>> {
+        self.load_genesis()
+    }
+
+    fn prune_history(&self, before_block: BlockNumber) -> ValidationDbResult<u64> {
+        self.prune_history(before_block)
+    }
+}
+
+impl TaskQueue for ValidatorDB {
+    fn add_validation_tasks(
+        &self,
+        tasks: &[(Block<Transaction>, SaltWitness, MptWitness)],
+    ) -> ValidationDbResult<()> {
+        self.add_validation_tasks(tasks)
+    }
+
+    fn store_block_data(
+        &self,
+        tasks: &[(Block<Transaction>, LightWitness)],
+    ) -> ValidationDbResult<()> {
+        self.store_block_data(tasks)
+    }
+
+    fn get_next_task(
+        &self,
+    ) -> ValidationDbResult<Option<(Block<Transaction>, SaltWitness, MptWitness)>> {
+        self.get_next_task()
+    }
+
+    fn recover_interrupted_tasks(&self) -> ValidationDbResult<()> {
+        self.recover_interrupted_tasks()
+    }
+}
+
+impl BlockDataStore for ValidatorDB {
+    fn get_block_and_witness(
+        &self,
+        block_hash: BlockHash,
+    ) -> ValidationDbResult<(Block<Transaction>, LightWitness)> {
+        self.get_block_and_witness(block_hash)
+    }
+
+    fn get_contract_codes(
+        &self,
+        code_hashes: &[B256],
+    ) -> ValidationDbResult<(HashMap<B256, Bytecode>, Vec<B256>)> {
+        self.get_contract_codes(code_hashes.iter().copied())
+    }
+
+    fn add_contract_codes(&self, bytecodes: &[(B256, Bytecode)]) -> ValidationDbResult<()> {
+        self.add_contract_codes(bytecodes)
+    }
+}
+
+impl ValidationResultStore for ValidatorDB {
+    fn complete_validation(&self, result: ValidationResult) -> ValidationDbResult<()> {
+        self.complete_validation(result)
+    }
+
+    fn get_validation_result(
+        &self,
+        block_hash: BlockHash,
+    ) -> ValidationDbResult<Option<ValidationResult>> {
+        self.get_validation_result(block_hash)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::B256;
+    use alloy_rpc_types_eth::Header;
+    use revm::state::Bytecode;
+
+    use super::*;
+
+    /// Creates a ValidatorDB backed by a temporary directory.
+    fn temp_db() -> ValidatorDB {
+        let dir = tempfile::tempdir().unwrap();
+        let db = ValidatorDB::new(dir.path().join("test.redb")).unwrap();
+        std::mem::forget(dir); // OS cleans up when process exits
+        db
+    }
+
+    /// Builds a test header with the given number, hash, and parent hash.
+    fn make_header(number: u64, hash: B256, parent_hash: B256) -> Header {
+        Header {
+            hash,
+            inner: alloy_consensus::Header {
+                number,
+                parent_hash,
+                state_root: B256::with_last_byte(number as u8),
+                withdrawals_root: Some(B256::with_last_byte(number as u8 + 100)),
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    /// Deterministic hash for a block number (for tests only).
+    fn block_hash(n: u64) -> B256 {
+        B256::with_last_byte(n as u8)
+    }
+
+    #[test]
+    fn chain_growth_and_promotion() {
+        let db = temp_db();
+
+        // Anchor at block 50
+        let anchor_hash = block_hash(50);
+        db.reset_anchor_block(50, anchor_hash, B256::ZERO, B256::ZERO).unwrap();
+
+        // Build headers 51, 52 with proper parent linkage
+        let h51 = make_header(51, block_hash(51), anchor_hash);
+        let h52 = make_header(52, block_hash(52), block_hash(51));
+        db.grow_remote_chain(&[h51, h52]).unwrap();
+
+        // Remote tip should be at 52
+        let remote_tip = db.get_remote_tip().unwrap().unwrap();
+        assert_eq!(remote_tip.0, 52);
+
+        // Promote one block
+        assert!(db.promote_remote_to_canonical().unwrap());
+        let local_tip = db.get_local_tip().unwrap().unwrap();
+        assert_eq!(local_tip.0, 51);
+
+        // Promote second block
+        assert!(db.promote_remote_to_canonical().unwrap());
+        let local_tip = db.get_local_tip().unwrap().unwrap();
+        assert_eq!(local_tip.0, 52);
+
+        // No more to promote
+        assert!(!db.promote_remote_to_canonical().unwrap());
+    }
+
+    #[test]
+    fn rollback() {
+        let db = temp_db();
+
+        // Anchor at block 50
+        let anchor_hash = block_hash(50);
+        db.reset_anchor_block(50, anchor_hash, B256::ZERO, B256::ZERO).unwrap();
+
+        // Grow remote chain to block 55
+        let headers: Vec<_> =
+            (51..=55).map(|n| make_header(n, block_hash(n), block_hash(n - 1))).collect();
+        db.grow_remote_chain(&headers).unwrap();
+
+        // Promote all to canonical
+        for _ in 0..5 {
+            assert!(db.promote_remote_to_canonical().unwrap());
+        }
+        assert_eq!(db.get_local_tip().unwrap().unwrap().0, 55);
+
+        // Rollback to block 52
+        db.rollback_chain(52).unwrap();
+        assert_eq!(db.get_local_tip().unwrap().unwrap().0, 52);
+        // Remote chain should also be rolled back
+        assert!(db.get_remote_tip().unwrap().is_none());
+    }
+
+    #[test]
+    fn genesis_round_trip() {
+        let db = temp_db();
+
+        // No genesis initially
+        assert!(db.load_genesis().unwrap().is_none());
+
+        // Store a minimal genesis
+        let genesis = Genesis::default();
+        db.store_genesis(&genesis).unwrap();
+
+        // Load it back
+        let loaded = db.load_genesis().unwrap().unwrap();
+        assert_eq!(
+            serde_json::to_string(&loaded).unwrap(),
+            serde_json::to_string(&genesis).unwrap()
+        );
+    }
+
+    #[test]
+    fn anchor_block_round_trip() {
+        let db = temp_db();
+
+        // No anchor initially
+        assert!(db.get_anchor_block().unwrap().is_none());
+
+        let hash = block_hash(100);
+        let state_root = B256::with_last_byte(0xAA);
+        let withdrawals_root = B256::with_last_byte(0xBB);
+        db.reset_anchor_block(100, hash, state_root, withdrawals_root).unwrap();
+
+        // Anchor block stored
+        let (num, stored_hash) = db.get_anchor_block().unwrap().unwrap();
+        assert_eq!(num, 100);
+        assert_eq!(stored_hash, hash);
+
+        // Local tip matches anchor
+        let (tip_num, tip_hash) = db.get_local_tip().unwrap().unwrap();
+        assert_eq!(tip_num, 100);
+        assert_eq!(tip_hash, hash);
+    }
+
+    #[test]
+    fn contract_code_cache() {
+        let db = temp_db();
+
+        // Create two test bytecodes
+        let code1 = Bytecode::new_raw(alloy_primitives::Bytes::from_static(&[0x60, 0x00]));
+        let hash1 = code1.hash_slow();
+        let code2 = Bytecode::new_raw(alloy_primitives::Bytes::from_static(&[0x60, 0x01]));
+        let hash2 = code2.hash_slow();
+        let unknown_hash = B256::with_last_byte(0xFF);
+
+        // Store first code
+        db.add_contract_codes(&[(hash1, code1.clone())]).unwrap();
+
+        // Query: hash1 found, hash2 and unknown missing
+        let (found, missing) = db.get_contract_codes([hash1, hash2, unknown_hash]).unwrap();
+        assert_eq!(found.len(), 1);
+        assert!(found.contains_key(&hash1));
+        assert_eq!(missing.len(), 2);
+
+        // Store second code
+        db.add_contract_codes(&[(hash2, code2)]).unwrap();
+
+        // Now both found, only unknown missing
+        let (found, missing) = db.get_contract_codes([hash1, hash2, unknown_hash]).unwrap();
+        assert_eq!(found.len(), 2);
+        assert_eq!(missing, vec![unknown_hash]);
+    }
+
+    #[test]
+    fn get_block_hash_canonical_and_remote() {
+        let db = temp_db();
+
+        let anchor_hash = block_hash(10);
+        db.reset_anchor_block(10, anchor_hash, B256::ZERO, B256::ZERO).unwrap();
+
+        // Block 10 is in canonical chain
+        assert_eq!(db.get_block_hash(10).unwrap(), Some(anchor_hash));
+
+        // Build remote blocks 11, 12
+        let h11 = make_header(11, block_hash(11), anchor_hash);
+        let h12 = make_header(12, block_hash(12), block_hash(11));
+        db.grow_remote_chain(&[h11, h12]).unwrap();
+
+        // Block 11 found in remote chain
+        assert_eq!(db.get_block_hash(11).unwrap(), Some(block_hash(11)));
+        // Block 99 not found anywhere
+        assert!(db.get_block_hash(99).unwrap().is_none());
+    }
+
+    #[test]
+    fn earliest_local_block() {
+        let db = temp_db();
+
+        // Empty chain
+        assert!(db.get_earliest_local_block().unwrap().is_none());
+
+        let anchor_hash = block_hash(50);
+        db.reset_anchor_block(50, anchor_hash, B256::ZERO, B256::ZERO).unwrap();
+
+        let (num, _) = db.get_earliest_local_block().unwrap().unwrap();
+        assert_eq!(num, 50);
+    }
+
+    #[test]
+    fn prune_history() {
+        let db = temp_db();
+
+        // Anchor at block 100
+        let anchor_hash = block_hash(100);
+        db.reset_anchor_block(100, anchor_hash, B256::ZERO, B256::ZERO).unwrap();
+
+        // Grow and promote 10 blocks (101..=110)
+        let headers: Vec<_> =
+            (101..=110).map(|n| make_header(n, block_hash(n), block_hash(n - 1))).collect();
+        db.grow_remote_chain(&headers).unwrap();
+        for _ in 0..10 {
+            db.promote_remote_to_canonical().unwrap();
+        }
+        assert_eq!(db.get_local_tip().unwrap().unwrap().0, 110);
+
+        // Verify earliest block before pruning
+        let (earliest_before, _) = db.get_earliest_local_block().unwrap().unwrap();
+        assert_eq!(earliest_before, 100);
+
+        // Prune blocks before 105.
+        // Note: pruned count reflects BLOCK_RECORDS entries (populated by add_validation_tasks,
+        // not promote_remote_to_canonical). The canonical chain orphan cleanup still runs.
+        db.prune_history(105).unwrap();
+
+        // Earliest block should now be >= 105 (orphaned canonical entries removed)
+        let (earliest, _) = db.get_earliest_local_block().unwrap().unwrap();
+        assert!(earliest >= 105, "Expected earliest >= 105, got {earliest}");
+    }
 }


### PR DESCRIPTION
## Summary

Introduce storage trait abstractions (`ChainState`, `TaskQueue`, `BlockDataStore`, `ValidationResultStore`) that decouple consumers from the concrete `redb`-backed `ValidatorDB` implementation, enabling alternative backends (e.g., in-memory for testing) without changing consumer code.

- Add `storage_traits.rs` with four domain-specific traits covering chain state management, task queue lifecycle, block/witness data retrieval, and validation result storage
- Implement all four traits on `ValidatorDB` via delegation to existing inherent methods (purely additive, no behavior change)
- Refactor `chain_sync.rs` to use trait bounds (`DB: ChainState + TaskQueue`) instead of concrete `&ValidatorDB` / `Arc<ValidatorDB>` parameters
- Add comprehensive `ValidatorDB` unit tests covering chain growth & promotion, rollback, genesis round-trip, anchor block, contract code cache, block hash lookup, earliest local block, and history pruning
- Add `tempfile` dev-dependency for test database isolation

## Details

### Storage Traits (`storage_traits.rs`)

| Trait | Responsibility |
|-------|---------------|
| `ChainState` | Local/remote chain tips, growth, rollback, genesis, anchor, pruning |
| `TaskQueue` | Validation task creation, claiming, and recovery |
| `BlockDataStore` | Block/witness retrieval and contract bytecode cache |
| `ValidationResultStore` | Validation result storage and lookup |

### `chain_sync.rs` Generalization

`fetch_blocks_batch`, `remote_chain_tracker`, and `find_divergence_point` now accept generic `DB` parameters bounded by the appropriate traits. Call sites in binaries continue to pass `ValidatorDB` unchanged since it implements all traits.

### Unit Tests (8 tests)

- `chain_growth_and_promotion` — anchor + remote growth + promote to canonical
- `rollback` — grow chain then roll back to earlier block
- `genesis_round_trip` — store and reload genesis config
- `anchor_block_round_trip` — reset and retrieve anchor block
- `contract_code_cache` — add and query contract bytecodes
- `get_block_hash_canonical_and_remote` — hash lookup across both chains
- `earliest_local_block` — empty chain and post-anchor queries
- `prune_history` — prune old canonical entries

## Test plan

- [x] `cargo check --workspace` passes
- [x] `cargo test -p stateless-core` passes (includes 8 new tests)
- [x] `cargo clippy --workspace --all-targets --all-features` clean
