### PR TITLE
chore: bump mega-evm to v1.5.2 and stateless-validator to v2.0.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1890,7 +1890,7 @@ dependencies = [
 
 [[package]]
 name = "debug-trace-server"
-version = "2.0.10"
+version = "2.0.11"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -5901,7 +5901,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stateless-common"
-version = "2.0.10"
+version = "2.0.11"
 dependencies = [
  "clap",
  "eyre",
@@ -5913,7 +5913,7 @@ dependencies = [
 
 [[package]]
 name = "stateless-core"
-version = "2.0.10"
+version = "2.0.11"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5960,7 +5960,7 @@ dependencies = [
 
 [[package]]
 name = "stateless-validator"
-version = "2.0.10"
+version = "2.0.11"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3459,8 +3459,8 @@ dependencies = [
 
 [[package]]
 name = "mega-evm"
-version = "1.5.1"
-source = "git+https://github.com/megaeth-labs/mega-evm.git?rev=v1.5.1#92e21683ccde382e99e6a96cd971887c6a2964e8"
+version = "1.5.2"
+source = "git+https://github.com/megaeth-labs/mega-evm.git?rev=v1.5.2#be425a5a5966ac8e8b7e3422c2d04ffb71f66c29"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3486,8 +3486,8 @@ dependencies = [
 
 [[package]]
 name = "mega-system-contracts"
-version = "1.5.1"
-source = "git+https://github.com/megaeth-labs/mega-evm.git?rev=v1.5.1#92e21683ccde382e99e6a96cd971887c6a2964e8"
+version = "1.5.2"
+source = "git+https://github.com/megaeth-labs/mega-evm.git?rev=v1.5.2#be425a5a5966ac8e8b7e3422c2d04ffb71f66c29"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.0.10"
+version = "2.0.11"
 edition = "2024"
 rust-version = "1.95"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ futures = "0.3"
 lz4_flex = { version = "0.11", default-features = false }
 
 # megaeth 
-mega-evm = { git = "https://github.com/megaeth-labs/mega-evm.git", rev = "v1.5.1" }
+mega-evm = { git = "https://github.com/megaeth-labs/mega-evm.git", rev = "v1.5.2" }
 metrics = "0.24"
 metrics-derive = "0.1"
 metrics-exporter-prometheus = { version = "0.18", default-features = false, features = ["http-listener"] }


### PR DESCRIPTION
## Summary

- Bump `mega-evm` dependency from `v1.5.1` to `v1.5.2`.
- Bump workspace version (`stateless-validator`, `stateless-core`, `stateless-common`, `debug-trace-server`) from `2.0.10` to `2.0.11`.
- Regenerate `Cargo.lock` accordingly.

## Test plan

- [x] `cargo check --workspace`
- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets --all-features`