### PR TITLE
refactor: drop redundant Arc<Bytecode> indirection

### DIFF
--- a/bin/debug-trace-server/src/chain_sync.rs
+++ b/bin/debug-trace-server/src/chain_sync.rs
@@ -201,13 +201,10 @@ mod tests {
     // Minimal mock for test compilation
     struct MockBlockStore;
     impl stateless_core::ContractStore for MockBlockStore {
-        fn get_contracts(
-            &self,
-            _: &[B256],
-        ) -> StoreResult<(HashMap<B256, Arc<Bytecode>>, Vec<B256>)> {
+        fn get_contracts(&self, _: &[B256]) -> StoreResult<(HashMap<B256, Bytecode>, Vec<B256>)> {
             Ok((Default::default(), vec![]))
         }
-        fn add_contracts(&self, _: &[(B256, Arc<Bytecode>)]) -> StoreResult<()> {
+        fn add_contracts(&self, _: &[(B256, Bytecode)]) -> StoreResult<()> {
             Ok(())
         }
     }

--- a/bin/debug-trace-server/src/data_provider.rs
+++ b/bin/debug-trace-server/src/data_provider.rs
@@ -65,8 +65,9 @@ pub struct BlockData {
     /// Light witness without expensive EC point validation.
     pub witness: LightWitness,
     /// Contract bytecodes keyed by code hash, required for EVM execution.
-    /// Values share allocations with the `ContractCache`.
-    pub contracts: HashMap<B256, Arc<Bytecode>>,
+    /// `Bytecode` is internally reference-counted, so values share their underlying allocation
+    /// with the `ContractCache` (and across `BlockData` clones) via cheap refcount-bump clones.
+    pub contracts: HashMap<B256, Bytecode>,
 }
 
 /// Default timeout for a user-facing witness fetch in seconds (8 seconds).
@@ -554,7 +555,7 @@ impl DataProvider {
         &self,
         code_hashes: &[B256],
         deadline: Instant,
-    ) -> DataProviderResult<HashMap<B256, Arc<Bytecode>>> {
+    ) -> DataProviderResult<HashMap<B256, Bytecode>> {
         resolve_contracts_inner(&self.rpc_client, &self.contract_cache, code_hashes, deadline).await
     }
 }
@@ -753,7 +754,7 @@ async fn resolve_contracts_inner(
     contract_cache: &ContractCache,
     code_hashes: &[B256],
     deadline: Instant,
-) -> DataProviderResult<HashMap<B256, Arc<Bytecode>>> {
+) -> DataProviderResult<HashMap<B256, Bytecode>> {
     let (mut contracts, missing) = contract_cache.get(code_hashes)?;
 
     if missing.is_empty() {
@@ -771,7 +772,7 @@ async fn resolve_contracts_inner(
     // `TraceRpcMetrics` adapter inside `round_robin_with_backoff`.
     let fetched = rpc_client.get_codes_with_deadline(&missing, true, Some(deadline)).await?;
 
-    let new_contracts: Vec<(B256, Arc<Bytecode>)> = fetched.into_iter().collect();
+    let new_contracts: Vec<(B256, Bytecode)> = fetched.into_iter().collect();
 
     // Write-through: memory always, disk in local-cache mode. We don't fail the trace on
     // cache-insert errors; the request has already been served.
@@ -791,14 +792,11 @@ async fn resolve_contracts_inner(
 pub(crate) struct NoopContractStore;
 
 impl ContractStore for NoopContractStore {
-    fn get_contracts(
-        &self,
-        hashes: &[B256],
-    ) -> StoreResult<(HashMap<B256, Arc<Bytecode>>, Vec<B256>)> {
+    fn get_contracts(&self, hashes: &[B256]) -> StoreResult<(HashMap<B256, Bytecode>, Vec<B256>)> {
         Ok((HashMap::default(), hashes.to_vec()))
     }
 
-    fn add_contracts(&self, _codes: &[(B256, Arc<Bytecode>)]) -> StoreResult<()> {
+    fn add_contracts(&self, _codes: &[(B256, Bytecode)]) -> StoreResult<()> {
         Ok(())
     }
 }

--- a/bin/debug-trace-server/src/server_db.rs
+++ b/bin/debug-trace-server/src/server_db.rs
@@ -3,7 +3,7 @@
 //! Provides persistent storage of block data, witnesses, and canonical chain state
 //! for serving `debug_*` and `trace_*` RPC methods.
 
-use std::{path::Path, sync::Arc};
+use std::path::Path;
 
 use alloy_primitives::{B256, BlockHash, BlockNumber, map::HashMap};
 use alloy_rpc_types_eth::Block;
@@ -218,14 +218,11 @@ impl ServerDB {
 }
 
 impl ContractStore for ServerDB {
-    fn get_contracts(
-        &self,
-        hashes: &[B256],
-    ) -> StoreResult<(HashMap<B256, Arc<Bytecode>>, Vec<B256>)> {
+    fn get_contracts(&self, hashes: &[B256]) -> StoreResult<(HashMap<B256, Bytecode>, Vec<B256>)> {
         read_contracts(&self.database, hashes)
     }
 
-    fn add_contracts(&self, codes: &[(B256, Arc<Bytecode>)]) -> StoreResult<()> {
+    fn add_contracts(&self, codes: &[(B256, Bytecode)]) -> StoreResult<()> {
         write_add_contracts(&self.database, codes)
     }
 }
@@ -352,8 +349,7 @@ mod tests {
 
         let hash1 = B256::from([1u8; 32]);
         let hash2 = B256::from([2u8; 32]);
-        let bytecode =
-            Arc::new(Bytecode::new_raw(alloy_primitives::Bytes::from_static(&[0x60, 0x00])));
+        let bytecode = Bytecode::new_raw(alloy_primitives::Bytes::from_static(&[0x60, 0x00]));
 
         ContractStore::add_contracts(&db, &[(hash1, bytecode.clone())]).unwrap();
 

--- a/bin/debug-trace-server/src/tracing_executor.rs
+++ b/bin/debug-trace-server/src/tracing_executor.rs
@@ -24,8 +24,6 @@
 //! ## Parity-style (trace_* methods)
 //! - `LocalizedTransactionTrace` - Flat call traces with block/tx context
 
-use std::sync::Arc;
-
 use alloy_consensus::Transaction;
 use alloy_evm::{Evm as EvmTrait, block::BlockExecutor};
 use alloy_op_evm::block::OpAlloyReceiptBuilder;
@@ -167,7 +165,7 @@ impl<'a> TracingEnv<'a> {
 
     fn create_witness_db<'b>(
         &'b self,
-        contracts: &'b HashMap<B256, Arc<Bytecode>>,
+        contracts: &'b HashMap<B256, Bytecode>,
     ) -> WitnessDatabase<'b, LightWitnessExecutor> {
         WitnessDatabase { header: self.header, witness: &self.light_witness_executor, contracts }
     }
@@ -444,7 +442,7 @@ pub fn trace_block(
     chain_spec: &ChainSpec,
     block: &Block<OpTransaction>,
     witness: LightWitness,
-    contracts: &HashMap<B256, Arc<Bytecode>>,
+    contracts: &HashMap<B256, Bytecode>,
     opts: GethDebugTracingOptions,
 ) -> Result<Vec<TraceResult>, ValidationError> {
     let env = TracingEnv::new(chain_spec, block, witness)?;
@@ -710,7 +708,7 @@ pub fn trace_transaction(
     block: &Block<OpTransaction>,
     tx_index: usize,
     light_witness: LightWitness,
-    contracts: &HashMap<B256, Arc<Bytecode>>,
+    contracts: &HashMap<B256, Bytecode>,
     opts: GethDebugTracingOptions,
 ) -> Result<GethTrace, ValidationError> {
     let env = TracingEnv::new(chain_spec, block, light_witness)?;
@@ -877,7 +875,7 @@ pub fn parity_trace_block(
     chain_spec: &ChainSpec,
     block: &Block<OpTransaction>,
     light_witness: LightWitness,
-    contracts: &HashMap<B256, Arc<Bytecode>>,
+    contracts: &HashMap<B256, Bytecode>,
 ) -> Result<Vec<LocalizedTransactionTrace>, ValidationError> {
     let env = TracingEnv::new(chain_spec, block, light_witness)?;
 
@@ -927,7 +925,7 @@ pub fn parity_trace_transaction(
     block: &Block<OpTransaction>,
     tx_index: usize,
     light_witness: LightWitness,
-    contracts: &HashMap<B256, Arc<Bytecode>>,
+    contracts: &HashMap<B256, Bytecode>,
 ) -> Result<Vec<LocalizedTransactionTrace>, ValidationError> {
     let env = TracingEnv::new(chain_spec, block, light_witness)?;
 

--- a/bin/stateless-validator/src/chain_sync.rs
+++ b/bin/stateless-validator/src/chain_sync.rs
@@ -196,7 +196,7 @@ impl BlockProcessor for ValidatorProcessor {
                     }
                 })?;
 
-            let new_bytecodes: Vec<(B256, Arc<Bytecode>)> = fetched.into_iter().collect();
+            let new_bytecodes: Vec<(B256, Bytecode)> = fetched.into_iter().collect();
 
             self.contract_cache
                 .insert(&new_bytecodes)

--- a/bin/stateless-validator/src/validator_db.rs
+++ b/bin/stateless-validator/src/validator_db.rs
@@ -6,7 +6,7 @@
 //! CANONICAL_CHAIN is bounded to `max_chain_length` entries; older entries are
 //! pruned inline during [`ChainStore::advance_chain`].
 
-use std::{path::Path, sync::Arc};
+use std::path::Path;
 
 use alloy_genesis::Genesis;
 use alloy_primitives::{B256, BlockHash, BlockNumber, map::HashMap};
@@ -73,14 +73,11 @@ impl ValidatorDB {
 }
 
 impl ContractStore for ValidatorDB {
-    fn get_contracts(
-        &self,
-        hashes: &[B256],
-    ) -> StoreResult<(HashMap<B256, Arc<Bytecode>>, Vec<B256>)> {
+    fn get_contracts(&self, hashes: &[B256]) -> StoreResult<(HashMap<B256, Bytecode>, Vec<B256>)> {
         read_contracts(&self.database, hashes)
     }
 
-    fn add_contracts(&self, codes: &[(B256, Arc<Bytecode>)]) -> StoreResult<()> {
+    fn add_contracts(&self, codes: &[(B256, Bytecode)]) -> StoreResult<()> {
         write_add_contracts(&self.database, codes)
     }
 }
@@ -227,10 +224,8 @@ mod tests {
         let hash2 = B256::from([2u8; 32]);
         let hash3 = B256::from([3u8; 32]);
 
-        let bytecode1 =
-            Arc::new(Bytecode::new_raw(alloy_primitives::Bytes::from_static(&[0x60, 0x00])));
-        let bytecode2 =
-            Arc::new(Bytecode::new_raw(alloy_primitives::Bytes::from_static(&[0x60, 0x01])));
+        let bytecode1 = Bytecode::new_raw(alloy_primitives::Bytes::from_static(&[0x60, 0x00]));
+        let bytecode2 = Bytecode::new_raw(alloy_primitives::Bytes::from_static(&[0x60, 0x01]));
 
         store.add_contracts(&[(hash1, bytecode1.clone()), (hash2, bytecode2.clone())]).unwrap();
 
@@ -282,8 +277,7 @@ mod tests {
         let cache = ContractCache::new(Arc::new(store));
 
         let hash = B256::from([1u8; 32]);
-        let bytecode =
-            Arc::new(Bytecode::new_raw(alloy_primitives::Bytes::from_static(&[0x60, 0x00])));
+        let bytecode = Bytecode::new_raw(alloy_primitives::Bytes::from_static(&[0x60, 0x00]));
 
         cache.insert(&[(hash, bytecode.clone())]).unwrap();
 
@@ -299,8 +293,7 @@ mod tests {
         let db_path = dir.path().join("test.redb");
 
         let hash = B256::from([1u8; 32]);
-        let bytecode =
-            Arc::new(Bytecode::new_raw(alloy_primitives::Bytes::from_static(&[0x60, 0x00])));
+        let bytecode = Bytecode::new_raw(alloy_primitives::Bytes::from_static(&[0x60, 0x00]));
 
         {
             let store = ValidatorDB::new(&db_path).unwrap();

--- a/crates/stateless-common/src/rpc_client.rs
+++ b/crates/stateless-common/src/rpc_client.rs
@@ -654,15 +654,15 @@ impl RpcClient {
     ///
     /// # Return type
     ///
-    /// Returns `Arc<Bytecode>` so the value shares one allocation with the
-    /// [`crate::ContractCache`] end-to-end. Callers that feed into the verified
-    /// `ContractCache` tiers should pass `verify = true`; the cache itself trusts memory/disk
-    /// hits and does not re-verify.
+    /// Returns plain `Bytecode`: it is already internally reference-counted, so it shares one
+    /// underlying allocation with the [`crate::ContractCache`] end-to-end without an outer `Arc`.
+    /// Callers that feed into the verified `ContractCache` tiers should pass `verify = true`; the
+    /// cache itself trusts memory/disk hits and does not re-verify.
     pub async fn get_codes(
         &self,
         hashes: &[B256],
         verify: bool,
-    ) -> std::result::Result<HashMap<B256, Arc<Bytecode>>, CodeFetchError> {
+    ) -> std::result::Result<HashMap<B256, Bytecode>, CodeFetchError> {
         self.get_codes_with_deadline(hashes, verify, None).await
     }
 
@@ -677,7 +677,7 @@ impl RpcClient {
         hashes: &[B256],
         verify: bool,
         deadline: Option<Instant>,
-    ) -> std::result::Result<HashMap<B256, Arc<Bytecode>>, CodeFetchError> {
+    ) -> std::result::Result<HashMap<B256, Bytecode>, CodeFetchError> {
         // `try_join_all` cancels the remaining per-hash futures on the first error — a
         // `VerificationFailure` or `Deadline` on one hash stops the rest of the batch
         // immediately and releases their concurrency permits, so a slow straggler can't
@@ -691,7 +691,7 @@ impl RpcClient {
                     return Err(CodeFetchError::VerificationFailure { requested: hash, actual });
                 }
             }
-            Ok::<_, CodeFetchError>((hash, Arc::new(code)))
+            Ok::<_, CodeFetchError>((hash, code))
         }))
         .await
         .map(|pairs| pairs.into_iter().collect())
@@ -1655,10 +1655,10 @@ mod tests {
         handle.stop().unwrap();
     }
 
-    /// All-good batch: verified entries are returned wrapped in `Arc<Bytecode>` (the type
-    /// change that lets `ContractCache::insert` avoid a second allocation at each call site).
+    /// All-good batch: verified entries are returned as plain `Bytecode` (already internally
+    /// reference-counted, so `ContractCache::insert` shares the allocation without a second wrap).
     #[tokio::test]
-    async fn test_get_codes_verify_ok_returns_arc_bytecode() {
+    async fn test_get_codes_verify_ok_returns_bytecode() {
         let good_code = Bytes::from_static(&[0x60, 0x00, 0x60, 0x01]);
         let good_hash = Bytecode::new_raw(good_code.clone()).hash_slow();
 
@@ -1667,10 +1667,10 @@ mod tests {
 
         let ok = client.get_codes(&[good_hash], true).await.unwrap();
         assert_eq!(ok.len(), 1);
-        let arc = ok.get(&good_hash).expect("good hash present");
-        assert_eq!(arc.bytes_slice(), Bytecode::new_raw(good_code).bytes_slice());
-        // Compile-time check that the return type is `Arc<Bytecode>` (refcount share with cache).
-        let _arc_clone: Arc<Bytecode> = Arc::clone(arc);
+        let code = ok.get(&good_hash).expect("good hash present");
+        assert_eq!(code.bytes_slice(), Bytecode::new_raw(good_code).bytes_slice());
+        // Compile-time check that the return type is plain `Bytecode` (a cheap refcount clone).
+        let _code_clone: Bytecode = code.clone();
 
         handle.stop().unwrap();
     }

--- a/crates/stateless-core/src/db.rs
+++ b/crates/stateless-core/src/db.rs
@@ -12,7 +12,7 @@
 //! Concrete implementations live in their respective binaries;
 //! shared redb helpers live in the `stateless-db` crate.
 
-use std::{boxed::Box, fmt, string::String, sync::Arc, vec::Vec};
+use std::{boxed::Box, fmt, string::String, vec::Vec};
 
 use alloy_primitives::{B256, BlockHash, BlockNumber, map::HashMap};
 use revm::state::Bytecode;
@@ -86,16 +86,17 @@ impl fmt::Display for MissingDataKind {
 }
 
 /// Result of a contract bytecode lookup: `(found, missing)`.
-pub type ContractLookup = (HashMap<B256, Arc<Bytecode>>, Vec<B256>);
+pub type ContractLookup = (HashMap<B256, Bytecode>, Vec<B256>);
 
 /// Contract bytecode persistence.
 ///
-/// Values are exchanged as `Arc<Bytecode>` so the in-memory `ContractCache` and
-/// downstream consumers (e.g. revm execution via `WitnessDatabase`) can share a
-/// single allocation instead of deep-cloning bytecode on every cache hit.
+/// Values are exchanged as plain `Bytecode`, not `Arc<Bytecode>`: `Bytecode` is already
+/// internally reference-counted (its `Bytes` buffer and `JumpTable` are both `Arc`-backed),
+/// so cloning is an O(1) refcount bump that shares the same allocation. An outer `Arc` would
+/// only add a redundant layer of indirection and a second heap allocation per contract.
 pub trait ContractStore: Send + Sync {
     fn get_contracts(&self, hashes: &[B256]) -> StoreResult<ContractLookup>;
-    fn add_contracts(&self, codes: &[(B256, Arc<Bytecode>)]) -> StoreResult<()>;
+    fn add_contracts(&self, codes: &[(B256, Bytecode)]) -> StoreResult<()>;
 }
 
 /// Chain-cursor management — the storage surface the pipeline drives on **every** scenario.

--- a/crates/stateless-core/src/evm_database.rs
+++ b/crates/stateless-core/src/evm_database.rs
@@ -7,7 +7,6 @@
 use std::{
     format,
     string::{String, ToString},
-    sync::Arc,
     vec::Vec,
 };
 
@@ -67,10 +66,11 @@ pub struct WitnessDatabase<'a, W> {
     /// Compact witness containing state subset and cryptographic proofs
     pub witness: &'a W,
     /// Contract bytecode cache, pre-populated before execution starts.
-    /// Values are `Arc<Bytecode>` so the cache and any cloned `BlockData` share a
-    /// single allocation; revm's trait still demands an owned `Bytecode`, so the
-    /// `DatabaseRef` impls deref-clone at the read boundary.
-    pub contracts: &'a HashMap<B256, Arc<Bytecode>>,
+    /// Values are plain `Bytecode`: it is already internally reference-counted (`Bytes` +
+    /// `Arc`-backed `JumpTable`), so the cache and any cloned `BlockData` share one allocation
+    /// without an outer `Arc`. revm's trait demands an owned `Bytecode`, so the `DatabaseRef`
+    /// impls clone (a cheap refcount bump) at the read boundary.
+    pub contracts: &'a HashMap<B256, Bytecode>,
 }
 
 impl<'a, W> WitnessDatabase<'a, W>
@@ -104,10 +104,7 @@ where
             _ => None,
         }) {
             Some(acc) => {
-                let code = acc
-                    .codehash
-                    .and_then(|hash| self.contracts.get(&hash))
-                    .map(|arc| (**arc).clone());
+                let code = acc.codehash.and_then(|hash| self.contracts.get(&hash)).cloned();
                 Ok(Some(AccountInfo {
                     balance: acc.balance,
                     nonce: acc.nonce,
@@ -128,7 +125,7 @@ where
         }
         self.contracts
             .get(&code_hash)
-            .map(|arc| (**arc).clone())
+            .cloned()
             .ok_or_else(|| WitnessDatabaseError("Code not found".to_string()))
     }
 

--- a/crates/stateless-core/src/evm_database.rs
+++ b/crates/stateless-core/src/evm_database.rs
@@ -364,9 +364,10 @@ mod tests {
         // Empty-code hash short-circuits to empty bytecode without touching the map.
         assert!(db.code_by_hash_ref(KECCAK_EMPTY).unwrap().is_empty());
 
-        // Present hash returns the bytecode, sharing the same allocation (cheap refcount clone);
-        // pointer equality implies the bytes match, so it also confirms the right code came back.
         let got = db.code_by_hash_ref(hash).unwrap();
+        // Correctness: the bytecode for the requested hash came back.
+        assert_eq!(got.bytes_slice(), code.bytes_slice());
+        // Cheap-clone property: the returned value shares the same underlying allocation.
         assert_eq!(got.bytes_slice().as_ptr(), code.bytes_slice().as_ptr());
 
         // Absent hash errors.

--- a/crates/stateless-core/src/evm_database.rs
+++ b/crates/stateless-core/src/evm_database.rs
@@ -344,4 +344,33 @@ mod tests {
 
         assert!(err.0.contains("bad metadata for bucket 65536"));
     }
+
+    /// `code_by_hash_ref` serves bytecode from the pre-populated contracts map: the empty-code
+    /// hash short-circuits to empty bytecode, a present hash returns the bytecode (a cheap clone
+    /// sharing the same underlying buffer), and an absent hash errors. revm normally reads code
+    /// inline via `basic_ref`'s `AccountInfo.code`, so this by-hash path is otherwise untested.
+    #[test]
+    fn code_by_hash_ref_serves_contracts_map() {
+        let header = Header::default();
+        let witness = LightWitness { kvs: Default::default(), levels: Default::default() };
+
+        let code = Bytecode::new_raw(Bytes::from_static(&[0x60, 0x00, 0x60, 0x01]));
+        let hash = code.hash_slow();
+        let mut contracts = HashMap::default();
+        contracts.insert(hash, code.clone());
+
+        let db = WitnessDatabase { header: &header, witness: &witness, contracts: &contracts };
+
+        // Empty-code hash short-circuits to empty bytecode without touching the map.
+        assert!(db.code_by_hash_ref(KECCAK_EMPTY).unwrap().is_empty());
+
+        // Present hash returns the bytecode, sharing the same allocation (cheap refcount clone).
+        let got = db.code_by_hash_ref(hash).unwrap();
+        assert_eq!(got.bytes_slice(), code.bytes_slice());
+        assert_eq!(got.bytes_slice().as_ptr(), code.bytes_slice().as_ptr());
+
+        // Absent hash errors.
+        let err = db.code_by_hash_ref(B256::from([0xAB; 32])).unwrap_err();
+        assert!(err.0.contains("Code not found"));
+    }
 }

--- a/crates/stateless-core/src/evm_database.rs
+++ b/crates/stateless-core/src/evm_database.rs
@@ -66,10 +66,10 @@ pub struct WitnessDatabase<'a, W> {
     /// Compact witness containing state subset and cryptographic proofs
     pub witness: &'a W,
     /// Contract bytecode cache, pre-populated before execution starts.
-    /// Values are plain `Bytecode`: it is already internally reference-counted (`Bytes` +
-    /// `Arc`-backed `JumpTable`), so the cache and any cloned `BlockData` share one allocation
-    /// without an outer `Arc`. revm's trait demands an owned `Bytecode`, so the `DatabaseRef`
-    /// impls clone (a cheap refcount bump) at the read boundary.
+    /// Values are plain `Bytecode`, which is already internally reference-counted, so the cache
+    /// and any cloned `BlockData` share one allocation without an outer `Arc`. revm's trait
+    /// demands an owned `Bytecode`, so the `DatabaseRef` impls clone (a cheap refcount bump) at
+    /// the read boundary.
     pub contracts: &'a HashMap<B256, Bytecode>,
 }
 
@@ -364,9 +364,9 @@ mod tests {
         // Empty-code hash short-circuits to empty bytecode without touching the map.
         assert!(db.code_by_hash_ref(KECCAK_EMPTY).unwrap().is_empty());
 
-        // Present hash returns the bytecode, sharing the same allocation (cheap refcount clone).
+        // Present hash returns the bytecode, sharing the same allocation (cheap refcount clone);
+        // pointer equality implies the bytes match, so it also confirms the right code came back.
         let got = db.code_by_hash_ref(hash).unwrap();
-        assert_eq!(got.bytes_slice(), code.bytes_slice());
         assert_eq!(got.bytes_slice().as_ptr(), code.bytes_slice().as_ptr());
 
         // Absent hash errors.

--- a/crates/stateless-core/src/executor.rs
+++ b/crates/stateless-core/src/executor.rs
@@ -26,7 +26,7 @@
 //! The module integrates with the Salt witness system for state reconstruction
 //! and uses Revm for transaction execution.
 
-use std::{boxed::Box, collections::BTreeMap, fmt::Debug, sync::Arc, vec::Vec};
+use std::{boxed::Box, collections::BTreeMap, fmt::Debug, vec::Vec};
 #[cfg(feature = "std")]
 use std::{io::Write, time::Instant};
 
@@ -469,7 +469,7 @@ pub fn validate_block<B: BlockInput>(
     block: &B,
     salt_witness: SaltWitness,
     mpt_witness: MptWitness,
-    contracts: &HashMap<B256, Arc<Bytecode>>,
+    contracts: &HashMap<B256, Bytecode>,
     #[cfg(feature = "std")] writer: Option<Box<dyn Write>>,
 ) -> Result<ValidationStats, ValidationError> {
     // A block carrying only transaction hashes can't be replayed — fail fast before paying

--- a/crates/stateless-core/src/pipeline/tests.rs
+++ b/crates/stateless-core/src/pipeline/tests.rs
@@ -83,10 +83,10 @@ impl MockStore {
 }
 
 impl crate::ContractStore for MockStore {
-    fn get_contracts(&self, _: &[B256]) -> StoreResult<(HashMap<B256, Arc<Bytecode>>, Vec<B256>)> {
+    fn get_contracts(&self, _: &[B256]) -> StoreResult<(HashMap<B256, Bytecode>, Vec<B256>)> {
         Ok((HashMap::default(), vec![]))
     }
-    fn add_contracts(&self, _: &[(B256, Arc<Bytecode>)]) -> StoreResult<()> {
+    fn add_contracts(&self, _: &[(B256, Bytecode)]) -> StoreResult<()> {
         Ok(())
     }
 }

--- a/crates/stateless-db/src/cache.rs
+++ b/crates/stateless-db/src/cache.rs
@@ -44,20 +44,15 @@ impl Default for ContractCacheConfig {
 #[derive(Debug, Clone, Default)]
 pub(crate) struct BytecodeWeighter;
 
-impl Weighter<B256, Arc<Bytecode>> for BytecodeWeighter {
-    fn weight(&self, _key: &B256, val: &Arc<Bytecode>) -> u64 {
+impl Weighter<B256, Bytecode> for BytecodeWeighter {
+    fn weight(&self, _key: &B256, val: &Bytecode) -> u64 {
         const ENTRY_OVERHEAD: u64 = 128;
         ENTRY_OVERHEAD + val.bytes_slice().len() as u64
     }
 }
 
-type MemoryCache = Cache<
-    B256,
-    Arc<Bytecode>,
-    BytecodeWeighter,
-    RandomState,
-    DefaultLifecycle<B256, Arc<Bytecode>>,
->;
+type MemoryCache =
+    Cache<B256, Bytecode, BytecodeWeighter, RandomState, DefaultLifecycle<B256, Bytecode>>;
 
 /// Snapshot of cache counters.
 #[derive(Debug, Clone, Copy, Default)]
@@ -80,8 +75,10 @@ pub struct ContractCacheStats {
 /// Writes go to both disk and memory (write-through; disk first so a failed store
 /// write never leaves memory hotter than disk).
 ///
-/// Values are stored as `Arc<Bytecode>` so that hits — the hot path — return by
-/// reference-count bump instead of deep-copying the bytecode.
+/// Values are stored as plain `Bytecode`, which is already internally reference-counted
+/// (`Bytes` buffer + `Arc`-backed `JumpTable`), so hits — the hot path — return by a cheap
+/// refcount bump that shares the same allocation, not a deep copy. An outer `Arc` would be
+/// redundant indirection.
 pub struct ContractCache {
     memory: MemoryCache,
     store: Arc<dyn ContractStore>,
@@ -120,14 +117,14 @@ impl ContractCache {
     /// caller should use a verified RPC fetch (`RpcClient::get_codes(.., verify=true)`)
     /// to populate the cache so all entries arrive pre-verified.
     pub fn get(&self, hashes: &[B256]) -> StoreResult<ContractLookup> {
-        let mut found: HashMap<B256, Arc<Bytecode>> = HashMap::default();
+        let mut found: HashMap<B256, Bytecode> = HashMap::default();
         found.reserve(hashes.len());
         let mut not_in_memory = Vec::with_capacity(hashes.len());
 
         for &hash in hashes {
-            if let Some(arc) = self.memory.get(&hash) {
+            if let Some(code) = self.memory.get(&hash) {
                 self.hits.fetch_add(1, Ordering::Relaxed);
-                found.insert(hash, arc);
+                found.insert(hash, code);
             } else {
                 self.misses.fetch_add(1, Ordering::Relaxed);
                 not_in_memory.push(hash);
@@ -140,8 +137,8 @@ impl ContractCache {
 
         let (from_disk, missing) = self.store.get_contracts(&not_in_memory)?;
 
-        for (hash, arc) in &from_disk {
-            self.memory.insert(*hash, arc.clone());
+        for (hash, code) in &from_disk {
+            self.memory.insert(*hash, code.clone());
         }
         found.extend(from_disk);
 
@@ -149,15 +146,15 @@ impl ContractCache {
     }
 
     /// Adds contract bytecodes to both disk and memory (write-through).
-    pub fn insert(&self, codes: &[(B256, Arc<Bytecode>)]) -> StoreResult<()> {
+    pub fn insert(&self, codes: &[(B256, Bytecode)]) -> StoreResult<()> {
         if codes.is_empty() {
             return Ok(());
         }
 
         self.store.add_contracts(codes)?;
 
-        for (hash, arc) in codes {
-            self.memory.insert(*hash, arc.clone());
+        for (hash, code) in codes {
+            self.memory.insert(*hash, code.clone());
         }
         self.inserts.fetch_add(1, Ordering::Relaxed);
 
@@ -185,12 +182,12 @@ mod tests {
 
     use super::*;
 
-    fn bc(b: u8) -> Arc<Bytecode> {
-        Arc::new(Bytecode::new_raw(Bytes::from(vec![b])))
+    fn bc(b: u8) -> Bytecode {
+        Bytecode::new_raw(Bytes::from(vec![b]))
     }
 
-    fn bc_sized(len: usize, fill: u8) -> Arc<Bytecode> {
-        Arc::new(Bytecode::new_raw(Bytes::from(vec![fill; len])))
+    fn bc_sized(len: usize, fill: u8) -> Bytecode {
+        Bytecode::new_raw(Bytes::from(vec![fill; len]))
     }
 
     fn h(n: u8) -> B256 {
@@ -200,7 +197,7 @@ mod tests {
     /// In-memory `ContractStore` that tracks hit counts and can be toggled to fail on writes.
     #[derive(Default)]
     struct FakeStore {
-        data: dashmap::DashMap<B256, Arc<Bytecode>>,
+        data: dashmap::DashMap<B256, Bytecode>,
         get_calls: AtomicUsize,
         add_calls: AtomicUsize,
         fail_add: std::sync::atomic::AtomicBool,
@@ -219,9 +216,9 @@ mod tests {
         fn get_contracts(
             &self,
             hashes: &[B256],
-        ) -> StoreResult<(HashMap<B256, Arc<Bytecode>>, Vec<B256>)> {
+        ) -> StoreResult<(HashMap<B256, Bytecode>, Vec<B256>)> {
             self.get_calls.fetch_add(1, Ordering::Relaxed);
-            let mut found: HashMap<B256, Arc<Bytecode>> = HashMap::default();
+            let mut found: HashMap<B256, Bytecode> = HashMap::default();
             let mut missing = Vec::new();
             for &h in hashes {
                 match self.data.get(&h) {
@@ -234,7 +231,7 @@ mod tests {
             Ok((found, missing))
         }
 
-        fn add_contracts(&self, codes: &[(B256, Arc<Bytecode>)]) -> StoreResult<()> {
+        fn add_contracts(&self, codes: &[(B256, Bytecode)]) -> StoreResult<()> {
             self.add_calls.fetch_add(1, Ordering::Relaxed);
             if self.fail_add.load(Ordering::Relaxed) {
                 return Err(StoreError::Corrupt("fake add failure".into()));
@@ -255,7 +252,13 @@ mod tests {
 
         let (found, missing) = cache.get(&[h(1)]).unwrap();
         let returned = found.get(&h(1)).unwrap();
-        assert!(Arc::ptr_eq(returned, &original), "memory hit must share the same Arc allocation");
+        // `Bytecode` is internally reference-counted, so a memory hit shares the same underlying
+        // buffer rather than deep-copying: the cloned-out value points at the same allocation.
+        assert_eq!(
+            returned.bytes_slice().as_ptr(),
+            original.bytes_slice().as_ptr(),
+            "memory hit must share the same bytecode allocation (cheap clone, no deep copy)",
+        );
         assert!(missing.is_empty());
         assert_eq!(store.get_calls(), 0, "memory hit must not hit store");
     }

--- a/crates/stateless-db/src/cache.rs
+++ b/crates/stateless-db/src/cache.rs
@@ -75,10 +75,9 @@ pub struct ContractCacheStats {
 /// Writes go to both disk and memory (write-through; disk first so a failed store
 /// write never leaves memory hotter than disk).
 ///
-/// Values are stored as plain `Bytecode`, which is already internally reference-counted
-/// (`Bytes` buffer + `Arc`-backed `JumpTable`), so hits — the hot path — return by a cheap
-/// refcount bump that shares the same allocation, not a deep copy. An outer `Arc` would be
-/// redundant indirection.
+/// Values are stored as plain `Bytecode`, which is already internally reference-counted, so hits
+/// — the hot path — return by a cheap refcount bump that shares the same allocation, not a deep
+/// copy. An outer `Arc` would be redundant indirection.
 pub struct ContractCache {
     memory: MemoryCache,
     store: Arc<dyn ContractStore>,

--- a/crates/stateless-db/src/helpers.rs
+++ b/crates/stateless-db/src/helpers.rs
@@ -1,7 +1,5 @@
 //! Shared redb read/write helpers used by both concrete database implementations.
 
-use std::sync::Arc;
-
 use alloy_primitives::{B256, BlockHash, BlockNumber, map::HashMap};
 use redb::{ReadableDatabase, ReadableTable};
 use revm::state::Bytecode;
@@ -150,14 +148,14 @@ pub fn read_contracts(database: &Database, hashes: &[B256]) -> StoreResult<Contr
     let read_txn = database.begin_read().store_err()?;
     let table = read_txn.open_table(CONTRACTS).store_err()?;
 
-    let mut found: HashMap<B256, Arc<Bytecode>> = HashMap::default();
+    let mut found: HashMap<B256, Bytecode> = HashMap::default();
     let mut missing = Vec::new();
 
     for &hash in hashes {
         match table.get(hash.0).store_err()? {
             Some(data) => {
                 let bytecode: Bytecode = decode_from_slice(data.value().as_slice())?;
-                found.insert(hash, Arc::new(bytecode));
+                found.insert(hash, bytecode);
             }
             None => missing.push(hash),
         }
@@ -167,10 +165,7 @@ pub fn read_contracts(database: &Database, hashes: &[B256]) -> StoreResult<Contr
 }
 
 /// Stores contract bytecodes in the CONTRACTS table.
-pub fn write_add_contracts(
-    database: &Database,
-    codes: &[(B256, Arc<Bytecode>)],
-) -> StoreResult<()> {
+pub fn write_add_contracts(database: &Database, codes: &[(B256, Bytecode)]) -> StoreResult<()> {
     if codes.is_empty() {
         return Ok(());
     }
@@ -178,7 +173,7 @@ pub fn write_add_contracts(
     {
         let mut table = write_txn.open_table(CONTRACTS).store_err()?;
         for (hash, bytecode) in codes {
-            let encoded = encode_to_vec(bytecode.as_ref())?;
+            let encoded = encode_to_vec(bytecode)?;
             table.insert(hash.0, encoded).store_err()?;
         }
     }
@@ -264,8 +259,8 @@ mod tests {
     fn contracts_roundtrip_and_missing_report() {
         let (_dir, db) = temp_db();
 
-        let a = (B256::from([1u8; 32]), Arc::new(Bytecode::new_raw(Bytes::from_static(&[0x60]))));
-        let b = (B256::from([2u8; 32]), Arc::new(Bytecode::new_raw(Bytes::from_static(&[0x61]))));
+        let a = (B256::from([1u8; 32]), Bytecode::new_raw(Bytes::from_static(&[0x60])));
+        let b = (B256::from([2u8; 32]), Bytecode::new_raw(Bytes::from_static(&[0x61])));
         let missing_hash = B256::from([3u8; 32]);
 
         write_add_contracts(&db, &[]).unwrap();

--- a/crates/stateless-test-utils/src/fixtures.rs
+++ b/crates/stateless-test-utils/src/fixtures.rs
@@ -13,7 +13,7 @@ use std::{
     fs::File,
     io::{BufRead, BufReader},
     path::{Path, PathBuf},
-    sync::{Arc, LazyLock},
+    sync::LazyLock,
 };
 
 use alloy_genesis::Genesis;
@@ -47,7 +47,7 @@ pub struct TestFixtures {
     pub block_numbers: BTreeMap<u64, BlockHash>,
     pub salt_witnesses: HashMap<BlockHash, SaltWitness>,
     pub mpt_witness_bytes: HashMap<BlockHash, Vec<u8>>,
-    pub contracts: HashMap<B256, Arc<Bytecode>>,
+    pub contracts: HashMap<B256, Bytecode>,
 }
 
 impl TestFixtures {
@@ -184,7 +184,7 @@ pub fn load_json<T: DeserializeOwned>(path: impl AsRef<Path>) -> Result<T> {
 }
 
 /// Loads contract bytecodes from a file (one `[hash, bytecode]` JSON per line).
-pub fn load_contracts(path: impl AsRef<Path>) -> HashMap<B256, Arc<Bytecode>> {
+pub fn load_contracts(path: impl AsRef<Path>) -> HashMap<B256, Bytecode> {
     let path = path.as_ref();
     let file = File::open(path).unwrap_or_else(|e| panic!("open {}: {e}", path.display()));
     BufReader::new(file)
@@ -194,7 +194,7 @@ pub fn load_contracts(path: impl AsRef<Path>) -> HashMap<B256, Arc<Bytecode>> {
         .map(|l| {
             let (hash, bytecode): (B256, Bytecode) =
                 serde_json::from_str(&l).expect("parse contract");
-            (hash, Arc::new(bytecode))
+            (hash, bytecode)
         })
         .collect()
 }


### PR DESCRIPTION
## Summary

`Bytecode` (`revm::state::Bytecode`, from `revm-bytecode` 6.2.2) is already internally reference-counted, so wrapping it in `Arc<Bytecode>` was a redundant second layer of indirection. This replaces `Arc<Bytecode>` with plain `Bytecode` everywhere it was stored or exchanged (contract cache, `ContractStore` trait, RPC fetch, witness DB, trace data), dropping one heap allocation and one pointer hop per contract while keeping clones cheap.

## Why

`Bytecode` is an enum whose every field is either `Copy` or `Arc`/`Bytes`-backed:

```rust
pub enum Bytecode {                        // derives Clone
    Eip7702(Eip7702Bytecode),              // { Address, u8, raw: Bytes }
    LegacyAnalyzed(LegacyAnalyzedBytecode) // { bytecode: Bytes, original_len, jump_table: JumpTable }
}
// Bytes     -> Arc-backed buffer (bytes 1.x)
// JumpTable -> Arc<BitVec<u8>>  ("immutable, cheap to clone")
```

So `Bytecode::clone()` is already an O(1) refcount bump that shares the same allocation — not a deep copy. The outer `Arc` only saved copying ~7 words of enum metadata, at the cost of an extra heap allocation per contract and an indirection on every access. It also gave **zero** benefit on the hottest path: `revm::DatabaseRef` requires an owned `Bytecode`, so `WitnessDatabase` already did `(**arc).clone()` at the read boundary, cloning the inner `Bytecode` regardless. The previous doc comments justified the `Arc` as avoiding a "deep-clone on every cache hit," but that premise was false.

## What changed

Type substitution `Arc<Bytecode>` -> `Bytecode` (plus removal of the `Arc::new(..)` / `(**arc).clone()` / `.as_ref()` adapters and rewritten rationale comments), across: **core contract** in `stateless-core` (`ContractLookup` + `ContractStore` trait in `db.rs`, `WitnessDatabase.contracts` in `evm_database.rs`, `validate_block` in `executor.rs`); **cache / persistence** in `stateless-db` (`ContractCache` weighter/map/get/insert in `cache.rs`, redb read/write in `helpers.rs`); **RPC / fixtures** (`RpcClient::get_codes*` in `rpc_client.rs`, `TestFixtures` in `fixtures.rs`); and the **binaries** (`validator_db.rs`, `server_db.rs`, `data_provider.rs`, `tracing_executor.rs`, both `chain_sync.rs`). The cache test that asserted `Arc::ptr_eq` now compares the underlying buffer pointer, demonstrating the shared-allocation property directly. Net diff: 14 files, +100 / -122.

## Performance

A wash-to-slight-improvement with no deep copies introduced anywhere. Cache hit goes from an `Arc` clone (1 atomic inc) to a `Bytecode` clone (2 atomic incs), offset by removing the `Arc::new` heap box and a pointer hop; EVM `code_by_hash_ref` / `basic_ref` do identical work minus the `(**arc)` deref; and `BlockData` clone (trace single-flight) still shares every underlying buffer.

## Breaking change

This changes the public `ContractStore` trait (`ContractLookup` and `add_contracts`) from `Arc<Bytecode>` to `Bytecode`. The out-of-tree mega-reth `FullNode` implements `ChainStore: ContractStore` and needs the same one-line type change in its impl — a coordination point for the EL compat matrix.

## Testing

- `cargo check --workspace --all-targets` — clean
- `cargo clippy --workspace --all-targets --all-features` — no warnings
- `cargo fmt --all --check` — clean
- `cargo test --workspace` — 209 passed, 0 failed