### PR TITLE
fix: bump mega-evm to 915f71e to fix missing storage slots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3256,7 +3256,7 @@ dependencies = [
 [[package]]
 name = "mega-evm"
 version = "1.5.1"
-source = "git+https://github.com/megaeth-labs/mega-evm.git?rev=4e4d85cc8202ec4980ec4fa0b6f50666c9d7e92e#4e4d85cc8202ec4980ec4fa0b6f50666c9d7e92e"
+source = "git+https://github.com/megaeth-labs/mega-evm.git?rev=47c7e3b1690e28a1c195db18129f66d91f508865#47c7e3b1690e28a1c195db18129f66d91f508865"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3283,7 +3283,7 @@ dependencies = [
 [[package]]
 name = "mega-system-contracts"
 version = "1.5.1"
-source = "git+https://github.com/megaeth-labs/mega-evm.git?rev=4e4d85cc8202ec4980ec4fa0b6f50666c9d7e92e#4e4d85cc8202ec4980ec4fa0b6f50666c9d7e92e"
+source = "git+https://github.com/megaeth-labs/mega-evm.git?rev=47c7e3b1690e28a1c195db18129f66d91f508865#47c7e3b1690e28a1c195db18129f66d91f508865"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3256,7 +3256,7 @@ dependencies = [
 [[package]]
 name = "mega-evm"
 version = "1.5.1"
-source = "git+https://github.com/megaeth-labs/mega-evm.git?rev=47c7e3b1690e28a1c195db18129f66d91f508865#47c7e3b1690e28a1c195db18129f66d91f508865"
+source = "git+https://github.com/megaeth-labs/mega-evm.git?rev=915f71e324141140c7f08687fc23db63402e06e0#915f71e324141140c7f08687fc23db63402e06e0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3283,7 +3283,7 @@ dependencies = [
 [[package]]
 name = "mega-system-contracts"
 version = "1.5.1"
-source = "git+https://github.com/megaeth-labs/mega-evm.git?rev=47c7e3b1690e28a1c195db18129f66d91f508865#47c7e3b1690e28a1c195db18129f66d91f508865"
+source = "git+https://github.com/megaeth-labs/mega-evm.git?rev=915f71e324141140c7f08687fc23db63402e06e0#915f71e324141140c7f08687fc23db63402e06e0"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ alloy-signer-local = "1.0.23"
 alloy-trie = { version = "0.9.0", default-features = false }
 
 # mega
-mega-evm = { git = "https://github.com/megaeth-labs/mega-evm.git", rev = "47c7e3b1690e28a1c195db18129f66d91f508865", default-features = false }
+mega-evm = { git = "https://github.com/megaeth-labs/mega-evm.git", rev = "915f71e324141140c7f08687fc23db63402e06e0", default-features = false }
 salt = { git = "https://github.com/megaeth-labs/salt.git", rev = "v1.0.2", default-features = false }
 
 # op

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ alloy-signer-local = "1.0.23"
 alloy-trie = { version = "0.9.0", default-features = false }
 
 # mega
-mega-evm = { git = "https://github.com/megaeth-labs/mega-evm.git", rev = "4e4d85cc8202ec4980ec4fa0b6f50666c9d7e92e", default-features = false }
+mega-evm = { git = "https://github.com/megaeth-labs/mega-evm.git", rev = "47c7e3b1690e28a1c195db18129f66d91f508865", default-features = false }
 salt = { git = "https://github.com/megaeth-labs/salt.git", rev = "v1.0.2", default-features = false }
 
 # op


### PR DESCRIPTION
## Summary

- Bump `mega-evm` to the latest `main` revision (`915f71e`) to pick up the fix for missing storage slots in stateless validation.
- Supersedes the intermediate bump to `47c7e3b` from earlier on this branch.

## Test plan

- [x] `cargo build --release` succeeds with the new revision
- [x] `cargo test --workspace` passes
- [x] Validator successfully processes blocks that previously failed due to lacking slots