### PR TITLE
chore: downgrade rust-version to 1.91

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 [workspace.package]
 version = "2.0.10"
 edition = "2024"
-rust-version = "1.95"
+rust-version = "1.91"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/megaeth-labs/stateless-validator"
 exclude = [".github/"]


### PR DESCRIPTION
## Summary
- Lower the workspace `rust-version` from `1.95` to `1.91` in `Cargo.toml`.
- Broadens the set of stable toolchains that can build the workspace, so downstream consumers and CI environments still on 1.91–1.94 are no longer locked out.

## Test plan
- [x] `cargo build --workspace` on a 1.91 toolchain
- [x] `cargo check --workspace --all-targets --all-features`
- [x] `cargo test --workspace`
- [x] Confirm no edition-2024 / 1.92+ language features are in use that would break the bumped-down MSRV