### PR TITLE
perf: enable gzip/brotli on witness/data HTTP transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,6 +41,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e76a019e91224d279006ff972f1e984179a6e9feb050adba6ce8274aef23195"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1083,6 +1098,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-compression"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1463,6 +1490,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "brotli"
+version = "8.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cc91aac060a7a1e25823bdccbfb6af1875b88f17c6daac97894eed8207166b3"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "5.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a32acac15fe1967bc3986b2a6347dffc965602354ea6f450ad07e8bfd253583"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1607,6 +1655,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "compression-codecs"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
+dependencies = [
+ "brotli",
+ "compression-core",
+ "flate2",
+ "memchr",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
+
+[[package]]
 name = "const-hex"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1688,6 +1754,15 @@ name = "crc-catalog"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "critical-section"
@@ -2163,6 +2238,16 @@ dependencies = [
  "rand 0.8.5",
  "rustc-hex",
  "static_assertions",
+]
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -3373,6 +3458,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -4370,9 +4456,11 @@ version = "0.12.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d0946410b9f7b082a427e4ef5c8ff541a88b357bc6c637c40db3a68ac70a36f"
 dependencies = [
+ "async-compression",
  "base64",
  "bytes",
  "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "http-body-util",
@@ -4392,6 +4480,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
@@ -5455,6 +5544,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
 name = "siphasher"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5606,6 +5701,7 @@ dependencies = [
  "kanal",
  "op-alloy-network",
  "op-alloy-rpc-types",
+ "reqwest 0.12.24",
  "revm",
  "rolling-file",
  "salt",

--- a/crates/stateless-common/Cargo.toml
+++ b/crates/stateless-common/Cargo.toml
@@ -35,11 +35,7 @@ clap.workspace = true
 eyre.workspace = true
 fastrand = { workspace = true, features = ["std"] }
 futures.workspace = true
-# Direct dep ONLY to enable gzip/brotli on the reqwest 0.12 that alloy-provider's
-# HTTP transport uses for witness/data fetches (Cargo feature unification). The
-# witness endpoint returns base64(zstd) and Cloudflare serves it Brotli-compressed,
-# so the validator decodes it transparently (~25% less witness bandwidth). The
-# crate is intentionally not referenced in code.
+# Enables gzip/brotli on alloy-provider's reqwest 0.12 (Cargo feature unification) for witness/data fetches; not referenced in code.
 reqwest = { version = "0.12", default-features = false, features = ["gzip", "brotli"] }
 rolling-file.workspace = true
 serde.workspace = true

--- a/crates/stateless-common/Cargo.toml
+++ b/crates/stateless-common/Cargo.toml
@@ -35,6 +35,12 @@ clap.workspace = true
 eyre.workspace = true
 fastrand = { workspace = true, features = ["std"] }
 futures.workspace = true
+# Direct dep ONLY to enable gzip/brotli on the reqwest 0.12 that alloy-provider's
+# HTTP transport uses for witness/data fetches (Cargo feature unification). The
+# witness endpoint returns base64(zstd) and Cloudflare serves it Brotli-compressed,
+# so the validator decodes it transparently (~25% less witness bandwidth). The
+# crate is intentionally not referenced in code.
+reqwest = { version = "0.12", default-features = false, features = ["gzip", "brotli"] }
 rolling-file.workspace = true
 serde.workspace = true
 thiserror.workspace = true


### PR DESCRIPTION
## Summary

The witness/data RPC client uses alloy-provider's HTTP transport, backed by reqwest 0.12, which had no compression features enabled — so the validator fetched responses uncompressed and paid the full base64(zstd) witness size on the wire (`mega_getBlockWitness` returns `"v0:" + base64(zstd)`, ~33% larger than raw zstd).

This adds a direct `reqwest = "0.12"` dependency in `stateless-common` with the `gzip` and `brotli` features. Via Cargo feature unification it enables compression on the `reqwest 0.12.24` that alloy-provider shares, so reqwest auto-sends `Accept-Encoding: gzip, br` and transparently decompresses. The crate is intentionally not referenced in code.

Once the client advertises support, Cloudflare serves the witness Worker response Brotli-compressed, recovering the base64 overhead: in testing one witness dropped from 30095 B (identity) to 22672 B (`content-encoding: br`), ~25% less wire bandwidth (larger witnesses save more).

No code or wire-format change; `cargo check -p stateless-common` passes and `Cargo.lock` was regenerated by cargo.
