### PR TITLE
ci: pin claude-code-action to v1.0.88

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -43,7 +43,7 @@ jobs:
           submodules: recursive
           fetch-depth: 1
 
-      - uses: anthropics/claude-code-action@v1
+      - uses: anthropics/claude-code-action@v1.0.88
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           additional_permissions: |
@@ -71,7 +71,7 @@ jobs:
           submodules: recursive
           fetch-depth: 1
 
-      - uses: anthropics/claude-code-action@v1
+      - uses: anthropics/claude-code-action@v1.0.88
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           additional_permissions: |
@@ -111,7 +111,7 @@ jobs:
           submodules: recursive
           fetch-depth: 1
 
-      - uses: anthropics/claude-code-action@v1
+      - uses: anthropics/claude-code-action@v1.0.88
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: |
@@ -142,7 +142,7 @@ jobs:
           submodules: recursive
           fetch-depth: 1
 
-      - uses: anthropics/claude-code-action@v1
+      - uses: anthropics/claude-code-action@v1.0.88
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: |


### PR DESCRIPTION
## Summary

Pin `anthropics/claude-code-action` from `@v1` to `@v1.0.88` to work around a known bug ([anthropics/claude-code-action#1187](https://github.com/anthropics/claude-code-action/issues/1187)) introduced in v1.0.89.

Since v1.0.89, the action crashes with `ENOENT: no such file or directory, symlink` during `restoreConfigFromBase` when any of the `SENSITIVE_PATHS` (e.g. `CLAUDE.md`) is a symlink. This breaks all PR review CI runs.

The fix is tracked in [anthropics/claude-code-action#1186](https://github.com/anthropics/claude-code-action/pull/1186). Once that lands, we can unpin back to `@v1`.