### PR TITLE
refactor: use SparseStateTrie::reveal_witness for withdrawal MPT verification

### DIFF
--- a/crates/stateless-core/src/withdrawals.rs
+++ b/crates/stateless-core/src/withdrawals.rs
@@ -183,105 +183,96 @@ mod tests {
     const SLOT: B256 = b256!("0x1111111111111111111111111111111111111111111111111111111111111111");
     const BOGUS: B256 = b256!("0xdeadbeef00000000000000000000000000000000000000000000000000000000");
 
-    fn header(root: Option<B256>) -> Header {
-        let inner = alloy_consensus::Header { withdrawals_root: root, ..Default::default() };
-        Header::from_consensus(inner.seal_slow(), None, None)
-    }
-
-    /// One-leaf storage trie: root = keccak(leaf_rlp). Returns (root, [leaf_bytes]).
-    fn single_leaf() -> (B256, Vec<Bytes>) {
-        let value_rlp = alloy_rlp::encode_fixed_size(&U256::from(42u64)).to_vec();
-        let leaf = TrieNode::Leaf(LeafNode::new(Nibbles::unpack(SLOT), value_rlp));
+    /// One-leaf storage trie for `SLOT → value`: returns (root, [leaf_bytes]).
+    fn leaf(value: u64) -> (B256, Vec<Bytes>) {
+        let value_rlp = alloy_rlp::encode_fixed_size(&U256::from(value)).to_vec();
         let mut rlp = Vec::new();
-        leaf.encode(&mut rlp);
+        TrieNode::Leaf(LeafNode::new(Nibbles::unpack(SLOT), value_rlp)).encode(&mut rlp);
         let bytes = Bytes::from(rlp);
         (keccak256(&bytes), vec![bytes])
     }
 
-    fn verify(
+    fn run(
         storage_root: B256,
         state: Vec<Bytes>,
         expected: Option<B256>,
+        updates: &[(B256, U256)],
     ) -> Result<(), WithdrawalValidationError> {
-        MptWitness { storage_root, state }.verify(&header(expected), B256Map::default())
-    }
-
-    fn verify_with(
-        storage_root: B256,
-        state: Vec<Bytes>,
-        expected: B256,
-        slot: B256,
-        value: U256,
-    ) -> Result<(), WithdrawalValidationError> {
-        let mut updates = B256Map::default();
-        updates.insert(slot, value);
-        MptWitness { storage_root, state }.verify(&header(Some(expected)), updates)
+        let inner = alloy_consensus::Header { withdrawals_root: expected, ..Default::default() };
+        let header = Header::from_consensus(inner.seal_slow(), None, None);
+        MptWitness { storage_root, state }.verify(&header, updates.iter().copied().collect())
     }
 
     #[test]
     fn missing_withdrawals_root() {
-        assert_eq!(verify(EMPTY_ROOT_HASH, vec![], None), Err(MissingWithdrawalsRoot));
+        assert_eq!(run(EMPTY_ROOT_HASH, vec![], None, &[]), Err(MissingWithdrawalsRoot));
     }
 
     #[test]
     fn empty_trie_verifies() {
-        verify(EMPTY_ROOT_HASH, vec![], Some(EMPTY_ROOT_HASH)).unwrap();
+        run(EMPTY_ROOT_HASH, vec![], Some(EMPTY_ROOT_HASH), &[]).unwrap();
+    }
+
+    #[test]
+    fn non_empty_trie_no_updates_verifies() {
+        let (root, state) = leaf(42);
+        run(root, state, Some(root), &[]).unwrap();
+    }
+
+    #[test]
+    fn leaf_update_changes_root() {
+        let (pre, state) = leaf(42);
+        let (post, _) = leaf(99);
+        run(pre, state, Some(post), &[(SLOT, U256::from(99u64))]).unwrap();
+    }
+
+    #[test]
+    fn leaf_removal_collapses_to_empty() {
+        let (root, state) = leaf(42);
+        run(root, state, Some(EMPTY_ROOT_HASH), &[(SLOT, U256::ZERO)]).unwrap();
     }
 
     #[test]
     fn pre_state_mismatch() {
         assert!(matches!(
-            verify(BOGUS, vec![], Some(EMPTY_ROOT_HASH)),
+            run(BOGUS, vec![], Some(EMPTY_ROOT_HASH), &[]),
             Err(PreStateRootMismatch { .. })
         ));
     }
 
     #[test]
     fn post_state_mismatch() {
-        let (root, state) = single_leaf();
+        let (root, state) = leaf(42);
         assert!(matches!(
-            verify(root, state, Some(EMPTY_ROOT_HASH)),
+            run(root, state, Some(EMPTY_ROOT_HASH), &[]),
             Err(PostStateRootMismatch { .. })
         ));
-    }
-
-    /// Happy path: non-empty trie, no updates, post-root equals pre-root.
-    #[test]
-    fn non_empty_trie_no_updates_verifies() {
-        let (root, state) = single_leaf();
-        verify(root, state, Some(root)).unwrap();
     }
 
     /// Attack: claimed pre-state root non-empty, witness nodes omitted.
     #[test]
     fn missing_nodes() {
-        let (root, _) = single_leaf();
-        assert!(matches!(verify(root, vec![], Some(root)), Err(PreStateRootMismatch { .. })));
+        let (root, _) = leaf(42);
+        assert!(matches!(run(root, vec![], Some(root), &[]), Err(PreStateRootMismatch { .. })));
     }
 
     /// Attack: tampered node bytes → hash mismatch → treated as missing.
     #[test]
     fn tampered_node() {
-        let (root, mut state) = single_leaf();
+        let (root, mut state) = leaf(42);
         let mut bytes = state[0].to_vec();
         *bytes.last_mut().unwrap() ^= 0x01;
         state[0] = Bytes::from(bytes);
-        assert!(matches!(verify(root, state, Some(root)), Err(PreStateRootMismatch { .. })));
+        assert!(matches!(run(root, state, Some(root), &[]), Err(PreStateRootMismatch { .. })));
     }
 
     /// Attack: update targets a slot whose subtree is missing.
     #[test]
     fn update_on_missing_subtree() {
-        let (root, _) = single_leaf();
+        let (root, _) = leaf(42);
         assert!(matches!(
-            verify_with(root, vec![], root, SLOT, U256::from(99u64)),
+            run(root, vec![], Some(root), &[(SLOT, U256::from(99u64))]),
             Err(PreStateRootMismatch { .. } | TrieOperationFailed(_))
         ));
-    }
-
-    #[test]
-    fn leaf_removal_collapses_to_empty() {
-        let (root, state) = single_leaf();
-        verify_with(root, state, EMPTY_ROOT_HASH, SLOT, U256::ZERO).unwrap();
     }
 }

--- a/crates/stateless-core/src/withdrawals.rs
+++ b/crates/stateless-core/src/withdrawals.rs
@@ -5,21 +5,17 @@
 //! storage updates from block execution, it cryptographically proves the storage root
 //! transition is valid.
 
-use std::collections::{HashSet, VecDeque};
-
+use alloy_consensus::constants::KECCAK_EMPTY;
 use alloy_primitives::{Address, B256, Bytes, U256, address, keccak256, map::B256Map};
-use alloy_rlp::Decodable;
+use alloy_rlp::Encodable;
 use alloy_rpc_types_eth::Header;
 use reth_trie::Nibbles;
-use reth_trie_common::{EMPTY_ROOT_HASH, TrieNode};
+use reth_trie_common::{EMPTY_ROOT_HASH, LeafNode, TrieAccount, TrieNode};
 use reth_trie_sparse::{
-    SerialSparseTrie, SparseTrie, SparseTrieInterface, TrieMasks, provider::DefaultTrieNodeProvider,
+    SerialSparseTrie, SparseStateTrie, provider::DefaultTrieNodeProviderFactory,
 };
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
-
-/// Number of children in an MPT branch node (0-15, hex digits)
-const BRANCH_NODE_CHILDREN: u8 = 16;
 
 /// L2 contract `L2ToL1MessagePasser`, storing commitments to withdrawal transactions.
 pub const ADDRESS_L2_TO_L1_MESSAGE_PASSER: Address =
@@ -31,17 +27,8 @@ pub enum WithdrawalValidationError {
     #[error("Missing withdrawals_root in block header")]
     MissingWithdrawalsRoot,
 
-    #[error("Witness node not found: {0:?}")]
-    WitnessNodeNotFound(B256),
-
-    #[error("RLP decode failed: {0}")]
-    RlpDecodeFailed(String),
-
     #[error("Trie operation failed: {0}")]
     TrieOperationFailed(String),
-
-    #[error("Trie not revealed")]
-    TrieNotRevealed,
 
     #[error("Pre-state root mismatch: expected {expected:?}, got {actual:?}")]
     PreStateRootMismatch { expected: B256, actual: B256 },
@@ -70,9 +57,10 @@ impl MptWitness {
     ///
     /// # Process
     ///
-    /// 1. Reconstructs pre-state trie from witness, verifies against `storage_root`
-    /// 2. Applies storage updates (inserts non-zero, removes zero values)
-    /// 3. Computes post-state root, verifies against `header.withdrawals_root`
+    /// 1. Synthesizes an account-level state witness wrapping the storage witness
+    /// 2. Reveals the trie via BFS, verifies pre-state root against `storage_root`
+    /// 3. Applies storage updates (inserts non-zero, removes zero values)
+    /// 4. Computes post-state root, verifies against `header.withdrawals_root`
     ///
     /// # Arguments
     ///
@@ -84,10 +72,7 @@ impl MptWitness {
     /// * `MissingWithdrawalsRoot` - Header lacks `withdrawals_root` field
     /// * `PreStateRootMismatch` - Witness doesn't match expected pre-state root
     /// * `PostStateRootMismatch` - Computed post-state doesn't match header
-    /// * `WitnessNodeNotFound` - Required trie node missing from witness
-    /// * `RlpDecodeFailed` - Invalid RLP encoding in witness node
-    /// * `TrieOperationFailed` - Trie update/removal failed
-    /// * `TrieNotRevealed` - Trie not revealed before root computation
+    /// * `TrieOperationFailed` - Trie reveal/update/removal failed
     pub fn verify(
         &self,
         header: &Header,
@@ -96,17 +81,20 @@ impl MptWitness {
         let expected_post_root =
             header.withdrawals_root.ok_or(WithdrawalValidationError::MissingWithdrawalsRoot)?;
 
-        // Build node lookup: hash → RLP bytes
-        let nodes =
-            self.state.iter().map(|node| (keccak256(node), node.clone())).collect::<B256Map<_>>();
+        // Synthesize account-level witness and reveal via BFS
+        let (synthesized_state_root, witness_map, hashed_address) = synthesize_state_witness(self);
 
-        // Reconstruct and verify pre-state
-        let mut trie = rebuild_trie(self.storage_root, &nodes)?;
-        let root = trie.root().ok_or(WithdrawalValidationError::TrieNotRevealed)?;
-        if root != self.storage_root {
+        let mut state_trie = SparseStateTrie::<SerialSparseTrie>::default();
+        state_trie
+            .reveal_witness(synthesized_state_root, &witness_map)
+            .map_err(|e| WithdrawalValidationError::TrieOperationFailed(e.to_string()))?;
+
+        // Verify pre-state root
+        let pre_root = state_trie.storage_root(hashed_address).unwrap_or(EMPTY_ROOT_HASH);
+        if pre_root != self.storage_root {
             return Err(WithdrawalValidationError::PreStateRootMismatch {
                 expected: self.storage_root,
-                actual: root,
+                actual: pre_root,
             });
         }
 
@@ -115,20 +103,27 @@ impl MptWitness {
             let nibbles = Nibbles::unpack(slot);
             if !value.is_zero() {
                 let encoded = alloy_rlp::encode_fixed_size(&value).to_vec();
-                trie.update_leaf(nibbles, encoded, DefaultTrieNodeProvider)
+                state_trie
+                    .update_storage_leaf(
+                        hashed_address,
+                        nibbles,
+                        encoded,
+                        DefaultTrieNodeProviderFactory,
+                    )
                     .map_err(|e| WithdrawalValidationError::TrieOperationFailed(e.to_string()))?;
             } else {
-                trie.remove_leaf(&nibbles, DefaultTrieNodeProvider)
+                state_trie
+                    .remove_storage_leaf(hashed_address, &nibbles, DefaultTrieNodeProviderFactory)
                     .map_err(|e| WithdrawalValidationError::TrieOperationFailed(e.to_string()))?;
             }
         }
 
-        // Verify post-state
-        let root = trie.root().ok_or(WithdrawalValidationError::TrieNotRevealed)?;
-        if root != expected_post_root {
+        // Verify post-state root
+        let post_root = state_trie.storage_root(hashed_address).unwrap_or(EMPTY_ROOT_HASH);
+        if post_root != expected_post_root {
             return Err(WithdrawalValidationError::PostStateRootMismatch {
                 expected: expected_post_root,
-                actual: root,
+                actual: post_root,
             });
         }
 
@@ -136,88 +131,34 @@ impl MptWitness {
     }
 }
 
-/// Reconstructs a sparse trie from witness nodes using breadth-first traversal.
+/// Wraps a storage-only `MptWitness` as a single-account state witness so that
+/// `SparseStateTrie::reveal_witness` can BFS-reveal the storage nodes automatically.
 ///
-/// Reveals nodes from the witness in BFS order, ensuring parents are revealed
-/// before children (required by sparse trie API). "Revealing" decodes the RLP
-/// node and registers it in the trie structure.
+/// `reveal_witness` expects an account-level state trie, but `MptWitness` only contains
+/// storage nodes for the L2ToL1MessagePasser contract. This helper synthesizes a one-leaf
+/// account trie whose `TrieAccount.storage_root` points to the real storage witness,
+/// allowing the existing BFS traversal to discover and reveal all storage nodes.
 ///
-/// # Arguments
-///
-/// * `root_hash` - Storage root to reconstruct (returns empty trie if `EMPTY_ROOT_HASH`)
-/// * `nodes` - Map of node hashes to RLP-encoded trie node data
-///
-/// # Returns
-///
-/// Sparse trie with all witness nodes revealed, ready for updates or root computation
-///
-/// # Errors
-///
-/// * `WitnessNodeNotFound` - Node hash not found in `nodes` map
-/// * `RlpDecodeFailed` - Node data failed RLP decoding
-/// * `TrieOperationFailed` - Sparse trie rejected node reveal
-/// * `TrieNotRevealed` - Child reveal attempted before parent revealed
-fn rebuild_trie(
-    root_hash: B256,
-    nodes: &B256Map<Bytes>,
-) -> Result<SparseTrie<SerialSparseTrie>, WithdrawalValidationError> {
-    if root_hash == EMPTY_ROOT_HASH {
-        return Ok(SparseTrie::revealed_empty());
-    }
+/// Returns `(synthesized_state_root, witness_map, hashed_address)`.
+fn synthesize_state_witness(witness: &MptWitness) -> (B256, B256Map<Bytes>, B256) {
+    let mut witness_map: B256Map<Bytes> =
+        witness.state.iter().map(|node| (keccak256(node), node.clone())).collect();
 
-    let mut trie = SparseTrie::<SerialSparseTrie>::default();
-    let mut queue = VecDeque::from([(root_hash, Nibbles::default())]);
-    let mut visited = HashSet::from([root_hash]);
+    let hashed_address = keccak256(ADDRESS_L2_TO_L1_MESSAGE_PASSER);
+    let trie_account = TrieAccount {
+        nonce: 0,
+        balance: U256::ZERO,
+        storage_root: witness.storage_root,
+        code_hash: KECCAK_EMPTY,
+    };
+    let mut account_rlp = Vec::new();
+    trie_account.encode(&mut account_rlp);
+    let account_leaf = TrieNode::Leaf(LeafNode::new(Nibbles::unpack(hashed_address), account_rlp));
+    let mut leaf_rlp = Vec::new();
+    account_leaf.encode(&mut leaf_rlp);
+    let leaf_bytes = Bytes::from(leaf_rlp);
+    let synthesized_state_root = keccak256(&leaf_bytes);
+    witness_map.insert(synthesized_state_root, leaf_bytes);
 
-    while let Some((hash, path)) = queue.pop_front() {
-        // Decode node from witness
-        let bytes = nodes.get(&hash).ok_or(WithdrawalValidationError::WitnessNodeNotFound(hash))?;
-        let node = TrieNode::decode(&mut bytes.as_ref())
-            .map_err(|e| WithdrawalValidationError::RlpDecodeFailed(e.to_string()))?;
-
-        // Reveal node in trie
-        if path.is_empty() {
-            trie.reveal_root(node.clone(), TrieMasks::none(), false)
-                .map_err(|e| WithdrawalValidationError::TrieOperationFailed(e.to_string()))?;
-        } else {
-            trie.as_revealed_mut()
-                .ok_or(WithdrawalValidationError::TrieNotRevealed)?
-                .reveal_node(path, node.clone(), TrieMasks::none())
-                .map_err(|e| WithdrawalValidationError::TrieOperationFailed(e.to_string()))?;
-        }
-
-        // Helper to enqueue unvisited child nodes
-        let mut enqueue = |child_hash: B256, child_path: Nibbles| {
-            if nodes.contains_key(&child_hash) && visited.insert(child_hash) {
-                queue.push_back((child_hash, child_path));
-            }
-        };
-
-        // Enqueue child nodes for BFS traversal
-        match node {
-            TrieNode::Branch(branch) => {
-                let mut stack_ptr = 0;
-                for idx in 0..BRANCH_NODE_CHILDREN {
-                    if branch.state_mask.is_bit_set(idx) {
-                        if let Some(child_hash) = branch.stack[stack_ptr].as_hash() {
-                            let mut child_path = path;
-                            child_path.push_unchecked(idx);
-                            enqueue(child_hash, child_path);
-                        }
-                        stack_ptr += 1;
-                    }
-                }
-            }
-            TrieNode::Extension(ext) => {
-                if let Some(child_hash) = ext.child.as_hash() {
-                    let mut child_path = path;
-                    child_path.extend(&ext.key);
-                    enqueue(child_hash, child_path);
-                }
-            }
-            TrieNode::Leaf(_) | TrieNode::EmptyRoot => {}
-        }
-    }
-
-    Ok(trie)
+    (synthesized_state_root, witness_map, hashed_address)
 }

--- a/crates/stateless-core/src/withdrawals.rs
+++ b/crates/stateless-core/src/withdrawals.rs
@@ -12,7 +12,7 @@ use alloy_rpc_types_eth::Header;
 use reth_trie::Nibbles;
 use reth_trie_common::{EMPTY_ROOT_HASH, LeafNode, TrieAccount, TrieNode};
 use reth_trie_sparse::{
-    SerialSparseTrie, SparseStateTrie, provider::DefaultTrieNodeProviderFactory,
+    SerialSparseTrie, SparseStateTrie, SparseTrie, provider::DefaultTrieNodeProviderFactory,
 };
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -89,10 +89,20 @@ impl MptWitness {
             .reveal_witness(synthesized_state_root, &witness_map)
             .map_err(|e| WithdrawalValidationError::TrieOperationFailed(e.to_string()))?;
 
+        // `reveal_witness` skips storage subtrees whose root is `EMPTY_ROOT_HASH`,
+        // leaving the per-address storage trie blind. That's fine for pre-state
+        // verification, but if the block writes any non-zero slot to an
+        // empty-pre-state trie (e.g. the first-ever withdrawal), the subsequent
+        // `update_storage_leaf` call would fail with "sparse trie is blind".
+        // Insert a revealed-empty storage trie so writes can proceed.
+        if self.storage_root == EMPTY_ROOT_HASH {
+            state_trie.insert_storage_trie(hashed_address, SparseTrie::revealed_empty());
+        }
+
         // Verify pre-state root. `storage_root` returns `None` when the storage
-        // trie wasn't revealed (reveal_witness skips storage subtrees whose
-        // root is EMPTY_ROOT_HASH), so fall back to EMPTY_ROOT_HASH for the
-        // empty-withdrawals case.
+        // trie wasn't revealed; that only happens when `self.storage_root` was
+        // non-empty and reveal_witness failed to populate it, which the check
+        // below will catch as a mismatch.
         let pre_root = state_trie.storage_root(hashed_address).unwrap_or(EMPTY_ROOT_HASH);
         if pre_root != self.storage_root {
             return Err(WithdrawalValidationError::PreStateRootMismatch {
@@ -274,5 +284,15 @@ mod tests {
             run(root, vec![], Some(root), &[(SLOT, U256::from(99u64))]),
             Err(PreStateRootMismatch { .. } | TrieOperationFailed(_))
         ));
+    }
+
+    /// First-ever withdrawal: empty pre-state storage trie, one new non-zero slot.
+    /// Exercises the `EMPTY_ROOT_HASH` pre-state path where `reveal_witness` skips
+    /// the storage subtree, so `update_storage_leaf` must still initialize and
+    /// write into the trie correctly.
+    #[test]
+    fn empty_pre_state_with_new_leaf() {
+        let (post, _) = leaf(42);
+        run(EMPTY_ROOT_HASH, vec![], Some(post), &[(SLOT, U256::from(42u64))]).unwrap();
     }
 }

--- a/crates/stateless-core/src/withdrawals.rs
+++ b/crates/stateless-core/src/withdrawals.rs
@@ -89,7 +89,10 @@ impl MptWitness {
             .reveal_witness(synthesized_state_root, &witness_map)
             .map_err(|e| WithdrawalValidationError::TrieOperationFailed(e.to_string()))?;
 
-        // Verify pre-state root
+        // Verify pre-state root. `storage_root` returns `None` when the storage
+        // trie wasn't revealed (reveal_witness skips storage subtrees whose
+        // root is EMPTY_ROOT_HASH), so fall back to EMPTY_ROOT_HASH for the
+        // empty-withdrawals case.
         let pre_root = state_trie.storage_root(hashed_address).unwrap_or(EMPTY_ROOT_HASH);
         if pre_root != self.storage_root {
             return Err(WithdrawalValidationError::PreStateRootMismatch {
@@ -118,7 +121,7 @@ impl MptWitness {
             }
         }
 
-        // Verify post-state root
+        // Verify post-state root (same empty-trie caveat as pre-state).
         let post_root = state_trie.storage_root(hashed_address).unwrap_or(EMPTY_ROOT_HASH);
         if post_root != expected_post_root {
             return Err(WithdrawalValidationError::PostStateRootMismatch {
@@ -158,7 +161,115 @@ fn synthesize_state_witness(witness: &MptWitness) -> (B256, B256Map<Bytes>, B256
     account_leaf.encode(&mut leaf_rlp);
     let leaf_bytes = Bytes::from(leaf_rlp);
     let synthesized_state_root = keccak256(&leaf_bytes);
+    // Synthesized leaf shares witness_map keyspace with real storage nodes;
+    // keccak-256 collision resistance makes a clash cryptographically negligible.
     witness_map.insert(synthesized_state_root, leaf_bytes);
 
     (synthesized_state_root, witness_map, hashed_address)
+}
+
+#[cfg(test)]
+mod tests {
+    use WithdrawalValidationError::*;
+    use alloy_primitives::{Sealable, b256};
+
+    use super::*;
+
+    const SLOT: B256 = b256!("0x1111111111111111111111111111111111111111111111111111111111111111");
+    const BOGUS: B256 = b256!("0xdeadbeef00000000000000000000000000000000000000000000000000000000");
+
+    fn header(root: Option<B256>) -> Header {
+        let inner = alloy_consensus::Header { withdrawals_root: root, ..Default::default() };
+        Header::from_consensus(inner.seal_slow(), None, None)
+    }
+
+    /// One-leaf storage trie: root = keccak(leaf_rlp). Returns (root, [leaf_bytes]).
+    fn single_leaf() -> (B256, Vec<Bytes>) {
+        let value_rlp = alloy_rlp::encode_fixed_size(&U256::from(42u64)).to_vec();
+        let leaf = TrieNode::Leaf(LeafNode::new(Nibbles::unpack(SLOT), value_rlp));
+        let mut rlp = Vec::new();
+        leaf.encode(&mut rlp);
+        let bytes = Bytes::from(rlp);
+        (keccak256(&bytes), vec![bytes])
+    }
+
+    fn verify(
+        storage_root: B256,
+        state: Vec<Bytes>,
+        expected: Option<B256>,
+    ) -> Result<(), WithdrawalValidationError> {
+        MptWitness { storage_root, state }.verify(&header(expected), B256Map::default())
+    }
+
+    fn verify_with(
+        storage_root: B256,
+        state: Vec<Bytes>,
+        expected: B256,
+        slot: B256,
+        value: U256,
+    ) -> Result<(), WithdrawalValidationError> {
+        let mut updates = B256Map::default();
+        updates.insert(slot, value);
+        MptWitness { storage_root, state }.verify(&header(Some(expected)), updates)
+    }
+
+    #[test]
+    fn missing_withdrawals_root() {
+        assert_eq!(verify(EMPTY_ROOT_HASH, vec![], None), Err(MissingWithdrawalsRoot));
+    }
+
+    #[test]
+    fn empty_trie_verifies() {
+        verify(EMPTY_ROOT_HASH, vec![], Some(EMPTY_ROOT_HASH)).unwrap();
+    }
+
+    #[test]
+    fn pre_state_mismatch() {
+        assert!(matches!(
+            verify(BOGUS, vec![], Some(EMPTY_ROOT_HASH)),
+            Err(PreStateRootMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn post_state_mismatch() {
+        let (root, state) = single_leaf();
+        assert!(matches!(
+            verify(root, state, Some(EMPTY_ROOT_HASH)),
+            Err(PostStateRootMismatch { .. })
+        ));
+    }
+
+    /// Attack: claimed pre-state root non-empty, witness nodes omitted.
+    #[test]
+    fn missing_nodes() {
+        let (root, _) = single_leaf();
+        assert!(matches!(verify(root, vec![], Some(root)), Err(PreStateRootMismatch { .. })));
+    }
+
+    /// Attack: tampered node bytes → hash mismatch → treated as missing.
+    #[test]
+    fn tampered_node() {
+        let (root, mut state) = single_leaf();
+        let mut bytes = state[0].to_vec();
+        *bytes.last_mut().unwrap() ^= 0x01;
+        state[0] = Bytes::from(bytes);
+        assert!(matches!(verify(root, state, Some(root)), Err(PreStateRootMismatch { .. })));
+    }
+
+    /// Attack: update targets a slot whose subtree is missing.
+    #[test]
+    fn update_on_missing_subtree() {
+        let (root, _) = single_leaf();
+        assert!(matches!(
+            verify_with(root, vec![], root, SLOT, U256::from(99u64)),
+            Err(PreStateRootMismatch { .. } | TrieOperationFailed(_))
+        ));
+    }
+
+    #[test]
+    fn leaf_removal_collapses_to_empty() {
+        let (root, state) = single_leaf();
+        verify_with(root, state, EMPTY_ROOT_HASH, SLOT, U256::ZERO).unwrap();
+    }
 }

--- a/crates/stateless-core/src/withdrawals.rs
+++ b/crates/stateless-core/src/withdrawals.rs
@@ -148,6 +148,11 @@ fn synthesize_state_witness(witness: &MptWitness) -> (B256, B256Map<Bytes>, B256
         witness.state.iter().map(|node| (keccak256(node), node.clone())).collect();
 
     let hashed_address = keccak256(ADDRESS_L2_TO_L1_MESSAGE_PASSER);
+    // `nonce`, `balance`, and `code_hash` are intentionally dummy values — they
+    // do not reflect the real L2ToL1MessagePasser account state. `reveal_witness`
+    // only reads `storage_root` from this leaf to navigate into the storage trie;
+    // the other fields are never inspected or validated. Do not change them
+    // thinking it makes verification more correct.
     let trie_account = TrieAccount {
         nonce: 0,
         balance: U256::ZERO,
@@ -238,6 +243,13 @@ mod tests {
             verify(root, state, Some(EMPTY_ROOT_HASH)),
             Err(PostStateRootMismatch { .. })
         ));
+    }
+
+    /// Happy path: non-empty trie, no updates, post-root equals pre-root.
+    #[test]
+    fn non_empty_trie_no_updates_verifies() {
+        let (root, state) = single_leaf();
+        verify(root, state, Some(root)).unwrap();
     }
 
     /// Attack: claimed pre-state root non-empty, witness nodes omitted.


### PR DESCRIPTION
## Summary

Refactor `MptWitness::verify` to use `SparseStateTrie::reveal_witness` instead of the hand-rolled BFS trie reconstruction in `rebuild_trie`.

- Replaces the custom BFS reveal loop (branch/extension child enqueueing, visited tracking, manual RLP decode) with reth's `SparseStateTrie::reveal_witness`, which handles BFS traversal internally.
- Introduces `synthesize_state_witness`, a helper that wraps the storage-only `MptWitness` as a single-account state witness so the account-level `reveal_witness` API can discover and reveal the storage nodes for `L2ToL1MessagePasser`.
- Switches storage updates to `update_storage_leaf` / `remove_storage_leaf` with `DefaultTrieNodeProviderFactory`, and reads roots via `state_trie.storage_root(hashed_address)`.
- Removes now-unused error variants (`WitnessNodeNotFound`, `RlpDecodeFailed`, `TrieNotRevealed`) and the `BRANCH_NODE_CHILDREN` constant.

Net diff: **+61 / −120 lines** in `crates/stateless-core/src/withdrawals.rs`.

## Motivation

The previous `rebuild_trie` duplicated logic that already exists in `reth-trie-sparse`. Delegating to `SparseStateTrie::reveal_witness` reduces surface area, removes three error variants and a BFS implementation we had to maintain ourselves, and keeps the withdrawal validator aligned with reth's sparse-trie API.

## Test plan

- [x] `cargo check -p stateless-core`
- [x] `cargo test -p stateless-core` (withdrawal validation tests)
- [x] `cargo clippy --workspace --all-targets --all-features`
- [x] `cargo fmt --all --check`
- [x] End-to-end: run `stateless-validator` against a block containing withdrawals and confirm `withdrawals_root` verification still passes.