### PR TITLE
chore: upgrade mega-evm to v1.5.0 & bump version to v2.0.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1890,7 +1890,7 @@ dependencies = [
 
 [[package]]
 name = "debug-trace-server"
-version = "2.0.8"
+version = "2.0.9"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -3459,8 +3459,8 @@ dependencies = [
 
 [[package]]
 name = "mega-evm"
-version = "1.4.1"
-source = "git+https://github.com/megaeth-labs/mega-evm.git?rev=v1.4.1#32a19f7ee52a1cb713085c9b170e2343236e3c9d"
+version = "1.5.0"
+source = "git+https://github.com/megaeth-labs/mega-evm.git?rev=v1.5.0#6de9fd1a101b8b9d5478380129f2b89a6f607298"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3486,8 +3486,8 @@ dependencies = [
 
 [[package]]
 name = "mega-system-contracts"
-version = "1.4.1"
-source = "git+https://github.com/megaeth-labs/mega-evm.git?rev=v1.4.1#32a19f7ee52a1cb713085c9b170e2343236e3c9d"
+version = "1.5.0"
+source = "git+https://github.com/megaeth-labs/mega-evm.git?rev=v1.5.0#6de9fd1a101b8b9d5478380129f2b89a6f607298"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -5901,7 +5901,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stateless-common"
-version = "2.0.8"
+version = "2.0.9"
 dependencies = [
  "clap",
  "eyre",
@@ -5913,7 +5913,7 @@ dependencies = [
 
 [[package]]
 name = "stateless-core"
-version = "2.0.8"
+version = "2.0.9"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5960,7 +5960,7 @@ dependencies = [
 
 [[package]]
 name = "stateless-validator"
-version = "2.0.8"
+version = "2.0.9"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.0.8"
+version = "2.0.9"
 edition = "2024"
 rust-version = "1.95"
 license = "MIT OR Apache-2.0"
@@ -48,7 +48,7 @@ futures = "0.3"
 lz4_flex = { version = "0.11", default-features = false }
 
 # megaeth 
-mega-evm = { git = "https://github.com/megaeth-labs/mega-evm.git", rev = "v1.4.1" }
+mega-evm = { git = "https://github.com/megaeth-labs/mega-evm.git", rev = "v1.5.0" }
 metrics = "0.24"
 metrics-derive = "0.1"
 metrics-exporter-prometheus = { version = "0.18", default-features = false, features = ["http-listener"] }


### PR DESCRIPTION
## Summary

Upgrade `mega-evm` dependency from v1.4.1 to v1.5.0 and bump workspace version to 2.0.9.

## Changes

- Update `mega-evm` git dependency from `rev = "v1.4.1"` to `rev = "v1.5.0"` in workspace `Cargo.toml`
- Bump workspace package version from `2.0.8` to `2.0.9`
- Update `Cargo.lock` to reflect new `mega-evm` (1.5.0) and `mega-system-contracts` (1.5.0) versions

## Test plan

- [x] `cargo check` passes with the new dependency
- [x] `cargo test` passes — no breaking API changes from mega-evm upgrade
- [x] `cargo clippy --workspace --all-targets --all-features` has no new warnings