### PR TITLE
chore: upgrade mega-evm and add Rex5 hardfork support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3254,7 +3254,7 @@ dependencies = [
 [[package]]
 name = "mega-evm"
 version = "1.5.1"
-source = "git+https://github.com/megaeth-labs/mega-evm.git?rev=v1.5.1#92e21683ccde382e99e6a96cd971887c6a2964e8"
+source = "git+https://github.com/megaeth-labs/mega-evm.git?rev=4e4d85cc8202ec4980ec4fa0b6f50666c9d7e92e#4e4d85cc8202ec4980ec4fa0b6f50666c9d7e92e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3281,7 +3281,7 @@ dependencies = [
 [[package]]
 name = "mega-system-contracts"
 version = "1.5.1"
-source = "git+https://github.com/megaeth-labs/mega-evm.git?rev=v1.5.1#92e21683ccde382e99e6a96cd971887c6a2964e8"
+source = "git+https://github.com/megaeth-labs/mega-evm.git?rev=4e4d85cc8202ec4980ec4fa0b6f50666c9d7e92e#4e4d85cc8202ec4980ec4fa0b6f50666c9d7e92e"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ alloy-signer-local = "1.0.23"
 alloy-trie = { version = "0.9.0", default-features = false }
 
 # mega
-mega-evm = { git = "https://github.com/megaeth-labs/mega-evm.git", rev = "v1.5.1" }
+mega-evm = { git = "https://github.com/megaeth-labs/mega-evm.git", rev = "4e4d85cc8202ec4980ec4fa0b6f50666c9d7e92e" }
 salt = { git = "https://github.com/megaeth-labs/salt.git", rev = "v1.0.1" }
 
 # op

--- a/crates/stateless-core/src/chain_spec.rs
+++ b/crates/stateless-core/src/chain_spec.rs
@@ -111,6 +111,8 @@ pub struct MegaethGenesisHardforks {
     pub rex_3_time: Option<u64>,
     /// Rex4 hardfork timestamp.
     pub rex_4_time: Option<u64>,
+    /// Rex5 hardfork timestamp.
+    pub rex_5_time: Option<u64>,
 }
 
 impl MegaethGenesisHardforks {
@@ -130,6 +132,7 @@ impl MegaethGenesisHardforks {
             (MegaHardfork::Rex2.boxed(), self.rex_2_time.map(ForkCondition::Timestamp)),
             (MegaHardfork::Rex3.boxed(), self.rex_3_time.map(ForkCondition::Timestamp)),
             (MegaHardfork::Rex4.boxed(), self.rex_4_time.map(ForkCondition::Timestamp)),
+            (MegaHardfork::Rex5.boxed(), self.rex_5_time.map(ForkCondition::Timestamp)),
         ]
         .into_iter()
         .filter_map(|(hardfork, condition)| condition.map(|c| (hardfork, c)))
@@ -149,6 +152,7 @@ pub static MEGA_MAINNET_HARDFORKS: std::sync::LazyLock<ChainHardforks> =
             (MegaHardfork::Rex2.boxed(), ForkCondition::Timestamp(0)),
             (MegaHardfork::Rex3.boxed(), ForkCondition::Timestamp(0)),
             (MegaHardfork::Rex4.boxed(), ForkCondition::Timestamp(0)),
+            (MegaHardfork::Rex5.boxed(), ForkCondition::Timestamp(0)),
         ])
     });
 
@@ -201,7 +205,8 @@ mod tests {
           "rex1Time": 5,
           "rex2Time": 6,
           "rex3Time": 7,
-          "rex4Time": 8
+          "rex4Time": 8,
+          "rex5Time": 9
         }
         "#;
         let fields = serde_json::from_str::<OtherFields>(genesis_info).unwrap();
@@ -214,5 +219,6 @@ mod tests {
         assert_eq!(hardforks.rex_2_time, Some(6));
         assert_eq!(hardforks.rex_3_time, Some(7));
         assert_eq!(hardforks.rex_4_time, Some(8));
+        assert_eq!(hardforks.rex_5_time, Some(9));
     }
 }


### PR DESCRIPTION
## Summary

- Bumps `mega-evm` from `v1.5.1` to commit `4e4d85cc8202ec4980ec4fa0b6f50666c9d7e92e` to pull in Rex5 support.
- Adds `Rex5` hardfork to `MegaethGenesisHardforks` and wires it into both the genesis-driven fork schedule and the `MEGA_MAINNET_HARDFORKS` preset.
- Extends the `rex*Time` genesis deserialization test to cover the new `rex5Time` field.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test -p stateless-core chain_spec`
- [x] `cargo fmt --all --check` and `cargo clippy --workspace --all-targets --all-features`