### PR TITLE
chore: update CODEOWNERS to new global owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,5 @@
 # Default: global code owners
 * @abelmega @vincent-k2026 @flyq @Troublor
+
+# ci configs
+.github/ @Troublor @flyq @krabat-l @yunlonggao-mega @mingy-mega @hongbo-trey

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Default: global code owners
-* @abelmega @vincent-k2026 @flyq
+* @abelmega @vincent-k2026 @flyq @Troublor

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,17 +1,2 @@
-# Default: repo owner owns everything
-* @Troublor
-
-# stateless-core
-/crates/stateless-core/ @flyq
-
-# stateless-common (shared by both)
-/crates/stateless-common/ @flyq @krabat-l
-
-# stateless-validator binary
-/bin/stateless-validator/ @flyq
-
-# debug-trace-server binary
-/bin/debug-trace-server/ @krabat-l
-
-# ci configs
-.github/ @Troublor @flyq @krabat-l @yunlonggao-mega @mingy-mega @hongbo-trey
+# Default: global code owners
+* @abelmega @vincent-k2026 @flyq


### PR DESCRIPTION
## Summary
- Replace path-specific code owners with a single global rule
- Set @abelmega @vincent-k2026 @flyq as code owners for all files

## Test plan
- Verify CODEOWNERS syntax is correct
- Confirm PR reviews are requested from the correct users

---
*This PR was generated by an automated agent.*