### PR TITLE
chore: salt rev bump + `fx_hashmap_serde` wiring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1157,7 +1157,7 @@ checksum = "7b7e4c2464d97fe331d41de9d5db0def0a96f4d823b8b32a2efd503578988973"
 [[package]]
 name = "banderwagon"
 version = "0.1.0"
-source = "git+https://github.com/megaeth-labs/salt.git?rev=v1.0.3#31d91fc13205fbcd7fa3e1329451a4239e1896bf"
+source = "git+https://github.com/megaeth-labs/salt.git?rev=a04647065f12dbd8461dc40569731656d160d694#a04647065f12dbd8461dc40569731656d160d694"
 dependencies = [
  "ark-ec 0.5.0 (git+https://github.com/megaeth-labs/algebra.git?rev=80ca69c37f79d5d00750edc1602af81b5f456695)",
  "ark-ed-on-bls12-381-bandersnatch",
@@ -2876,7 +2876,7 @@ dependencies = [
 [[package]]
 name = "ipa-multipoint"
 version = "0.1.0"
-source = "git+https://github.com/megaeth-labs/salt.git?rev=v1.0.3#31d91fc13205fbcd7fa3e1329451a4239e1896bf"
+source = "git+https://github.com/megaeth-labs/salt.git?rev=a04647065f12dbd8461dc40569731656d160d694#a04647065f12dbd8461dc40569731656d160d694"
 dependencies = [
  "banderwagon",
  "hashbrown 0.16.1",
@@ -5117,7 +5117,7 @@ checksum = "dd29631678d6fb0903b69223673e122c32e9ae559d0960a38d574695ebc0ea15"
 [[package]]
 name = "salt"
 version = "1.0.3"
-source = "git+https://github.com/megaeth-labs/salt.git?rev=v1.0.3#31d91fc13205fbcd7fa3e1329451a4239e1896bf"
+source = "git+https://github.com/megaeth-labs/salt.git?rev=a04647065f12dbd8461dc40569731656d160d694#a04647065f12dbd8461dc40569731656d160d694"
 dependencies = [
  "auto_impl",
  "banderwagon",
@@ -5139,7 +5139,7 @@ dependencies = [
 [[package]]
 name = "salt-macros"
 version = "0.1.0"
-source = "git+https://github.com/megaeth-labs/salt.git?rev=v1.0.3#31d91fc13205fbcd7fa3e1329451a4239e1896bf"
+source = "git+https://github.com/megaeth-labs/salt.git?rev=a04647065f12dbd8461dc40569731656d160d694#a04647065f12dbd8461dc40569731656d160d694"
 dependencies = [
  "rayon",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1157,7 +1157,7 @@ checksum = "7b7e4c2464d97fe331d41de9d5db0def0a96f4d823b8b32a2efd503578988973"
 [[package]]
 name = "banderwagon"
 version = "0.1.0"
-source = "git+https://github.com/megaeth-labs/salt.git?rev=v1.0.2#2bb00254bbe9fd6671afac8a1bf3464614638b1c"
+source = "git+https://github.com/megaeth-labs/salt.git?rev=v1.0.3#31d91fc13205fbcd7fa3e1329451a4239e1896bf"
 dependencies = [
  "ark-ec 0.5.0 (git+https://github.com/megaeth-labs/algebra.git?rev=80ca69c37f79d5d00750edc1602af81b5f456695)",
  "ark-ed-on-bls12-381-bandersnatch",
@@ -2876,7 +2876,7 @@ dependencies = [
 [[package]]
 name = "ipa-multipoint"
 version = "0.1.0"
-source = "git+https://github.com/megaeth-labs/salt.git?rev=v1.0.2#2bb00254bbe9fd6671afac8a1bf3464614638b1c"
+source = "git+https://github.com/megaeth-labs/salt.git?rev=v1.0.3#31d91fc13205fbcd7fa3e1329451a4239e1896bf"
 dependencies = [
  "banderwagon",
  "hashbrown 0.16.1",
@@ -5116,8 +5116,8 @@ checksum = "dd29631678d6fb0903b69223673e122c32e9ae559d0960a38d574695ebc0ea15"
 
 [[package]]
 name = "salt"
-version = "1.0.2"
-source = "git+https://github.com/megaeth-labs/salt.git?rev=v1.0.2#2bb00254bbe9fd6671afac8a1bf3464614638b1c"
+version = "1.0.3"
+source = "git+https://github.com/megaeth-labs/salt.git?rev=v1.0.3#31d91fc13205fbcd7fa3e1329451a4239e1896bf"
 dependencies = [
  "auto_impl",
  "banderwagon",
@@ -5139,7 +5139,7 @@ dependencies = [
 [[package]]
 name = "salt-macros"
 version = "0.1.0"
-source = "git+https://github.com/megaeth-labs/salt.git?rev=v1.0.2#2bb00254bbe9fd6671afac8a1bf3464614638b1c"
+source = "git+https://github.com/megaeth-labs/salt.git?rev=v1.0.3#31d91fc13205fbcd7fa3e1329451a4239e1896bf"
 dependencies = [
  "rayon",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 [workspace.package]
 version = "2.0.10"
 edition = "2024"
-rust-version = "1.95"
+rust-version = "1.91"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/megaeth-labs/stateless-validator"
 exclude = [".github/"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 [workspace.package]
 version = "2.0.10"
 edition = "2024"
-rust-version = "1.91"
+rust-version = "1.95"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/megaeth-labs/stateless-validator"
 exclude = [".github/"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ alloy-trie = { version = "0.9.0", default-features = false }
 
 # mega
 mega-evm = { git = "https://github.com/megaeth-labs/mega-evm.git", rev = "915f71e324141140c7f08687fc23db63402e06e0", default-features = false }
-salt = { git = "https://github.com/megaeth-labs/salt.git", rev = "v1.0.3", default-features = false }
+salt = { git = "https://github.com/megaeth-labs/salt.git", rev = "a04647065f12dbd8461dc40569731656d160d694", default-features = false }
 
 # op
 op-alloy-network = { version = "0.18.12", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ alloy-trie = { version = "0.9.0", default-features = false }
 
 # mega
 mega-evm = { git = "https://github.com/megaeth-labs/mega-evm.git", rev = "915f71e324141140c7f08687fc23db63402e06e0", default-features = false }
-salt = { git = "https://github.com/megaeth-labs/salt.git", rev = "v1.0.2", default-features = false }
+salt = { git = "https://github.com/megaeth-labs/salt.git", rev = "v1.0.3", default-features = false }
 
 # op
 op-alloy-network = { version = "0.18.12", default-features = false }

--- a/crates/stateless-core/src/light_witness.rs
+++ b/crates/stateless-core/src/light_witness.rs
@@ -216,9 +216,9 @@ mod tests {
         }
         let original = LightWitness { kvs: BTreeMap::new(), levels };
 
-        let bytes = bincode::serde::encode_to_vec(&original, bincode::config::legacy()).unwrap();
+        let bytes = bincode::serde::encode_to_vec(&original, bincode::config::standard()).unwrap();
         let (decoded, _): (LightWitness, _) =
-            bincode::serde::decode_from_slice(&bytes, bincode::config::legacy()).unwrap();
+            bincode::serde::decode_from_slice(&bytes, bincode::config::standard()).unwrap();
 
         assert_eq!(original.kvs, decoded.kvs);
         assert_eq!(original.levels.len(), decoded.levels.len());

--- a/crates/stateless-core/src/light_witness.rs
+++ b/crates/stateless-core/src/light_witness.rs
@@ -32,7 +32,12 @@ type FxHashMap<K, V> = HashMap<K, V, FxBuildHasher>;
 pub struct LightWitness {
     /// All witnessed key-value pairs (same as SaltWitness.kvs)
     pub kvs: BTreeMap<SaltKey, Option<SaltValue>>,
-    /// Bucket subtree levels (same as SaltProof.levels)
+    /// Bucket subtree levels (same as SaltProof.levels).
+    ///
+    /// Routed through [`salt::fx_hashmap_serde`] so we don't have to enable
+    /// `hashbrown/serde` (which transitively pulls in `serde_core 1.0.221+`
+    /// and breaks downstream `alloy-tx-macros 1.0.23`).
+    #[serde(with = "salt::fx_hashmap_serde")]
     pub levels: FxHashMap<BucketId, u8>,
 }
 
@@ -197,5 +202,28 @@ mod tests {
         let fast = LightWitness { kvs: BTreeMap::new(), levels: FxHashMap::default() };
         assert!(fast.kvs.is_empty());
         assert!(fast.levels.is_empty());
+    }
+
+    /// Round-trip a populated `LightWitness` through bincode to confirm the
+    /// `#[serde(with = "salt::fx_hashmap_serde")]` wiring on the `levels`
+    /// field actually works end-to-end. The adapter itself is covered by
+    /// salt's own tests; this test just guards the integration.
+    #[test]
+    fn round_trip_through_bincode() {
+        let mut levels: FxHashMap<BucketId, u8> = HashMap::with_hasher(FxBuildHasher);
+        for (k, v) in [(0u32, 0u8), (42, 3), (1_000_000, 7), (BucketId::MAX, 255)] {
+            levels.insert(k, v);
+        }
+        let original = LightWitness { kvs: BTreeMap::new(), levels };
+
+        let bytes = bincode::serde::encode_to_vec(&original, bincode::config::legacy()).unwrap();
+        let (decoded, _): (LightWitness, _) =
+            bincode::serde::decode_from_slice(&bytes, bincode::config::legacy()).unwrap();
+
+        assert_eq!(original.kvs, decoded.kvs);
+        assert_eq!(original.levels.len(), decoded.levels.len());
+        for (k, v) in &original.levels {
+            assert_eq!(decoded.levels.get(k), Some(v));
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Bump `salt` dependency from `v1.0.2` to commit `a046470` (post-`v1.0.3`, which exports the new `salt::fx_hashmap_serde` module). `Cargo.lock` is updated for `salt`, `salt-macros`, `banderwagon`, and `ipa-multipoint`.
- Route `LightWitness.levels` (`FxHashMap<BucketId, u8>`) through `#[serde(with = "salt::fx_hashmap_serde")]` so we no longer need to enable `hashbrown/serde`. The `hashbrown/serde` feature transitively pulls in `serde_core 1.0.221+`, which breaks downstream `alloy-tx-macros 1.0.23`; using salt's adapter keeps us off that path.
- Add a `round_trip_through_bincode` unit test in `light_witness.rs` to guard the integration — it bincode-encodes/decodes a populated `LightWitness` (using `bincode::config::standard()`, matching how we store light witnesses on disk) and asserts the `levels` map survives the round trip. The adapter itself is covered by salt's own tests; this only pins down the wiring on our side.

## Test plan

- [x] `cargo build --release`
- [x] `cargo test --workspace` (includes the new `round_trip_through_bincode` test for `LightWitness`)
- [x] `cargo clippy --workspace --all-targets --all-features`
- [x] Validate a range of mainnet blocks end-to-end to confirm witness verification still passes against the new SALT release.