### PR TITLE
chore: bump mega-evm to v1.5.1 and stateless-validator to 2.0.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1890,7 +1890,7 @@ dependencies = [
 
 [[package]]
 name = "debug-trace-server"
-version = "2.0.9"
+version = "2.0.10"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -5901,7 +5901,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stateless-common"
-version = "2.0.9"
+version = "2.0.10"
 dependencies = [
  "clap",
  "eyre",
@@ -5913,7 +5913,7 @@ dependencies = [
 
 [[package]]
 name = "stateless-core"
-version = "2.0.9"
+version = "2.0.10"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5960,7 +5960,7 @@ dependencies = [
 
 [[package]]
 name = "stateless-validator"
-version = "2.0.9"
+version = "2.0.10"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3459,8 +3459,8 @@ dependencies = [
 
 [[package]]
 name = "mega-evm"
-version = "1.5.0"
-source = "git+https://github.com/megaeth-labs/mega-evm.git?rev=v1.5.0#6de9fd1a101b8b9d5478380129f2b89a6f607298"
+version = "1.5.1"
+source = "git+https://github.com/megaeth-labs/mega-evm.git?rev=v1.5.1#92e21683ccde382e99e6a96cd971887c6a2964e8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3486,8 +3486,8 @@ dependencies = [
 
 [[package]]
 name = "mega-system-contracts"
-version = "1.5.0"
-source = "git+https://github.com/megaeth-labs/mega-evm.git?rev=v1.5.0#6de9fd1a101b8b9d5478380129f2b89a6f607298"
+version = "1.5.1"
+source = "git+https://github.com/megaeth-labs/mega-evm.git?rev=v1.5.1#92e21683ccde382e99e6a96cd971887c6a2964e8"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ futures = "0.3"
 lz4_flex = { version = "0.11", default-features = false }
 
 # megaeth 
-mega-evm = { git = "https://github.com/megaeth-labs/mega-evm.git", rev = "v1.5.0" }
+mega-evm = { git = "https://github.com/megaeth-labs/mega-evm.git", rev = "v1.5.1" }
 metrics = "0.24"
 metrics-derive = "0.1"
 metrics-exporter-prometheus = { version = "0.18", default-features = false, features = ["http-listener"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.0.9"
+version = "2.0.10"
 edition = "2024"
 rust-version = "1.95"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
**Summary**

- **Bump crate version to 2.0.10** to prepare a new release.
- **Upgrade `mega-evm` dependency** to the latest compatible version.

**Details**

- Version field updated across relevant Cargo manifests from 2.0.9 to 2.0.10.
- `mega-evm` crate version increased to pick up recent fixes/improvements, with no functional changes expected beyond dependency behavior.

**Testing**

- [x] `cargo check`  
- [x] `cargo test`  