### PR TITLE
chore: remove legacy STATELESS_VALIDATOR_LOG_* env var migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,10 +107,10 @@ Each command-line flag has an equivalent environment variable:
 - `STATELESS_VALIDATOR_METRICS_PORT` → `--metrics-port`
 
 **Logging Configuration:**
-- `STATELESS_VALIDATOR_LOG_FILE_DIRECTORY`: Directory for log files; enables file logging when set.
+- `STATELESS_LOG_FILE_DIRECTORY`: Directory for log files; enables file logging when set.
   Files rotate daily as `stateless-validator.log.YYYY-MM-DD`.
-- `STATELESS_VALIDATOR_LOG_FILE`: Log level for file output (debug|info|warn|error, default: debug)
-- `STATELESS_VALIDATOR_LOG_STDOUT`: Log level for console output (debug|info|warn|error, default: info)
+- `STATELESS_LOG_FILE`: Log level for file output (debug|info|warn|error, default: debug)
+- `STATELESS_LOG_STDOUT`: Log level for console output (debug|info|warn|error, default: info)
 
 Command-line arguments take precedence over environment variables.
 

--- a/bin/stateless-validator/src/app.rs
+++ b/bin/stateless-validator/src/app.rs
@@ -7,10 +7,7 @@ use alloy_primitives::BlockHash;
 use alloy_rpc_types_eth::BlockId;
 use clap::Parser;
 use eyre::Result;
-use stateless_common::{
-    BackoffPolicy, RpcClient, RpcClientConfig,
-    logging::{LogArgs, migrate_legacy_env_vars},
-};
+use stateless_common::{BackoffPolicy, RpcClient, RpcClientConfig, logging::LogArgs};
 use stateless_core::{
     ChainStore, ContractStore, GenesisStore, chain_spec::ChainSpec, db::BlockMeta,
 };
@@ -153,7 +150,6 @@ pub struct CommandLineArgs {
 /// validator DB, loads or initializes the chain spec + anchor, then hands off to
 /// [`workers::run_with_signals`].
 pub async fn run() -> Result<()> {
-    migrate_legacy_env_vars();
     let args = CommandLineArgs::parse();
     let _log_guard = args.log.init_tracing()?;
     let start = std::time::Instant::now();

--- a/crates/stateless-common/src/logging.rs
+++ b/crates/stateless-common/src/logging.rs
@@ -149,31 +149,6 @@ fn build_file_writer(
     Ok((non_blocking, guard))
 }
 
-/// Migrate legacy `STATELESS_VALIDATOR_LOG_*` env vars to the new `STATELESS_LOG_*` names.
-/// Only copies when the new var is not already set, so the new name always takes precedence.
-///
-/// Must be called **before** `clap::Parser::parse()` so that clap sees the migrated values.
-///
-/// # Safety
-///
-/// This mutates process-global environment state. Call it early in `main()` before
-/// spawning any threads or starting async runtimes.
-pub fn migrate_legacy_env_vars() {
-    const LEGACY_MAP: &[(&str, &str)] = &[
-        ("STATELESS_VALIDATOR_LOG_STDOUT", "STATELESS_LOG_STDOUT"),
-        ("STATELESS_VALIDATOR_LOG_FILE", "STATELESS_LOG_FILE"),
-        ("STATELESS_VALIDATOR_LOG_FILE_DIRECTORY", "STATELESS_LOG_FILE_DIRECTORY"),
-    ];
-    for &(old, new) in LEGACY_MAP {
-        if std::env::var(new).is_err() &&
-            let Ok(val) = std::env::var(old)
-        {
-            // SAFETY: called before any multithreaded runtime is started.
-            unsafe { std::env::set_var(new, val) };
-        }
-    }
-}
-
 impl LogArgs {
     /// Initialize the global tracing subscriber based on the current configuration.
     ///


### PR DESCRIPTION
## Summary

- Drop the `migrate_legacy_env_vars()` shim in `stateless-common::logging` that copied `STATELESS_VALIDATOR_LOG_*` into the newer `STATELESS_LOG_*` names at startup.
- Remove the corresponding call in `bin/stateless-validator/src/app.rs::run()` and its import.
- Update `README.md` so the **Logging Configuration** section documents only the canonical `STATELESS_LOG_FILE_DIRECTORY` / `STATELESS_LOG_FILE` / `STATELESS_LOG_STDOUT` variables.

The legacy names duplicated the new ones and were only kept as a transitional alias; with the rename settled, the migration helper is no longer needed.

## Breaking change

Users still setting `STATELESS_VALIDATOR_LOG_FILE_DIRECTORY`, `STATELESS_VALIDATOR_LOG_FILE`, or `STATELESS_VALIDATOR_LOG_STDOUT` must rename them to the `STATELESS_LOG_*` equivalents. Command-line flags (`--log-*`) are unchanged.

## Test plan

- [x] `cargo build` / `cargo check --workspace`
- [x] `cargo fmt --all --check` and `cargo clippy --workspace --all-targets --all-features`
- [x] Run `stateless-validator` with `STATELESS_LOG_FILE_DIRECTORY=./validator-data/logs STATELESS_LOG_STDOUT=info` and confirm file + stdout logging behave as before.
- [x] Run with the old `STATELESS_VALIDATOR_LOG_*` names and confirm they are now ignored (no silent fallthrough).