### PR TITLE
feat: parse Rex5 SequencerRegistry bootstrap from genesis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3256,7 +3256,7 @@ dependencies = [
 [[package]]
 name = "mega-evm"
 version = "1.5.1"
-source = "git+https://github.com/megaeth-labs/mega-evm.git?rev=915f71e324141140c7f08687fc23db63402e06e0#915f71e324141140c7f08687fc23db63402e06e0"
+source = "git+https://github.com/megaeth-labs/mega-evm.git?rev=09ceb5d3f91fcec61d4f40fa2a67d13d7c1ab245#09ceb5d3f91fcec61d4f40fa2a67d13d7c1ab245"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3283,7 +3283,7 @@ dependencies = [
 [[package]]
 name = "mega-system-contracts"
 version = "1.5.1"
-source = "git+https://github.com/megaeth-labs/mega-evm.git?rev=915f71e324141140c7f08687fc23db63402e06e0#915f71e324141140c7f08687fc23db63402e06e0"
+source = "git+https://github.com/megaeth-labs/mega-evm.git?rev=09ceb5d3f91fcec61d4f40fa2a67d13d7c1ab245#09ceb5d3f91fcec61d4f40fa2a67d13d7c1ab245"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -3412,7 +3412,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ alloy-signer-local = "1.0.23"
 alloy-trie = { version = "0.9.0", default-features = false }
 
 # mega
-mega-evm = { git = "https://github.com/megaeth-labs/mega-evm.git", rev = "915f71e324141140c7f08687fc23db63402e06e0", default-features = false }
+mega-evm = { git = "https://github.com/megaeth-labs/mega-evm.git", rev = "09ceb5d3f91fcec61d4f40fa2a67d13d7c1ab245", default-features = false }
 salt = { git = "https://github.com/megaeth-labs/salt.git", rev = "a04647065f12dbd8461dc40569731656d160d694", default-features = false }
 
 # op

--- a/crates/stateless-core/src/chain_spec.rs
+++ b/crates/stateless-core/src/chain_spec.rs
@@ -1,6 +1,7 @@
 //! Chain specification and hardfork activation logic.
 
-use std::{any::Any, boxed::Box, sync::Arc, vec, vec::Vec};
+use core::any::Any;
+use std::{boxed::Box, sync::Arc, vec, vec::Vec};
 
 use alloy_genesis::Genesis;
 use alloy_hardforks::{EthereumHardfork, EthereumHardforks, ForkCondition, Hardfork};

--- a/crates/stateless-core/src/chain_spec.rs
+++ b/crates/stateless-core/src/chain_spec.rs
@@ -74,9 +74,10 @@ impl ChainSpec {
     /// `rex5InitialSequencer` / `rex5InitialAdmin` addresses; both are validated immediately so a
     /// misconfigured genesis fails at load rather than at the first Rex5 block.
     pub fn from_genesis(genesis: Genesis) -> Self {
-        // extract megaeth hardforks from genesis
-        let megaeth_hardforks =
-            MegaethGenesisHardforks::extract_from(&genesis.config.extra_fields).unwrap_or_default();
+        // A malformed `rex5Time` treated as "Rex5 absent" would skip the bootstrap-required
+        // check and diverge from mega-reth at the activation timestamp, so surface parse errors.
+        let megaeth_hardforks = MegaethGenesisHardforks::extract_from(&genesis.config.extra_fields)
+            .unwrap_or_else(|err| panic!("malformed MegaETH hardforks in genesis: {err}"));
         let rex5_scheduled = megaeth_hardforks.rex_5_time.is_some();
         let mut megaeth_hardforks = megaeth_hardforks.into_vec();
 
@@ -155,8 +156,10 @@ pub struct MegaethGenesisHardforks {
 
 impl MegaethGenesisHardforks {
     /// Extract the MegaETH genesis hardforks from a genesis file.
-    pub fn extract_from(others: &OtherFields) -> Option<Self> {
-        others.deserialize_as().ok()
+    ///
+    /// Absent fields deserialize to `None`; present-but-malformed fields return an error.
+    pub fn extract_from(others: &OtherFields) -> serde_json::Result<Self> {
+        others.deserialize_as()
     }
 
     /// Convert the MegaETH genesis hardforks into a vector of hardforks and their conditions.
@@ -281,7 +284,7 @@ mod tests {
         }
         "#;
         let fields = serde_json::from_str::<OtherFields>(genesis_info).unwrap();
-        let hardforks = MegaethGenesisHardforks::extract_from(&fields).unwrap();
+        let hardforks = MegaethGenesisHardforks::extract_from(&fields).expect("well-formed");
         assert_eq!(hardforks.mini_rex_time, Some(1));
         assert_eq!(hardforks.mini_rex_1_time, Some(2));
         assert_eq!(hardforks.mini_rex_2_time, Some(3));
@@ -291,6 +294,14 @@ mod tests {
         assert_eq!(hardforks.rex_3_time, Some(7));
         assert_eq!(hardforks.rex_4_time, Some(8));
         assert_eq!(hardforks.rex_5_time, Some(9));
+    }
+
+    #[test]
+    #[should_panic(expected = "malformed MegaETH hardforks in genesis")]
+    fn test_chain_spec_malformed_rex5_time_panics() {
+        let mut genesis = Genesis::default();
+        genesis.config.extra_fields.insert_value("rex5Time".to_string(), "not-a-number").unwrap();
+        let _ = ChainSpec::from_genesis(genesis);
     }
 
     #[test]

--- a/crates/stateless-core/src/chain_spec.rs
+++ b/crates/stateless-core/src/chain_spec.rs
@@ -1,7 +1,7 @@
 //! Chain specification and hardfork activation logic.
 
 use core::any::Any;
-use std::{boxed::Box, sync::Arc, vec, vec::Vec};
+use std::{boxed::Box, vec, vec::Vec};
 
 use alloy_genesis::Genesis;
 use alloy_hardforks::{EthereumHardfork, EthereumHardforks, ForkCondition, Hardfork};
@@ -26,9 +26,8 @@ pub struct ChainSpec {
     pub hardforks: ChainHardforks,
     /// Rex5 `SequencerRegistry` bootstrap, parsed from genesis `config` extra fields.
     ///
-    /// `None` for pre-Rex5 chains; `Some(...)` when `rex5Time` is configured. Held as
-    /// `Arc` so `Clone` is cheap (the executor clones `ChainSpec` per block).
-    pub sequencer_registry_config: Option<Arc<SequencerRegistryConfig>>,
+    /// `None` for pre-Rex5 chains; `Some(...)` when `rex5Time` is configured.
+    pub sequencer_registry_config: Option<SequencerRegistryConfig>,
 }
 
 impl EthereumHardforks for ChainSpec {
@@ -51,7 +50,7 @@ impl MegaHardforks for ChainSpec {
     fn fork_params_any(&self, fork: MegaHardfork) -> Option<&(dyn Any + Send + Sync)> {
         match fork {
             MegaHardfork::Rex5 => {
-                self.sequencer_registry_config.as_deref().map(|c| c as &(dyn Any + Send + Sync))
+                self.sequencer_registry_config.as_ref().map(|c| c as &(dyn Any + Send + Sync))
             }
             _ => None,
         }
@@ -94,7 +93,7 @@ impl ChainSpec {
             let cfg = parsed.into_config();
             cfg.validate()
                 .unwrap_or_else(|err| panic!("invalid SequencerRegistryConfig: {}", err.message));
-            Some(Arc::new(cfg))
+            Some(cfg)
         } else {
             None
         };
@@ -179,21 +178,9 @@ impl MegaethGenesisHardforks {
     }
 }
 
-/// Rex5 `SequencerRegistry` bootstrap configuration in genesis.
+/// Rex5 `SequencerRegistry` bootstrap, parsed from genesis `config` extra fields.
 ///
-/// Read as top-level `config` extra fields (flat schema; matches mega-reth):
-/// ```json
-/// "config": {
-///   "rex5Time": 0,
-///   "rex5InitialSequencer": "0x...",
-///   "rex5InitialAdmin": "0x..."
-/// }
-/// ```
-///
-/// The initial system address is intentionally absent — it is hardcoded to
-/// `mega_evm::MEGA_SYSTEM_ADDRESS` at genesis because every pre-Rex5 component
-/// (payload executor, txpool, replay) assumes that constant.
-///
+/// Flat schema (matches mega-reth) so a single genesis.json works for both binaries.
 /// Both addresses must be non-zero or [`SequencerRegistryConfig::validate`] rejects them.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/crates/stateless-core/src/chain_spec.rs
+++ b/crates/stateless-core/src/chain_spec.rs
@@ -92,8 +92,7 @@ impl ChainSpec {
                 panic!("malformed or missing SequencerRegistryConfig in genesis: {err}")
             });
             let cfg = parsed.into_config();
-            cfg.validate()
-                .unwrap_or_else(|err| panic!("invalid SequencerRegistryConfig: {err}"));
+            cfg.validate().unwrap_or_else(|err| panic!("invalid SequencerRegistryConfig: {err}"));
             Some(cfg)
         } else {
             None

--- a/crates/stateless-core/src/chain_spec.rs
+++ b/crates/stateless-core/src/chain_spec.rs
@@ -1,12 +1,13 @@
 //! Chain specification and hardfork activation logic.
 
-use std::{boxed::Box, vec, vec::Vec};
+use std::{any::Any, boxed::Box, sync::Arc, vec, vec::Vec};
 
 use alloy_genesis::Genesis;
 use alloy_hardforks::{EthereumHardfork, EthereumHardforks, ForkCondition, Hardfork};
 use alloy_op_hardforks::{OpHardfork, OpHardforks};
+use alloy_primitives::Address;
 use alloy_serde::OtherFields;
-use mega_evm::{MegaHardfork, MegaHardforks};
+use mega_evm::{HardforkParams, MegaHardfork, MegaHardforks, SequencerRegistryConfig};
 use reth_ethereum_forks::ChainHardforks;
 use reth_optimism_chainspec::OpChainSpec;
 
@@ -22,6 +23,11 @@ pub const BLOB_GASPRICE_UPDATE_FRACTION: u64 = 3338477;
 pub struct ChainSpec {
     pub chain_id: u64,
     pub hardforks: ChainHardforks,
+    /// Rex5 `SequencerRegistry` bootstrap, parsed from genesis `config` extra fields.
+    ///
+    /// `None` for pre-Rex5 chains; `Some(...)` when `rex5Time` is configured. Held as
+    /// `Arc` so `Clone` is cheap (the executor clones `ChainSpec` per block).
+    pub sequencer_registry_config: Option<Arc<SequencerRegistryConfig>>,
 }
 
 impl EthereumHardforks for ChainSpec {
@@ -40,6 +46,15 @@ impl MegaHardforks for ChainSpec {
     fn mega_fork_activation(&self, fork: MegaHardfork) -> ForkCondition {
         self.hardforks.fork(fork)
     }
+
+    fn fork_params_any(&self, fork: MegaHardfork) -> Option<&(dyn Any + Send + Sync)> {
+        match fork {
+            MegaHardfork::Rex5 => {
+                self.sequencer_registry_config.as_deref().map(|c| c as &(dyn Any + Send + Sync))
+            }
+            _ => None,
+        }
+    }
 }
 
 impl ChainSpec {
@@ -55,13 +70,33 @@ impl ChainSpec {
     /// - The MegaETH set is then merged with the Optimism/Ethereum set to build a single
     ///   [`ChainHardforks`] that drives fork activation.
     ///
-    /// This yields a deterministic activation order across all supported hardfork families.
+    /// When `rex5Time` is configured, the genesis `config` extra fields must also carry the flat
+    /// `rex5InitialSequencer` / `rex5InitialAdmin` addresses; both are validated immediately so a
+    /// misconfigured genesis fails at load rather than at the first Rex5 block.
     pub fn from_genesis(genesis: Genesis) -> Self {
         // extract megaeth hardforks from genesis
-        let mut megaeth_hardforks =
-            MegaethGenesisHardforks::extract_from(&genesis.config.extra_fields)
-                .unwrap_or_default()
-                .into_vec();
+        let megaeth_hardforks =
+            MegaethGenesisHardforks::extract_from(&genesis.config.extra_fields).unwrap_or_default();
+        let rex5_scheduled = megaeth_hardforks.rex_5_time.is_some();
+        let mut megaeth_hardforks = megaeth_hardforks.into_vec();
+
+        // Rex5 SequencerRegistry bootstrap, required iff `rex5Time` is scheduled. Parsed from
+        // the same flat schema mega-reth uses (`rex5InitialSequencer` / `rex5InitialAdmin` as
+        // top-level `config` fields), so a single genesis.json works for both binaries.
+        let sequencer_registry_config = if rex5_scheduled {
+            let parsed = MegaethGenesisSequencerRegistryConfig::parse_required_from(
+                &genesis.config.extra_fields,
+            )
+            .unwrap_or_else(|err| {
+                panic!("malformed or missing SequencerRegistryConfig in genesis: {err}")
+            });
+            let cfg = parsed.into_config();
+            cfg.validate()
+                .unwrap_or_else(|err| panic!("invalid SequencerRegistryConfig: {}", err.message));
+            Some(Arc::new(cfg))
+        } else {
+            None
+        };
 
         let chain_id = genesis.config.chain_id;
         let op_chain_spec = OpChainSpec::from_genesis(genesis);
@@ -90,7 +125,7 @@ impl ChainSpec {
         // we merge megaeth_hardforks with op_hardforks
         all_hardforks.append(&mut op_hardforks);
 
-        Self { chain_id, hardforks: ChainHardforks::new(all_hardforks) }
+        Self { chain_id, hardforks: ChainHardforks::new(all_hardforks), sequencer_registry_config }
     }
 }
 
@@ -140,6 +175,50 @@ impl MegaethGenesisHardforks {
         .into_iter()
         .filter_map(|(hardfork, condition)| condition.map(|c| (hardfork, c)))
         .collect()
+    }
+}
+
+/// Rex5 `SequencerRegistry` bootstrap configuration in genesis.
+///
+/// Read as top-level `config` extra fields (flat schema; matches mega-reth):
+/// ```json
+/// "config": {
+///   "rex5Time": 0,
+///   "rex5InitialSequencer": "0x...",
+///   "rex5InitialAdmin": "0x..."
+/// }
+/// ```
+///
+/// The initial system address is intentionally absent — it is hardcoded to
+/// `mega_evm::MEGA_SYSTEM_ADDRESS` at genesis because every pre-Rex5 component
+/// (payload executor, txpool, replay) assumes that constant.
+///
+/// Both addresses must be non-zero or [`SequencerRegistryConfig::validate`] rejects them.
+#[derive(Default, Debug, Clone, Copy, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MegaethGenesisSequencerRegistryConfig {
+    /// Initial sequencer (mini-block signing key) seeded at Rex5 activation.
+    pub rex5_initial_sequencer: Address,
+    /// Initial admin (can schedule future role changes) seeded at Rex5 activation.
+    pub rex5_initial_admin: Address,
+}
+
+impl MegaethGenesisSequencerRegistryConfig {
+    /// Parse the required SequencerRegistry bootstrap from genesis extra fields.
+    ///
+    /// Returns a serde error if either address field is missing or malformed. Callers should
+    /// only invoke it once they have decided the bootstrap is required, i.e. when `rex5Time`
+    /// is configured.
+    pub fn parse_required_from(others: &OtherFields) -> serde_json::Result<Self> {
+        others.deserialize_as()
+    }
+
+    /// Convert to the canonical mega-evm [`SequencerRegistryConfig`].
+    pub fn into_config(self) -> SequencerRegistryConfig {
+        SequencerRegistryConfig {
+            rex5_initial_sequencer: self.rex5_initial_sequencer,
+            rex5_initial_admin: self.rex5_initial_admin,
+        }
     }
 }
 
@@ -224,5 +303,86 @@ mod tests {
         assert_eq!(hardforks.rex_3_time, Some(7));
         assert_eq!(hardforks.rex_4_time, Some(8));
         assert_eq!(hardforks.rex_5_time, Some(9));
+    }
+
+    #[test]
+    fn test_parse_sequencer_registry_from_flat_json() {
+        let genesis_info = r#"
+        {
+          "rex5Time": 0,
+          "rex5InitialSequencer": "0x0000000000000000000000000000000000000001",
+          "rex5InitialAdmin": "0x0000000000000000000000000000000000000002"
+        }
+        "#;
+        let fields = serde_json::from_str::<OtherFields>(genesis_info).unwrap();
+        let parsed = MegaethGenesisSequencerRegistryConfig::parse_required_from(&fields).unwrap();
+        assert_eq!(parsed.rex5_initial_sequencer, Address::with_last_byte(1));
+        assert_eq!(parsed.rex5_initial_admin, Address::with_last_byte(2));
+    }
+
+    #[test]
+    fn test_chain_spec_carries_sequencer_registry_as_fork_params() {
+        let mut genesis = Genesis::default();
+        genesis.config.extra_fields.insert_value("rex5Time".to_string(), 0).unwrap();
+        genesis
+            .config
+            .extra_fields
+            .insert_value(
+                "rex5InitialSequencer".to_string(),
+                "0x0000000000000000000000000000000000000001",
+            )
+            .unwrap();
+        genesis
+            .config
+            .extra_fields
+            .insert_value(
+                "rex5InitialAdmin".to_string(),
+                "0x0000000000000000000000000000000000000002",
+            )
+            .unwrap();
+        let spec = ChainSpec::from_genesis(genesis);
+        let params = spec.fork_params::<SequencerRegistryConfig>().expect("Rex5 params present");
+        assert_eq!(params.rex5_initial_sequencer, Address::with_last_byte(1));
+        assert_eq!(params.rex5_initial_admin, Address::with_last_byte(2));
+    }
+
+    #[test]
+    fn test_chain_spec_no_rex5_returns_none() {
+        let genesis = Genesis::default();
+        let spec = ChainSpec::from_genesis(genesis);
+        assert!(spec.fork_params::<SequencerRegistryConfig>().is_none());
+        assert!(spec.sequencer_registry_config.is_none());
+    }
+
+    #[test]
+    #[should_panic(expected = "malformed or missing SequencerRegistryConfig in genesis")]
+    fn test_chain_spec_rex5_without_bootstrap_panics() {
+        let mut genesis = Genesis::default();
+        genesis.config.extra_fields.insert_value("rex5Time".to_string(), 0).unwrap();
+        let _ = ChainSpec::from_genesis(genesis);
+    }
+
+    #[test]
+    #[should_panic(expected = "invalid SequencerRegistryConfig")]
+    fn test_chain_spec_zero_sequencer_panics() {
+        let mut genesis = Genesis::default();
+        genesis.config.extra_fields.insert_value("rex5Time".to_string(), 0).unwrap();
+        genesis
+            .config
+            .extra_fields
+            .insert_value(
+                "rex5InitialSequencer".to_string(),
+                "0x0000000000000000000000000000000000000000",
+            )
+            .unwrap();
+        genesis
+            .config
+            .extra_fields
+            .insert_value(
+                "rex5InitialAdmin".to_string(),
+                "0x0000000000000000000000000000000000000002",
+            )
+            .unwrap();
+        let _ = ChainSpec::from_genesis(genesis);
     }
 }

--- a/crates/stateless-core/src/chain_spec.rs
+++ b/crates/stateless-core/src/chain_spec.rs
@@ -93,7 +93,7 @@ impl ChainSpec {
             });
             let cfg = parsed.into_config();
             cfg.validate()
-                .unwrap_or_else(|err| panic!("invalid SequencerRegistryConfig: {}", err.message));
+                .unwrap_or_else(|err| panic!("invalid SequencerRegistryConfig: {err}"));
             Some(cfg)
         } else {
             None

--- a/crates/stateless-core/src/chain_spec.rs
+++ b/crates/stateless-core/src/chain_spec.rs
@@ -195,7 +195,7 @@ impl MegaethGenesisHardforks {
 /// (payload executor, txpool, replay) assumes that constant.
 ///
 /// Both addresses must be non-zero or [`SequencerRegistryConfig::validate`] rejects them.
-#[derive(Default, Debug, Clone, Copy, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct MegaethGenesisSequencerRegistryConfig {
     /// Initial sequencer (mini-block signing key) seeded at Rex5 activation.
@@ -382,6 +382,30 @@ mod tests {
             .insert_value(
                 "rex5InitialAdmin".to_string(),
                 "0x0000000000000000000000000000000000000002",
+            )
+            .unwrap();
+        let _ = ChainSpec::from_genesis(genesis);
+    }
+
+    #[test]
+    #[should_panic(expected = "invalid SequencerRegistryConfig")]
+    fn test_chain_spec_zero_admin_panics() {
+        let mut genesis = Genesis::default();
+        genesis.config.extra_fields.insert_value("rex5Time".to_string(), 0).unwrap();
+        genesis
+            .config
+            .extra_fields
+            .insert_value(
+                "rex5InitialSequencer".to_string(),
+                "0x0000000000000000000000000000000000000001",
+            )
+            .unwrap();
+        genesis
+            .config
+            .extra_fields
+            .insert_value(
+                "rex5InitialAdmin".to_string(),
+                "0x0000000000000000000000000000000000000000",
             )
             .unwrap();
         let _ = ChainSpec::from_genesis(genesis);


### PR DESCRIPTION
## Summary

Mirrors mega-reth PR [#1738](https://github.com/megaeth-labs/mega-reth/pull/1738) on the stateless-validator side so the executor can replay Rex5 blocks.

- Bumps `mega-evm` from `915f71e` to `09ceb5d` — the first rev that ships `SequencerRegistryConfig`,  `HardforkParams`, and `MegaHardforks::fork_params_any`. Without these the block executor errors with `"Rex5 active but SequencerRegistryConfig not configured"` on the first Rex5 block (see `mega-evm/src/block/executor.rs:285`).
- Teaches `ChainSpec::from_genesis` to read the flat `rex5InitialSequencer` / `rex5InitialAdmin` extra fields from `config` when `rex5Time` is set, validate them via `HardforkParams::validate` (zero-seed rejection), and expose them through `MegaHardforks::fork_params_any` so mega-evm picks them up during `pre_execution_changes`. The genesis schema is byte-identical to mega-reth's `MegaethGenesisSequencerRegistryConfig` (2 fields, no `initial_system_address` — that's hardcoded to `MEGA_SYSTEM_ADDRESS`), so one `genesis.json` works for both binaries.
- Panic messages match mega-reth verbatim (`"malformed or missing SequencerRegistryConfig in genesis: …"` for missing/malformed bootstrap, `"invalid SequencerRegistryConfig: …"` for zero seeds) so the same strings show up in both sets of logs.

No other source files need to change: `executor.rs` already clones `ChainSpec` into `MegaBlockExecutorFactory`, and mega-evm's pre-execution helpers (`transact_deploy_sequencer_registry`, `transact_apply_pending_changes`) record every account/slot they touch into the witness read set per the contract documented in `mega-evm/src/system/mod.rs`, so `WitnessDatabase` and `ContractCache` are unaffected.

## Test plan

- [x] `cargo check -p stateless-core`
- [x] `cargo test -p stateless-core chain_spec` — 8 unit tests: flat-schema parse, fork-params propagation, missing-bootstrap panic, zero-seed panic
- [x] `cargo build --workspace`
- [x] `cargo test -p stateless-validator --test integration` — 6/6 pass; pre-Rex5 fixtures exercise the `fork_params_any → None` path
- [x] `cargo clippy --workspace --all-targets --all-features`
- [x] `cargo fmt --all --check` and `cargo sort --check --workspace --grouped --order package,workspace,lints,profile,bin,benches,dependencies,dev-dependencies,features`
- [x] Replay real Rex5 block in chain-ops, and run test-client