### PR TITLE
chore: bump mega-evm to v1.7.0 and validator to v2.0.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3340,8 +3340,8 @@ dependencies = [
 
 [[package]]
 name = "mega-evm"
-version = "1.6.1"
-source = "git+https://github.com/megaeth-labs/mega-evm.git?tag=v1.6.1#19f3965962c4cc1c12aaedd0ccbd972e4ab10d17"
+version = "1.7.0"
+source = "git+https://github.com/megaeth-labs/mega-evm.git?tag=v1.7.0#30ce038cfb0ec108e886ef48105a7ab367a99b33"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3368,8 +3368,8 @@ dependencies = [
 
 [[package]]
 name = "mega-system-contracts"
-version = "1.6.1"
-source = "git+https://github.com/megaeth-labs/mega-evm.git?tag=v1.6.1#19f3965962c4cc1c12aaedd0ccbd972e4ab10d17"
+version = "1.7.0"
+source = "git+https://github.com/megaeth-labs/mega-evm.git?tag=v1.7.0#30ce038cfb0ec108e886ef48105a7ab367a99b33"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1884,7 +1884,7 @@ dependencies = [
 
 [[package]]
 name = "debug-trace-server"
-version = "2.0.14"
+version = "2.0.15"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -5684,7 +5684,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stateless-common"
-version = "2.0.14"
+version = "2.0.15"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -5719,7 +5719,7 @@ dependencies = [
 
 [[package]]
 name = "stateless-core"
-version = "2.0.14"
+version = "2.0.15"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5759,7 +5759,7 @@ dependencies = [
 
 [[package]]
 name = "stateless-db"
-version = "2.0.14"
+version = "2.0.15"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -5778,7 +5778,7 @@ dependencies = [
 
 [[package]]
 name = "stateless-test-utils"
-version = "2.0.14"
+version = "2.0.15"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -5796,7 +5796,7 @@ dependencies = [
 
 [[package]]
 name = "stateless-validator"
-version = "2.0.14"
+version = "2.0.15"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.0.14"
+version = "2.0.15"
 edition = "2024"
 rust-version = "1.91"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ alloy-signer-local = "1.0.23"
 alloy-trie = { version = "0.9.0", default-features = false }
 
 # mega
-mega-evm = { git = "https://github.com/megaeth-labs/mega-evm.git", tag = "v1.6.1", default-features = false }
+mega-evm = { git = "https://github.com/megaeth-labs/mega-evm.git", tag = "v1.7.0", default-features = false }
 salt = { git = "https://github.com/megaeth-labs/salt.git", tag = "v1.0.5", default-features = false }
 
 # op


### PR DESCRIPTION
## Summary
Bumps the `mega-evm` dependency `v1.6.1` → `v1.7.0` and the workspace version `2.0.14` → `2.0.15`, propagated to all six member crates via `version.workspace = true`. `Cargo.lock` regenerated: only `mega-evm` and `mega-system-contracts` move to v1.7.0, no other dependency changes.

Notable upstream changes in mega-evm v1.7.0: REX6 preparation (megaeth-labs/mega-evm#348, megaeth-labs/mega-evm#350), hardened SequencerRegistry sequencer rotation (megaeth-labs/mega-evm#351), hardened system-contract bytecode/storage-layout verification (megaeth-labs/mega-evm#316), and REX4 SLOAD-path perf improvements (megaeth-labs/mega-evm#334).

## Testing
`cargo check --workspace`, `cargo test --workspace` (145 passed, 0 failed), `cargo fmt --all --check`, `cargo clippy --workspace --all-targets --all-features`, and `cargo sort --check --workspace` all pass locally.