### PR TITLE
ci: allow mega-putin bot in claude action review jobs

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -74,6 +74,8 @@ jobs:
       - uses: anthropics/claude-code-action@v1.0.88
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # PRs opened by the engineer-agent bot (mega-putin) must still be reviewed.
+          allowed_bots: "mega-putin"
           additional_permissions: |
             actions: read
           claude_args: |
@@ -114,6 +116,8 @@ jobs:
       - uses: anthropics/claude-code-action@v1.0.88
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # PRs opened by the engineer-agent bot (mega-putin) must still be reviewed.
+          allowed_bots: "mega-putin"
           claude_args: |
             --allowedTools "Read,Glob,Grep,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*),Bash(gh label list:*),Bash(git log:*),Bash(git diff:*),Bash(ls:*)"
           prompt: |


### PR DESCRIPTION
## Summary
- The `anthropics/claude-code-action` step ignores events authored by bot accounts by default, so the automated `pr-review` and `label-check` jobs skip PRs opened by the engineer-agent bot (`mega-putin`).
- Add `allowed_bots: "mega-putin"` to both jobs so mega-putin's PRs still get reviewed and label-checked, matching the existing pattern in `mega-agents`.

## Test plan
- YAML validated locally (`yaml.safe_load`).
- Verify on a mega-putin-authored PR that the `pr-review` and `label-check` jobs run instead of being skipped.

---
*This PR was generated by an automated agent.*