### PR TITLE
feat: add kona validator binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .claude/
 .cursor/
 .mcp.json
+.omo/
 
 # database
 validator-data

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ This file provides guidance to AI agents (e.g., Claude Code, Codex, Cursor, etc.
 ## Project Overview
 
 Stateless validator for MegaETH — validates blocks using SALT witness data without requiring full chain state.
-The workspace contains two binaries: `stateless-validator` (chain-following validator) and `debug-trace-server` (RPC server for debug/trace methods).
+The workspace contains three binaries: `stateless-validator` (chain-following MegaEVM validator), `kona-validator` (chain-following Kona validator), and `debug-trace-server` (RPC server for debug/trace methods).
 See `README.md` for detailed documentation and quickstart.
 
 ## Build & Development Commands
@@ -40,7 +40,8 @@ The project uses nightly `2026-02-03` toolchain (edition 2024, rust-version 1.95
 | `stateless-db`         | `crates/stateless-db`         | redb-backed persistence: table definitions, read/write helpers, `ContractCache`            |
 | `stateless-common`     | `crates/stateless-common`     | RPC client, metrics/logging utilities, witness size estimation                             |
 | `stateless-test-utils` | `crates/stateless-test-utils` | Test fixtures (blocks, witnesses, contracts) and env-var lock for integration tests        |
-| `stateless-validator`  | `bin/stateless-validator`     | Main binary: chain sync, parallel validation workers (`app.rs` / `workers.rs` / `main.rs`) |
+| `stateless-validator`  | `bin/stateless-validator`     | Main binary: chain sync, parallel validation workers with `MegaEvmValidator` (`app.rs` / `workers.rs` / `main.rs`) |
+| `kona-validator`       | `bin/stateless-validator`     | Kona-backed validator binary sharing the validator pipeline (`src/bin/kona-validator.rs`) |
 | `debug-trace-server`   | `bin/debug-trace-server`      | Standalone RPC server for debug/trace methods                                              |
 
 Additional directories: `test_data/` (integration test fixtures including genesis config), `audits/` (security audit reports).
@@ -49,7 +50,7 @@ Additional directories: `test_data/` (integration test fixtures including genesi
 
 ### Pipeline
 
-Both binaries share a generic three-stage pipeline defined in `stateless-core::pipeline`:
+The validator binaries and trace server share a generic three-stage pipeline defined in `stateless-core::pipeline`:
 
 1. **Fetch** — `block_fetcher` streams blocks + witnesses from a `BlockFetcher` via a bounded in-flight window (concurrency capped by `fetcher_max_in_flight`).
 2. **Process** — N workers run `BlockProcessor::process` (validator: EVM execution; trace server: pass-through).
@@ -61,7 +62,8 @@ On a detected reorg, the rollback floor comes from a pluggable `ReorgResolver`: 
 ### Executor abstraction
 
 Per-block validation is pluggable via the `BlockValidator` trait in `stateless-core::executor`, consumed by the validator's `ValidatorProcessor<V>`.
-`MegaEvmValidator` is the in-repo backend (mega-evm replay + SALT root update via `validate_block`); alternative executors (e.g. a kona-based validator binary) implement the trait out-of-tree with their own error types.
+`MegaEvmValidator` is the default in-repo backend (mega-evm replay + SALT root update via `validate_block`), while `KonaValidator` is exposed through the separate `kona-validator` binary.
+Other embedders can implement the trait out-of-tree with their own error types.
 `ValidationInput` bundles the per-block inputs (block, witnesses, contracts); its optional `parent_header` is required only by backends that re-derive header fields from the parent instead of trusting the block's own header.
 
 ### Database

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3849,7 +3849,7 @@ dependencies = [
 [[package]]
 name = "kona-cli"
 version = "0.3.2"
-source = "git+https://github.com/megaeth-labs/mega-kona.git?branch=clay%2Ffeat%2Fregist_pnet_config#0e12e4a4380aa46f06daca81afb72a1b91645dfc"
+source = "git+https://github.com/megaeth-labs/mega-kona.git?branch=clay%2Ffeat%2Fregist_pnet_config#203e6cc723b235f03f9b71a8c76ccfdfa7937509"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -3869,7 +3869,7 @@ dependencies = [
 [[package]]
 name = "kona-derive"
 version = "0.4.5"
-source = "git+https://github.com/megaeth-labs/mega-kona.git?branch=clay%2Ffeat%2Fregist_pnet_config#0e12e4a4380aa46f06daca81afb72a1b91645dfc"
+source = "git+https://github.com/megaeth-labs/mega-kona.git?branch=clay%2Ffeat%2Fregist_pnet_config#203e6cc723b235f03f9b71a8c76ccfdfa7937509"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3890,7 +3890,7 @@ dependencies = [
 [[package]]
 name = "kona-driver"
 version = "0.4.0"
-source = "git+https://github.com/megaeth-labs/mega-kona.git?branch=clay%2Ffeat%2Fregist_pnet_config#0e12e4a4380aa46f06daca81afb72a1b91645dfc"
+source = "git+https://github.com/megaeth-labs/mega-kona.git?branch=clay%2Ffeat%2Fregist_pnet_config#203e6cc723b235f03f9b71a8c76ccfdfa7937509"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -3911,7 +3911,7 @@ dependencies = [
 [[package]]
 name = "kona-executor"
 version = "0.4.0"
-source = "git+https://github.com/megaeth-labs/mega-kona.git?branch=clay%2Ffeat%2Fregist_pnet_config#0e12e4a4380aa46f06daca81afb72a1b91645dfc"
+source = "git+https://github.com/megaeth-labs/mega-kona.git?branch=clay%2Ffeat%2Fregist_pnet_config#203e6cc723b235f03f9b71a8c76ccfdfa7937509"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3944,7 +3944,7 @@ dependencies = [
 [[package]]
 name = "kona-genesis"
 version = "0.4.5"
-source = "git+https://github.com/megaeth-labs/mega-kona.git?branch=clay%2Ffeat%2Fregist_pnet_config#0e12e4a4380aa46f06daca81afb72a1b91645dfc"
+source = "git+https://github.com/megaeth-labs/mega-kona.git?branch=clay%2Ffeat%2Fregist_pnet_config#203e6cc723b235f03f9b71a8c76ccfdfa7937509"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -3964,7 +3964,7 @@ dependencies = [
 [[package]]
 name = "kona-hardforks"
 version = "0.4.5"
-source = "git+https://github.com/megaeth-labs/mega-kona.git?branch=clay%2Ffeat%2Fregist_pnet_config#0e12e4a4380aa46f06daca81afb72a1b91645dfc"
+source = "git+https://github.com/megaeth-labs/mega-kona.git?branch=clay%2Ffeat%2Fregist_pnet_config#203e6cc723b235f03f9b71a8c76ccfdfa7937509"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -3975,7 +3975,7 @@ dependencies = [
 [[package]]
 name = "kona-log"
 version = "0.1.0"
-source = "git+https://github.com/megaeth-labs/mega-kona.git?branch=clay%2Ffeat%2Fregist_pnet_config#0e12e4a4380aa46f06daca81afb72a1b91645dfc"
+source = "git+https://github.com/megaeth-labs/mega-kona.git?branch=clay%2Ffeat%2Fregist_pnet_config#203e6cc723b235f03f9b71a8c76ccfdfa7937509"
 dependencies = [
  "risc0-zkvm",
 ]
@@ -3983,12 +3983,12 @@ dependencies = [
 [[package]]
 name = "kona-macros"
 version = "0.1.2"
-source = "git+https://github.com/megaeth-labs/mega-kona.git?branch=clay%2Ffeat%2Fregist_pnet_config#0e12e4a4380aa46f06daca81afb72a1b91645dfc"
+source = "git+https://github.com/megaeth-labs/mega-kona.git?branch=clay%2Ffeat%2Fregist_pnet_config#203e6cc723b235f03f9b71a8c76ccfdfa7937509"
 
 [[package]]
 name = "kona-megaevm"
 version = "0.1.0"
-source = "git+https://github.com/megaeth-labs/mega-kona.git?branch=clay%2Ffeat%2Fregist_pnet_config#0e12e4a4380aa46f06daca81afb72a1b91645dfc"
+source = "git+https://github.com/megaeth-labs/mega-kona.git?branch=clay%2Ffeat%2Fregist_pnet_config#203e6cc723b235f03f9b71a8c76ccfdfa7937509"
 dependencies = [
  "alloy-hardforks 0.2.13",
  "alloy-op-hardforks 0.2.13",
@@ -4000,7 +4000,7 @@ dependencies = [
 [[package]]
 name = "kona-mpt"
 version = "0.3.0"
-source = "git+https://github.com/megaeth-labs/mega-kona.git?branch=clay%2Ffeat%2Fregist_pnet_config#0e12e4a4380aa46f06daca81afb72a1b91645dfc"
+source = "git+https://github.com/megaeth-labs/mega-kona.git?branch=clay%2Ffeat%2Fregist_pnet_config#203e6cc723b235f03f9b71a8c76ccfdfa7937509"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -4012,7 +4012,7 @@ dependencies = [
 [[package]]
 name = "kona-preimage"
 version = "0.3.0"
-source = "git+https://github.com/megaeth-labs/mega-kona.git?branch=clay%2Ffeat%2Fregist_pnet_config#0e12e4a4380aa46f06daca81afb72a1b91645dfc"
+source = "git+https://github.com/megaeth-labs/mega-kona.git?branch=clay%2Ffeat%2Fregist_pnet_config#203e6cc723b235f03f9b71a8c76ccfdfa7937509"
 dependencies = [
  "alloy-primitives",
  "async-channel",
@@ -4025,7 +4025,7 @@ dependencies = [
 [[package]]
 name = "kona-proof"
 version = "0.3.0"
-source = "git+https://github.com/megaeth-labs/mega-kona.git?branch=clay%2Ffeat%2Fregist_pnet_config#0e12e4a4380aa46f06daca81afb72a1b91645dfc"
+source = "git+https://github.com/megaeth-labs/mega-kona.git?branch=clay%2Ffeat%2Fregist_pnet_config#203e6cc723b235f03f9b71a8c76ccfdfa7937509"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4063,7 +4063,7 @@ dependencies = [
 [[package]]
 name = "kona-protocol"
 version = "0.4.5"
-source = "git+https://github.com/megaeth-labs/mega-kona.git?branch=clay%2Ffeat%2Fregist_pnet_config#0e12e4a4380aa46f06daca81afb72a1b91645dfc"
+source = "git+https://github.com/megaeth-labs/mega-kona.git?branch=clay%2Ffeat%2Fregist_pnet_config#203e6cc723b235f03f9b71a8c76ccfdfa7937509"
 dependencies = [
  "alloc-no-stdlib",
  "alloy-consensus",
@@ -4092,7 +4092,7 @@ dependencies = [
 [[package]]
 name = "kona-registry"
 version = "0.4.5"
-source = "git+https://github.com/megaeth-labs/mega-kona.git?branch=clay%2Ffeat%2Fregist_pnet_config#0e12e4a4380aa46f06daca81afb72a1b91645dfc"
+source = "git+https://github.com/megaeth-labs/mega-kona.git?branch=clay%2Ffeat%2Fregist_pnet_config#203e6cc723b235f03f9b71a8c76ccfdfa7937509"
 dependencies = [
  "alloy-chains",
  "alloy-eips",
@@ -4111,7 +4111,7 @@ dependencies = [
 [[package]]
 name = "kona-system-contracts"
 version = "0.1.0"
-source = "git+https://github.com/megaeth-labs/mega-kona.git?branch=clay%2Ffeat%2Fregist_pnet_config#0e12e4a4380aa46f06daca81afb72a1b91645dfc"
+source = "git+https://github.com/megaeth-labs/mega-kona.git?branch=clay%2Ffeat%2Fregist_pnet_config#203e6cc723b235f03f9b71a8c76ccfdfa7937509"
 dependencies = [
  "alloy-primitives",
  "mega-evm 1.5.1",
@@ -6869,7 +6869,7 @@ dependencies = [
 [[package]]
 name = "salt-stateless"
 version = "1.0.0"
-source = "git+https://github.com/megaeth-labs/mega-kona.git?branch=clay%2Ffeat%2Fregist_pnet_config#0e12e4a4380aa46f06daca81afb72a1b91645dfc"
+source = "git+https://github.com/megaeth-labs/mega-kona.git?branch=clay%2Ffeat%2Fregist_pnet_config#203e6cc723b235f03f9b71a8c76ccfdfa7937509"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,9 +63,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy-chains"
-version = "0.2.20"
+version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bc32535569185cbcb6ad5fa64d989a47bccb9a08e27284b1f2a3ccf16e6d010"
+checksum = "84e0378e959aa6a885897522080a990e80eb317f1e9a222a604492ea50e13096"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -76,9 +76,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "1.1.2"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6440213a22df93a87ed512d2f668e7dc1d62a05642d107f82d61edc9e12370"
+checksum = "41e46a465e50a339a817070ec23f06eb3fc9fbb8af71612868367b875a9d49e3"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -98,14 +98,14 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror 2.0.17",
+ "thiserror",
 ]
 
 [[package]]
 name = "alloy-consensus-any"
-version = "1.1.2"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15d0bea09287942405c4f9d2a4f22d1e07611c2dbd9d5bf94b75366340f9e6e0"
+checksum = "07001b1693af794c7526aab400b42e38075f986ef8fef78841e5ebc745473e56"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -125,7 +125,7 @@ dependencies = [
  "alloy-rlp",
  "crc",
  "serde",
- "thiserror 2.0.17",
+ "thiserror",
 ]
 
 [[package]]
@@ -151,18 +151,33 @@ dependencies = [
  "borsh",
  "k256",
  "serde",
- "thiserror 2.0.17",
+ "thiserror",
+]
+
+[[package]]
+name = "alloy-eip7928"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b827a6d7784fe3eb3489d40699407a4cdcce74271421a01bdffe60cf573bb16"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "borsh",
+ "once_cell",
+ "serde",
+ "thiserror",
 ]
 
 [[package]]
 name = "alloy-eips"
-version = "1.1.2"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bd2c7ae05abcab4483ce821f12f285e01c0b33804e6883dd9ca1569a87ee2be"
+checksum = "def1626eea28d48c6cc0a6f16f34d4af0001906e4f889df6c660b39c86fd044d"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
  "alloy-eip7702",
+ "alloy-eip7928",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-serde",
@@ -171,10 +186,12 @@ dependencies = [
  "c-kzg",
  "derive_more",
  "either",
+ "ethereum_ssz",
+ "ethereum_ssz_derive",
  "serde",
  "serde_with",
  "sha2 0.10.9",
- "thiserror 2.0.17",
+ "thiserror",
 ]
 
 [[package]]
@@ -185,23 +202,23 @@ checksum = "28de0dd1bbb0634ef7c3715e8e60176b77b82f8b6b15b2e35fe64cf6640f6550"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-hardforks",
+ "alloy-hardforks 0.2.13",
  "alloy-primitives",
  "alloy-rpc-types-eth",
  "alloy-sol-types",
  "auto_impl",
  "derive_more",
- "op-alloy-consensus",
+ "op-alloy-consensus 0.18.14",
  "op-revm",
  "revm",
- "thiserror 2.0.17",
+ "thiserror",
 ]
 
 [[package]]
 name = "alloy-genesis"
-version = "1.1.2"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc47eaae86488b07ea8e20236184944072a78784a1f4993f8ec17b3aa5d08c21"
+checksum = "64ba7afffa225272cf50c62ff04ac574adc7bfa73af2370db556340f26fcff5c"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -223,6 +240,20 @@ dependencies = [
  "alloy-primitives",
  "auto_impl",
  "dyn-clone",
+]
+
+[[package]]
+name = "alloy-hardforks"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83ba208044232d14d4adbfa77e57d6329f51bc1acc21f5667bb7db72d88a0831"
+dependencies = [
+ "alloy-chains",
+ "alloy-eip2124",
+ "alloy-primitives",
+ "auto_impl",
+ "dyn-clone",
+ "serde",
 ]
 
 [[package]]
@@ -248,7 +279,7 @@ dependencies = [
  "http",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror",
  "tracing",
 ]
 
@@ -275,14 +306,14 @@ dependencies = [
  "futures-utils-wasm",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror",
 ]
 
 [[package]]
 name = "alloy-network-primitives"
-version = "1.1.2"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7805124ad69e57bbae7731c9c344571700b2a18d351bda9e0eba521c991d1bcb"
+checksum = "21af5255bd276e528ee625d97033884916e879a1c6edcd5b70a043bd440c0710"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -300,10 +331,10 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-evm",
- "alloy-op-hardforks",
+ "alloy-op-hardforks 0.2.13",
  "alloy-primitives",
  "auto_impl",
- "op-alloy-consensus",
+ "op-alloy-consensus 0.18.14",
  "op-revm",
  "revm",
 ]
@@ -315,8 +346,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3417f4187eaf7f7fb0d7556f0197bca26f0b23c4bb3aca0c9d566dc1c5d727a2"
 dependencies = [
  "alloy-chains",
- "alloy-hardforks",
+ "alloy-hardforks 0.2.13",
  "auto_impl",
+]
+
+[[package]]
+name = "alloy-op-hardforks"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6472c610150c4c4c15be9e1b964c9b78068f933bda25fb9cdf09b9ac2bb66f36"
+dependencies = [
+ "alloy-chains",
+ "alloy-hardforks 0.4.7",
+ "alloy-primitives",
+ "auto_impl",
+ "serde",
 ]
 
 [[package]]
@@ -340,6 +384,7 @@ dependencies = [
  "proptest",
  "rand 0.9.2",
  "rapidhash",
+ "rayon",
  "ruint",
  "rustc-hash",
  "serde",
@@ -373,13 +418,13 @@ dependencies = [
  "either",
  "futures",
  "futures-utils-wasm",
- "lru",
+ "lru 0.13.0",
  "parking_lot",
  "pin-project",
  "reqwest 0.12.24",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror",
  "tokio",
  "tracing",
  "url",
@@ -443,10 +488,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-rpc-types-eth"
-version = "1.1.2"
+name = "alloy-rpc-types-engine"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed5fafb741c19b3cca4cdd04fa215c89413491f9695a3e928dee2ae5657f607e"
+checksum = "f35af673cc14e89813ab33671d79b6e73fe38788c5f3a8ec3a75476b58225f53"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
+ "derive_more",
+ "ethereum_ssz",
+ "ethereum_ssz_derive",
+ "rand 0.8.5",
+ "serde",
+ "strum",
+]
+
+[[package]]
+name = "alloy-rpc-types-eth"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cc3f354a5079480acca0a6533d1d3838177a03ea494ef0ae8d1679efea88274"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -460,7 +524,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror 2.0.17",
+ "thiserror",
 ]
 
 [[package]]
@@ -474,14 +538,14 @@ dependencies = [
  "alloy-serde",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror",
 ]
 
 [[package]]
 name = "alloy-serde"
-version = "1.1.2"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6f180c399ca7c1e2fe17ea58343910cad0090878a696ff5a50241aee12fc529"
+checksum = "9e6d631f8b975229361d8af7b2c749af31c73b3cf1352f90e144ddb06227105e"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -500,7 +564,7 @@ dependencies = [
  "either",
  "elliptic-curve",
  "k256",
- "thiserror 2.0.17",
+ "thiserror",
 ]
 
 [[package]]
@@ -516,7 +580,7 @@ dependencies = [
  "async-trait",
  "k256",
  "rand 0.8.5",
- "thiserror 2.0.17",
+ "thiserror",
 ]
 
 [[package]]
@@ -574,7 +638,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "954d1b2533b9b2c7959652df3076954ecb1122a28cc740aa84e7b0a49f6ac0a9"
 dependencies = [
  "serde",
- "winnow",
+ "winnow 0.7.13",
 ]
 
 [[package]]
@@ -597,14 +661,14 @@ checksum = "cae82426d98f8bc18f53c5223862907cac30ab8fc5e4cd2bb50808e6d3ab43d8"
 dependencies = [
  "alloy-json-rpc",
  "auto_impl",
- "base64",
+ "base64 0.22.1",
  "derive_more",
  "futures",
  "futures-utils-wasm",
  "parking_lot",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror",
  "tokio",
  "tower",
  "tracing",
@@ -645,11 +709,11 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "1.1.2"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae109e33814b49fc0a62f2528993aa8a2dd346c26959b151f05441dc0b9da292"
+checksum = "99dac443033e83b14f68fac56e8c27e76421f1253729574197ceccd06598f3ef"
 dependencies = [
- "darling",
+ "darling 0.21.3",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -665,10 +729,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
 name = "anstyle"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "ark-bls12-381"
@@ -703,6 +817,39 @@ dependencies = [
  "ark-ff 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ark-r1cs-std",
  "ark-std 0.5.0",
+]
+
+[[package]]
+name = "ark-crypto-primitives"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0c292754729c8a190e50414fd1a37093c786c709899f29c9f7daccecfa855e"
+dependencies = [
+ "ahash",
+ "ark-crypto-primitives-macros",
+ "ark-ec 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ark-ff 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ark-relations",
+ "ark-serialize 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ark-snark",
+ "ark-std 0.5.0",
+ "blake2",
+ "derivative",
+ "digest 0.10.7",
+ "fnv",
+ "merlin",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "ark-crypto-primitives-macros"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7e89fe77d1f0f4fe5b96dfc940923d88d17b6a773808124f21e764dfb063c6a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -926,6 +1073,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-groth16"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88f1d0f3a534bb54188b8dcc104307db6c56cdae574ddc3212aec0625740fc7e"
+dependencies = [
+ "ark-crypto-primitives",
+ "ark-ec 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ark-ff 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ark-poly 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ark-relations",
+ "ark-serialize 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ark-std 0.5.0",
+]
+
+[[package]]
 name = "ark-poly"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1052,6 +1214,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-snark"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d368e2848c2d4c129ce7679a7d0d2d612b6a274d3ea6a13bad4445d61b381b88"
+dependencies = [
+ "ark-ff 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ark-relations",
+ "ark-serialize 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ark-std 0.5.0",
+]
+
+[[package]]
 name = "ark-std"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1083,6 +1257,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arraydeque"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1095,6 +1275,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -1184,7 +1376,7 @@ checksum = "7b7e4c2464d97fe331d41de9d5db0def0a96f4d823b8b32a2efd503578988973"
 [[package]]
 name = "banderwagon"
 version = "0.1.0"
-source = "git+https://github.com/megaeth-labs/salt.git?tag=v1.0.5#b6b30e733276f50855a2d3c0781177803ba8f8d9"
+source = "git+https://github.com/megaeth-labs/salt.git?rev=80c02eb1e5d85c3348fc7f3075d80440eeebe1fb#80c02eb1e5d85c3348fc7f3075d80440eeebe1fb"
 dependencies = [
  "ark-ec 0.5.0 (git+https://github.com/megaeth-labs/algebra.git?rev=80ca69c37f79d5d00750edc1602af81b5f456695)",
  "ark-ed-on-bls12-381-bandersnatch",
@@ -1199,6 +1391,12 @@ name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
+name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
@@ -1227,8 +1425,36 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
 dependencies = [
+ "bincode_derive",
  "serde",
  "unty",
+]
+
+[[package]]
+name = "bincode_derive"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
+dependencies = [
+ "virtue",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags 2.10.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1264,6 +1490,12 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
@@ -1285,6 +1517,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "blake3"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1296,6 +1537,12 @@ dependencies = [
  "cfg-if",
  "constant_time_eq",
 ]
+
+[[package]]
+name = "block"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
 name = "block-buffer"
@@ -1333,7 +1580,7 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c340fe0f0b267787095cbe35240c6786ff19da63ec7b69367ba338eace8169b"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "boa_interner",
  "boa_macros",
  "boa_string",
@@ -1349,7 +1596,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f620c3f06f51e65c0504ddf04978be1b814ac6586f0b45f6019801ab5efd37f9"
 dependencies = [
  "arrayvec",
- "bitflags",
+ "bitflags 2.10.0",
  "boa_ast",
  "boa_gc",
  "boa_interner",
@@ -1383,7 +1630,7 @@ dependencies = [
  "static_assertions",
  "tap",
  "thin-vec",
- "thiserror 2.0.17",
+ "thiserror",
  "time",
 ]
 
@@ -1434,7 +1681,7 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cc142dac798cdc6e2dbccfddeb50f36d2523bb977a976e19bdb3ae19b740804"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "boa_ast",
  "boa_interner",
  "boa_macros",
@@ -1464,6 +1711,19 @@ dependencies = [
  "rustc-hash",
  "sptr",
  "static_assertions",
+]
+
+[[package]]
+name = "bonsai-sdk"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a381a5f681e536070483826412fcfcd6f6637921717c6aa0a3759926899ee9c2"
+dependencies = [
+ "duplicate",
+ "maybe-async",
+ "reqwest 0.12.24",
+ "serde",
+ "thiserror",
 ]
 
 [[package]]
@@ -1523,6 +1783,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
 
 [[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
+
+[[package]]
 name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1573,6 +1839,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "camino"
+version = "1.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f2d30e4173c4026932d51d31d6b0613b1fd3014bf3f9f8943d4ba139c437ba0"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver 1.0.27",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1582,6 +1880,15 @@ dependencies = [
  "jobserver",
  "libc",
  "shlex",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -1611,6 +1918,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
+
+[[package]]
 name = "clap"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1626,8 +1944,10 @@ version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
+ "anstream",
  "anstyle",
  "clap_lex",
+ "strsim",
 ]
 
 [[package]]
@@ -1647,6 +1967,15 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror",
+]
 
 [[package]]
 name = "colorchoice"
@@ -1671,6 +2000,21 @@ name = "compression-core"
 version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "const-default"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b396d1f76d455557e1218ec8066ae14bba60b4b36ecd55577ba979f5db7ecaa"
 
 [[package]]
 name = "const-hex"
@@ -1726,10 +2070,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "core-graphics-types"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "libc",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -1834,12 +2208,36 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1859,11 +2257,22 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
- "darling_core",
+ "darling_core 0.21.3",
  "quote",
  "syn 2.0.117",
 ]
@@ -1906,12 +2315,12 @@ dependencies = [
  "http-body-util",
  "jsonrpsee",
  "libc",
- "mega-evm",
+ "mega-evm 1.6.1",
  "metrics",
  "metrics-derive",
  "metrics-exporter-prometheus",
  "op-alloy-network",
- "op-alloy-rpc-types",
+ "op-alloy-rpc-types 0.18.14",
  "pin-project-lite",
  "quick_cache",
  "rayon",
@@ -1927,7 +2336,7 @@ dependencies = [
  "stateless-db",
  "stateless-test-utils",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror",
  "tokio",
  "tokio-util",
  "tower",
@@ -1952,6 +2361,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
+ "pem-rfc7468",
  "zeroize",
 ]
 
@@ -1988,23 +2398,55 @@ dependencies = [
 ]
 
 [[package]]
-name = "derive_more"
-version = "2.0.1"
+name = "derive_builder"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
 dependencies = [
  "derive_more-impl",
 ]
 
 [[package]]
 name = "derive_more-impl"
-version = "2.0.1"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
- "convert_case",
+ "convert_case 0.10.0",
  "proc-macro2",
  "quote",
+ "rustc_version 0.4.1",
  "syn 2.0.117",
  "unicode-xid",
 ]
@@ -2031,6 +2473,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2042,16 +2505,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "docker-generate"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf673e0848ef09fa4aeeba78e681cf651c0c7d35f76ee38cec8e55bc32fa111"
+
+[[package]]
 name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "duplicate"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e92f10a49176cbffacaedabfaa11d51db1ea0f80a83c26e1873b43cd1742c24"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+]
 
 [[package]]
 name = "dyn-clone"
@@ -2096,6 +2582,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "elf"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4445909572dbd556c457c849c4ca58623d84b27c8fff1e74b0b4227d8b90d17b"
+
+[[package]]
 name = "elliptic-curve"
 version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2113,6 +2605,39 @@ dependencies = [
  "serdect",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "embedded-alloc"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f2de9133f68db0d4627ad69db767726c99ff8585272716708227008d3f1bddd"
+dependencies = [
+ "const-default",
+ "critical-section",
+ "linked_list_allocator",
+ "rlsf",
+]
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -2149,6 +2674,67 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "ethereum_serde_utils"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38df44a7a271ab43835678f9215b53cc2523e4714a215da6643d83dc110245da"
+dependencies = [
+ "alloy-primitives",
+ "hex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+]
+
+[[package]]
+name = "ethereum_ssz"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dcddb2554d19cde19b099fadddde576929d7a4d0c1cd3512d1fd95cf174375c"
+dependencies = [
+ "alloy-primitives",
+ "ethereum_serde_utils",
+ "itertools 0.13.0",
+ "serde",
+ "serde_derive",
+ "smallvec",
+ "typenum",
+]
+
+[[package]]
+name = "ethereum_ssz_derive"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a657b6b3b7e153637dc6bdc6566ad9279d9ee11a15b12cfb24a2e04360637e9f"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -2251,6 +2837,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2267,6 +2862,33 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "foreign-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
+dependencies = [
+ "foreign-types-macros",
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
 name = "form_urlencoded"
@@ -2469,6 +3091,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "halfbrown"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa2c385c6df70fd180bbb673d93039dbd2cd34e41d782600bdf6e1ca7bce39aa"
+dependencies = [
+ "hashbrown 0.15.5",
+ "serde",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2506,6 +3138,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2531,6 +3172,12 @@ checksum = "5313b072ce3c597065a808dbf612c4c8e8590bdbf8b579508bf7a762c5eae6cd"
 dependencies = [
  "arrayvec",
 ]
+
+[[package]]
+name = "hex-literal"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
 name = "hmac"
@@ -2632,7 +3279,7 @@ version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52e9a2a24dc5c6821e71a7030e1e14b7b632acac55c40e9d2e082c621261bb56"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-core",
@@ -2921,6 +3568,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "include_bytes_aligned"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ee796ad498c8d9a1d68e477df8f754ed784ef875de1414ebdaf169f70a6a784"
+
+[[package]]
 name = "indenter"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2945,6 +3598,7 @@ checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
+ "rayon",
  "serde",
  "serde_core",
 ]
@@ -2961,7 +3615,7 @@ dependencies = [
 [[package]]
 name = "ipa-multipoint"
 version = "0.1.0"
-source = "git+https://github.com/megaeth-labs/salt.git?tag=v1.0.5#b6b30e733276f50855a2d3c0781177803ba8f8d9"
+source = "git+https://github.com/megaeth-labs/salt.git?rev=80c02eb1e5d85c3348fc7f3075d80440eeebe1fb#80c02eb1e5d85c3348fc7f3075d80440eeebe1fb"
 dependencies = [
  "banderwagon",
  "hashbrown 0.16.1",
@@ -2971,7 +3625,7 @@ dependencies = [
  "rustc-hash",
  "salt-macros",
  "sha2 0.9.9",
- "thiserror 2.0.17",
+ "thiserror",
 ]
 
 [[package]]
@@ -2989,6 +3643,12 @@ dependencies = [
  "memchr",
  "serde",
 ]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
@@ -3085,7 +3745,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror",
  "tokio",
  "tower",
  "tracing",
@@ -3123,7 +3783,7 @@ dependencies = [
  "serde",
  "serde_json",
  "soketto",
- "thiserror 2.0.17",
+ "thiserror",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -3140,7 +3800,7 @@ dependencies = [
  "http",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror",
 ]
 
 [[package]]
@@ -3187,6 +3847,277 @@ dependencies = [
 ]
 
 [[package]]
+name = "kona-cli"
+version = "0.3.2"
+source = "git+https://github.com/megaeth-labs/mega-kona.git?branch=clay%2Ffeat%2Fregist_pnet_config#0e12e4a4380aa46f06daca81afb72a1b91645dfc"
+dependencies = [
+ "alloy-chains",
+ "alloy-primitives",
+ "clap",
+ "kona-genesis",
+ "kona-registry",
+ "libc",
+ "metrics-exporter-prometheus",
+ "metrics-process",
+ "serde",
+ "thiserror",
+ "tracing",
+ "tracing-appender",
+ "tracing-subscriber 0.3.23",
+]
+
+[[package]]
+name = "kona-derive"
+version = "0.4.5"
+source = "git+https://github.com/megaeth-labs/mega-kona.git?branch=clay%2Ffeat%2Fregist_pnet_config#0e12e4a4380aa46f06daca81afb72a1b91645dfc"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-rpc-types-engine",
+ "async-trait",
+ "kona-genesis",
+ "kona-hardforks",
+ "kona-macros",
+ "kona-protocol",
+ "op-alloy-consensus 0.22.4",
+ "op-alloy-rpc-types-engine",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "kona-driver"
+version = "0.4.0"
+source = "git+https://github.com/megaeth-labs/mega-kona.git?branch=clay%2Ffeat%2Fregist_pnet_config#0e12e4a4380aa46f06daca81afb72a1b91645dfc"
+dependencies = [
+ "alloy-consensus",
+ "alloy-primitives",
+ "alloy-rlp",
+ "async-trait",
+ "kona-derive",
+ "kona-executor",
+ "kona-genesis",
+ "kona-protocol",
+ "mega-evm 1.5.1",
+ "op-alloy-consensus 0.22.4",
+ "op-alloy-rpc-types-engine",
+ "spin 0.10.0",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "kona-executor"
+version = "0.4.0"
+source = "git+https://github.com/megaeth-labs/mega-kona.git?branch=clay%2Ffeat%2Fregist_pnet_config#0e12e4a4380aa46f06daca81afb72a1b91645dfc"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-op-hardforks 0.4.7",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "alloy-trie",
+ "anyhow",
+ "bincode 2.0.1",
+ "eyre",
+ "kona-genesis",
+ "kona-log",
+ "kona-megaevm",
+ "kona-mpt",
+ "kona-protocol",
+ "mega-evm 1.5.1",
+ "op-alloy-consensus 0.22.4",
+ "op-alloy-rpc-types 0.22.4",
+ "op-alloy-rpc-types-engine",
+ "risc0-zkvm",
+ "salt",
+ "salt-stateless",
+ "simd-json",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "kona-genesis"
+version = "0.4.5"
+source = "git+https://github.com/megaeth-labs/mega-kona.git?branch=clay%2Ffeat%2Fregist_pnet_config#0e12e4a4380aa46f06daca81afb72a1b91645dfc"
+dependencies = [
+ "alloy-chains",
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-genesis",
+ "alloy-hardforks 0.4.7",
+ "alloy-op-hardforks 0.4.7",
+ "alloy-primitives",
+ "alloy-sol-types",
+ "derive_more",
+ "mega-evm 1.5.1",
+ "serde",
+ "serde_repr",
+ "thiserror",
+]
+
+[[package]]
+name = "kona-hardforks"
+version = "0.4.5"
+source = "git+https://github.com/megaeth-labs/mega-kona.git?branch=clay%2Ffeat%2Fregist_pnet_config#0e12e4a4380aa46f06daca81afb72a1b91645dfc"
+dependencies = [
+ "alloy-eips",
+ "alloy-primitives",
+ "kona-protocol",
+ "op-alloy-consensus 0.22.4",
+]
+
+[[package]]
+name = "kona-log"
+version = "0.1.0"
+source = "git+https://github.com/megaeth-labs/mega-kona.git?branch=clay%2Ffeat%2Fregist_pnet_config#0e12e4a4380aa46f06daca81afb72a1b91645dfc"
+dependencies = [
+ "risc0-zkvm",
+]
+
+[[package]]
+name = "kona-macros"
+version = "0.1.2"
+source = "git+https://github.com/megaeth-labs/mega-kona.git?branch=clay%2Ffeat%2Fregist_pnet_config#0e12e4a4380aa46f06daca81afb72a1b91645dfc"
+
+[[package]]
+name = "kona-megaevm"
+version = "0.1.0"
+source = "git+https://github.com/megaeth-labs/mega-kona.git?branch=clay%2Ffeat%2Fregist_pnet_config#0e12e4a4380aa46f06daca81afb72a1b91645dfc"
+dependencies = [
+ "alloy-hardforks 0.2.13",
+ "alloy-op-hardforks 0.2.13",
+ "alloy-primitives",
+ "mega-evm 1.5.1",
+ "salt",
+]
+
+[[package]]
+name = "kona-mpt"
+version = "0.3.0"
+source = "git+https://github.com/megaeth-labs/mega-kona.git?branch=clay%2Ffeat%2Fregist_pnet_config#0e12e4a4380aa46f06daca81afb72a1b91645dfc"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-trie",
+ "op-alloy-rpc-types-engine",
+ "thiserror",
+]
+
+[[package]]
+name = "kona-preimage"
+version = "0.3.0"
+source = "git+https://github.com/megaeth-labs/mega-kona.git?branch=clay%2Ffeat%2Fregist_pnet_config#0e12e4a4380aa46f06daca81afb72a1b91645dfc"
+dependencies = [
+ "alloy-primitives",
+ "async-channel",
+ "async-trait",
+ "serde",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "kona-proof"
+version = "0.3.0"
+source = "git+https://github.com/megaeth-labs/mega-kona.git?branch=clay%2Ffeat%2Fregist_pnet_config#0e12e4a4380aa46f06daca81afb72a1b91645dfc"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-trie",
+ "ark-bls12-381 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ark-ff 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "async-trait",
+ "kona-cli",
+ "kona-derive",
+ "kona-driver",
+ "kona-executor",
+ "kona-genesis",
+ "kona-megaevm",
+ "kona-mpt",
+ "kona-preimage",
+ "kona-protocol",
+ "kona-registry",
+ "kona-system-contracts",
+ "lazy_static",
+ "lru 0.16.4",
+ "mega-evm 1.5.1",
+ "op-alloy-consensus 0.22.4",
+ "op-alloy-rpc-types-engine",
+ "serde",
+ "serde_json",
+ "spin 0.10.0",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "tracing-subscriber 0.3.23",
+]
+
+[[package]]
+name = "kona-protocol"
+version = "0.4.5"
+source = "git+https://github.com/megaeth-labs/mega-kona.git?branch=clay%2Ffeat%2Fregist_pnet_config#0e12e4a4380aa46f06daca81afb72a1b91645dfc"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-hardforks 0.4.7",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-rpc-types-engine",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "async-trait",
+ "brotli",
+ "derive_more",
+ "kona-genesis",
+ "miniz_oxide",
+ "op-alloy-consensus 0.22.4",
+ "op-alloy-rpc-types 0.22.4",
+ "op-alloy-rpc-types-engine",
+ "serde",
+ "spin 0.10.0",
+ "thiserror",
+ "tracing",
+ "unsigned-varint",
+]
+
+[[package]]
+name = "kona-registry"
+version = "0.4.5"
+source = "git+https://github.com/megaeth-labs/mega-kona.git?branch=clay%2Ffeat%2Fregist_pnet_config#0e12e4a4380aa46f06daca81afb72a1b91645dfc"
+dependencies = [
+ "alloy-chains",
+ "alloy-eips",
+ "alloy-genesis",
+ "alloy-hardforks 0.4.7",
+ "alloy-op-hardforks 0.4.7",
+ "alloy-primitives",
+ "kona-genesis",
+ "lazy_static",
+ "serde",
+ "serde_json",
+ "tabled",
+ "toml 0.9.12+spec-1.1.0",
+]
+
+[[package]]
+name = "kona-system-contracts"
+version = "0.1.0"
+source = "git+https://github.com/megaeth-labs/mega-kona.git?branch=clay%2Ffeat%2Fregist_pnet_config#0e12e4a4380aa46f06daca81afb72a1b91645dfc"
+dependencies = [
+ "alloy-primitives",
+ "mega-evm 1.5.1",
+]
+
+[[package]]
 name = "kzg-rs"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3201,10 +4132,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy-regex"
+version = "3.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bae91019476d3ec7147de9aa291cadb6d870abf2f3015d2da73a90325ac1496"
+dependencies = [
+ "lazy-regex-proc_macros",
+ "once_cell",
+ "regex",
+]
+
+[[package]]
+name = "lazy-regex-proc_macros"
+version = "3.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4de9c1e1439d8b7b3061b2d209809f447ca33241733d9a3c01eabf2dc8d94358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin 0.9.8",
+]
 
 [[package]]
 name = "libc"
@@ -3213,10 +4170,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+
+[[package]]
+name = "libproc"
+version = "0.14.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a54ad7278b8bc5301d5ffd2a94251c004feb971feba96c971ea4063645990757"
+dependencies = [
+ "bindgen",
+ "errno",
+ "libc",
+]
+
+[[package]]
+name = "libredox"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "libsecp256k1"
@@ -3225,7 +4212,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e79019718125edc905a079a70cfa5f3820bc76139fc91d6f9abc27ea2a887139"
 dependencies = [
  "arrayref",
- "base64",
+ "base64 0.22.1",
  "digest 0.9.0",
  "libsecp256k1-core",
  "libsecp256k1-gen-ecmult",
@@ -3263,6 +4250,12 @@ checksum = "3db8d6ba2cec9eacc40e6e8ccc98931840301f1006e95647ceb2dd5c3aa06f7c"
 dependencies = [
  "libsecp256k1-core",
 ]
+
+[[package]]
+name = "linked_list_allocator"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b23ac50abb8261cb38c6e2a7192d3302e0836dac1628f6a93b82b4fad185897"
 
 [[package]]
 name = "linux-raw-sys"
@@ -3307,6 +4300,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+dependencies = [
+ "hashbrown 0.16.1",
+]
+
+[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3317,6 +4319,12 @@ name = "lz4_flex"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db9a0d582c2874f68138a16ce1867e0ffde6c0bb0a0df85e1f36d04146db488a"
+
+[[package]]
+name = "mach2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dae608c151f68243f2b000364e1f7b186d9c29845f7d2d85bd31b9ad77ad552b"
 
 [[package]]
 name = "macro-string"
@@ -3330,12 +4338,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "malloc_buf"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata",
+]
+
+[[package]]
+name = "maybe-async"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "746873a384ad60adc5db74471dfaba74bd278afbdcfd81db93fafcdfc8b5ca0c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "mega-evm"
+version = "1.5.1"
+source = "git+https://github.com/megaeth-labs/mega-evm-internal?rev=b3d8cb645e1caed3f3bf19046431be7d39beb1cf#b3d8cb645e1caed3f3bf19046431be7d39beb1cf"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-evm",
+ "alloy-hardforks 0.2.13",
+ "alloy-op-evm",
+ "alloy-op-hardforks 0.2.13",
+ "alloy-primitives",
+ "alloy-sol-types",
+ "auto_impl",
+ "bitflags 2.10.0",
+ "delegate",
+ "derive_more",
+ "mega-system-contracts 1.5.1",
+ "once_cell",
+ "op-alloy-consensus 0.18.14",
+ "op-alloy-flz",
+ "op-revm",
+ "revm",
+ "serde",
+ "thiserror",
+ "tracing",
 ]
 
 [[package]]
@@ -3346,24 +4402,36 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-evm",
- "alloy-hardforks",
+ "alloy-hardforks 0.2.13",
  "alloy-op-evm",
- "alloy-op-hardforks",
+ "alloy-op-hardforks 0.2.13",
  "alloy-primitives",
  "alloy-sol-types",
  "auto_impl",
- "bitflags",
+ "bitflags 2.10.0",
  "delegate",
  "derive_more",
- "mega-system-contracts",
+ "mega-system-contracts 1.6.1",
  "once_cell",
- "op-alloy-consensus",
+ "op-alloy-consensus 0.18.14",
  "op-alloy-flz",
  "op-revm",
  "revm",
  "serde",
- "thiserror 2.0.17",
+ "thiserror",
  "tracing",
+]
+
+[[package]]
+name = "mega-system-contracts"
+version = "1.5.1"
+source = "git+https://github.com/megaeth-labs/mega-evm-internal?rev=b3d8cb645e1caed3f3bf19046431be7d39beb1cf#b3d8cb645e1caed3f3bf19046431be7d39beb1cf"
+dependencies = [
+ "alloy-primitives",
+ "alloy-sol-types",
+ "semver 1.0.27",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -3394,6 +4462,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "merlin"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58c38e2799fc0978b65dfff8023ec7843e2330bb462f19198840b34b6582397d"
+dependencies = [
+ "byteorder",
+ "keccak",
+ "rand_core 0.6.4",
+ "zeroize",
+]
+
+[[package]]
+name = "metal"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ecfd3296f8c56b7c1f6fbac3c71cefa9d78ce009850c45000015f206dc7fa21"
+dependencies = [
+ "bitflags 2.10.0",
+ "block",
+ "core-graphics-types",
+ "foreign-types",
+ "log",
+ "objc",
+ "paste",
+]
+
+[[package]]
 name = "metrics"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3421,7 +4516,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3589659543c04c7dc5526ec858591015b87cd8746583b51b48ef4353f99dbcda"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "http-body-util",
  "hyper",
  "hyper-util",
@@ -3430,9 +4525,25 @@ dependencies = [
  "metrics",
  "metrics-util",
  "quanta",
- "thiserror 2.0.17",
+ "thiserror",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "metrics-process"
+version = "2.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4268d87f64a752f5a651314fc683f04da10be65701ea3e721ba4d74f79163cac"
+dependencies = [
+ "libc",
+ "libproc",
+ "mach2",
+ "metrics",
+ "once_cell",
+ "procfs",
+ "rlimit",
+ "windows",
 ]
 
 [[package]]
@@ -3450,6 +4561,12 @@ dependencies = [
  "rand_xoshiro",
  "sketches-ddsketch",
 ]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -3491,6 +4608,22 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "no_std_strings"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5b0c77c1b780822bc749a33e39aeb2c07584ab93332303babeabb645298a76e"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -3536,6 +4669,22 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
+]
+
+[[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.5",
+ "smallvec",
+ "zeroize",
 ]
 
 [[package]]
@@ -3650,6 +4799,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
+dependencies = [
+ "malloc_buf",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3658,6 +4816,12 @@ dependencies = [
  "critical-section",
  "portable-atomic",
 ]
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "op-alloy-consensus"
@@ -3674,7 +4838,23 @@ dependencies = [
  "alloy-serde",
  "derive_more",
  "serde",
- "thiserror 2.0.17",
+ "thiserror",
+]
+
+[[package]]
+name = "op-alloy-consensus"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "726da827358a547be9f1e37c2a756b9e3729cb0350f43408164794b370cad8ae"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
+ "derive_more",
+ "serde",
+ "thiserror",
 ]
 
 [[package]]
@@ -3695,8 +4875,8 @@ dependencies = [
  "alloy-provider",
  "alloy-rpc-types-eth",
  "alloy-signer",
- "op-alloy-consensus",
- "op-alloy-rpc-types",
+ "op-alloy-consensus 0.18.14",
+ "op-alloy-rpc-types 0.18.14",
 ]
 
 [[package]]
@@ -3712,10 +4892,50 @@ dependencies = [
  "alloy-rpc-types-eth",
  "alloy-serde",
  "derive_more",
- "op-alloy-consensus",
+ "op-alloy-consensus 0.18.14",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror",
+]
+
+[[package]]
+name = "op-alloy-rpc-types"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562dd4462562c41f9fdc4d860858c40e14a25df7f983ae82047f15f08fce4d19"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-network-primitives",
+ "alloy-primitives",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "derive_more",
+ "op-alloy-consensus 0.22.4",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "op-alloy-rpc-types-engine"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8f24b8cb66e4b33e6c9e508bf46b8ecafc92eadd0b93fedd306c0accb477657"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-rpc-types-engine",
+ "alloy-serde",
+ "derive_more",
+ "ethereum_ssz",
+ "ethereum_ssz_derive",
+ "op-alloy-consensus 0.22.4",
+ "serde",
+ "snap",
+ "thiserror",
 ]
 
 [[package]]
@@ -3735,6 +4955,12 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "p256"
@@ -3870,6 +5096,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "papergrid"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6978128c8b51d8f4080631ceb2302ab51e32cc6e8615f735ee2f83fd269ae3f1"
+dependencies = [
+ "bytecount",
+ "fnv",
+ "unicode-width 0.2.2",
+]
+
+[[package]]
 name = "parity-scale-codec"
 version = "3.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3896,6 +5133,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -3925,6 +5168,15 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -4018,6 +5270,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
 name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4044,6 +5307,18 @@ name = "portable-atomic"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+
+[[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "serde",
+]
 
 [[package]]
 name = "potential_utf"
@@ -4095,7 +5370,7 @@ version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.23.7",
 ]
 
 [[package]]
@@ -4130,6 +5405,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "version_check",
+]
+
+[[package]]
+name = "procfs"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25485360a54d6861439d60facef26de713b1e126bf015ec8f98239467a2b82f7"
+dependencies = [
+ "bitflags 2.10.0",
+ "procfs-core",
+ "rustix",
+]
+
+[[package]]
+name = "procfs-core"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6401bf7b6af22f78b563665d15a22e9aef27775b79b149a66ca022468a4e405"
+dependencies = [
+ "bitflags 2.10.0",
+ "hex",
+]
+
+[[package]]
 name = "proptest"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4137,7 +5445,7 @@ checksum = "bee689443a2bd0a16ab0348b52ee43e3b2d1b1f931c8aa5c9f8de4c86fbe8c40"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags",
+ "bitflags 2.10.0",
  "num-traits",
  "rand 0.9.2",
  "rand_chacha 0.9.0",
@@ -4146,6 +5454,29 @@ dependencies = [
  "rusty-fork",
  "tempfile",
  "unarray",
+]
+
+[[package]]
+name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4193,7 +5524,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.17",
+ "thiserror",
  "tokio",
  "tracing",
  "web-time",
@@ -4214,7 +5545,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.17",
+ "thiserror",
  "tinyvec",
  "tracing",
  "web-time",
@@ -4350,7 +5681,7 @@ version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -4388,7 +5719,18 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.16",
+ "libredox",
+ "thiserror",
 ]
 
 [[package]]
@@ -4457,8 +5799,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d0946410b9f7b082a427e4ef5c8ff541a88b357bc6c637c40db3a68ac70a36f"
 dependencies = [
  "async-compression",
- "base64",
+ "base64 0.22.1",
  "bytes",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "http",
@@ -4487,6 +5830,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots",
 ]
@@ -4497,7 +5841,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-core",
@@ -4556,7 +5900,7 @@ dependencies = [
  "alloy-trie",
  "bytes",
  "modular-bitfield",
- "op-alloy-consensus",
+ "op-alloy-consensus 0.18.14",
  "reth-codecs-derive",
  "reth-zstd-compressors",
  "serde",
@@ -4567,7 +5911,7 @@ name = "reth-codecs-derive"
 version = "1.6.0"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.6.0#d8451e54e7267f9f1634118d6d279b2216f7e2bb"
 dependencies = [
- "convert_case",
+ "convert_case 0.7.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -4579,7 +5923,7 @@ version = "1.6.0"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.6.0#d8451e54e7267f9f1634118d6d279b2216f7e2bb"
 dependencies = [
  "alloy-eip2124",
- "alloy-hardforks",
+ "alloy-hardforks 0.2.13",
  "alloy-primitives",
  "auto_impl",
  "once_cell",
@@ -4596,7 +5940,7 @@ dependencies = [
  "alloy-rlp",
  "nybbles",
  "reth-storage-errors",
- "thiserror 2.0.17",
+ "thiserror",
 ]
 
 [[package]]
@@ -4608,7 +5952,7 @@ dependencies = [
  "alloy-rlp",
  "secp256k1 0.30.0",
  "serde_with",
- "thiserror 2.0.17",
+ "thiserror",
  "url",
 ]
 
@@ -4621,12 +5965,12 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-genesis",
- "alloy-hardforks",
+ "alloy-hardforks 0.2.13",
  "alloy-primitives",
  "derive_more",
  "miniz_oxide",
- "op-alloy-consensus",
- "op-alloy-rpc-types",
+ "op-alloy-consensus 0.18.14",
+ "op-alloy-rpc-types 0.18.14",
  "reth-chainspec",
  "reth-ethereum-forks",
  "reth-network-peers",
@@ -4635,7 +5979,7 @@ dependencies = [
  "reth-primitives-traits",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror",
 ]
 
 [[package]]
@@ -4643,7 +5987,7 @@ name = "reth-optimism-forks"
 version = "1.6.0"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.6.0#d8451e54e7267f9f1634118d6d279b2216f7e2bb"
 dependencies = [
- "alloy-op-hardforks",
+ "alloy-op-hardforks 0.2.13",
  "alloy-primitives",
  "once_cell",
  "reth-ethereum-forks",
@@ -4659,7 +6003,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "bytes",
- "op-alloy-consensus",
+ "op-alloy-consensus 0.18.14",
  "reth-codecs",
  "reth-primitives-traits",
  "reth-zstd-compressors",
@@ -4683,7 +6027,7 @@ dependencies = [
  "bytes",
  "derive_more",
  "once_cell",
- "op-alloy-consensus",
+ "op-alloy-consensus 0.18.14",
  "reth-codecs",
  "revm-bytecode",
  "revm-primitives",
@@ -4691,7 +6035,7 @@ dependencies = [
  "secp256k1 0.30.0",
  "serde",
  "serde_with",
- "thiserror 2.0.17",
+ "thiserror",
 ]
 
 [[package]]
@@ -4702,7 +6046,7 @@ dependencies = [
  "alloy-primitives",
  "derive_more",
  "serde",
- "thiserror 2.0.17",
+ "thiserror",
 ]
 
 [[package]]
@@ -4729,7 +6073,7 @@ dependencies = [
  "reth-prune-types",
  "reth-static-file-types",
  "revm-database-interface",
- "thiserror 2.0.17",
+ "thiserror",
 ]
 
 [[package]]
@@ -4925,7 +6269,7 @@ dependencies = [
  "revm",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror",
 ]
 
 [[package]]
@@ -4986,7 +6330,7 @@ version = "7.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f64fbacb86008394aaebd3454f9643b7d5a782bd251135e17c5b33da592d84d"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "revm-bytecode",
  "revm-primitives",
  "serde",
@@ -5026,6 +6370,231 @@ dependencies = [
 ]
 
 [[package]]
+name = "risc0-binfmt"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1883f0c5d19b865f395209a137dcb29e56dc49951424967b8d0114c129f46e77"
+dependencies = [
+ "anyhow",
+ "borsh",
+ "bytemuck",
+ "derive_more",
+ "elf",
+ "lazy_static",
+ "postcard",
+ "rand 0.9.2",
+ "risc0-zkp",
+ "risc0-zkvm-platform",
+ "ruint",
+ "semver 1.0.27",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "risc0-build"
+version = "3.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f89937fa1c424b188cc4cabf65335736eca9c1e3df79c127f48636f55682f3a4"
+dependencies = [
+ "anyhow",
+ "cargo_metadata",
+ "derive_builder",
+ "dirs",
+ "docker-generate",
+ "hex",
+ "risc0-binfmt",
+ "risc0-zkos-v1compat",
+ "risc0-zkp",
+ "risc0-zkvm-platform",
+ "rzup",
+ "semver 1.0.27",
+ "serde",
+ "serde_json",
+ "stability",
+ "tempfile",
+]
+
+[[package]]
+name = "risc0-circuit-keccak"
+version = "4.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f543c60287fece797a5da4209384ab1bfebd9644fcfe591e11b1aa85f1a02f8"
+dependencies = [
+ "anyhow",
+ "bytemuck",
+ "paste",
+ "risc0-binfmt",
+ "risc0-circuit-recursion",
+ "risc0-core",
+ "risc0-zkp",
+ "tracing",
+]
+
+[[package]]
+name = "risc0-circuit-recursion"
+version = "4.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2347e909c6b2a65584b5898f3802eec5b8c1b4b45329edfdd8587b6a04dd3357"
+dependencies = [
+ "anyhow",
+ "bytemuck",
+ "hex",
+ "metal",
+ "risc0-core",
+ "risc0-zkp",
+ "tracing",
+]
+
+[[package]]
+name = "risc0-circuit-rv32im"
+version = "4.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61676419814a818fdb5e10066b13c5488b3f54aa9668794bd06c99bc91bff1f2"
+dependencies = [
+ "anyhow",
+ "bit-vec",
+ "bytemuck",
+ "derive_more",
+ "paste",
+ "risc0-binfmt",
+ "risc0-core",
+ "risc0-zkp",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "risc0-core"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5b956a976b8ce4713694dcc6c370b522a42ccef4ba45da5b6e57dbf26cdb7b1"
+dependencies = [
+ "bytemuck",
+ "rand_core 0.9.3",
+]
+
+[[package]]
+name = "risc0-groth16"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc57e76bb87193d154ac5ee6ee352fbd7edabddab36f02a81f40a048e5ca14f9"
+dependencies = [
+ "anyhow",
+ "ark-bn254",
+ "ark-ec 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ark-ff 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ark-groth16",
+ "ark-serialize 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytemuck",
+ "hex",
+ "num-bigint 0.4.6",
+ "num-traits",
+ "risc0-binfmt",
+ "risc0-zkp",
+ "serde",
+]
+
+[[package]]
+name = "risc0-zkos-v1compat"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bd70cb45b5d37d025f25663b87c6b9dc9df7f413ee2068531a57f50b0eb95db"
+dependencies = [
+ "include_bytes_aligned",
+ "no_std_strings",
+ "risc0-zkvm-platform",
+]
+
+[[package]]
+name = "risc0-zkp"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f40d362a6c146ec6dc69208f539b92fd86e47b0dbc2083801423034a38155a2"
+dependencies = [
+ "anyhow",
+ "blake2",
+ "borsh",
+ "bytemuck",
+ "cfg-if",
+ "digest 0.10.7",
+ "hex",
+ "hex-literal",
+ "metal",
+ "paste",
+ "rand_core 0.9.3",
+ "risc0-core",
+ "risc0-zkvm-platform",
+ "serde",
+ "sha2 0.10.9",
+ "stability",
+ "tracing",
+]
+
+[[package]]
+name = "risc0-zkvm"
+version = "3.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22b7eafb5d85be59cbd9da83f662cf47d834f1b836e14f675d1530b12c666867"
+dependencies = [
+ "anyhow",
+ "bincode 1.3.3",
+ "bonsai-sdk",
+ "borsh",
+ "bytemuck",
+ "bytes",
+ "derive_more",
+ "hex",
+ "lazy-regex",
+ "prost",
+ "risc0-binfmt",
+ "risc0-build",
+ "risc0-circuit-keccak",
+ "risc0-circuit-recursion",
+ "risc0-circuit-rv32im",
+ "risc0-core",
+ "risc0-groth16",
+ "risc0-zkos-v1compat",
+ "risc0-zkp",
+ "risc0-zkvm-platform",
+ "rrs-lib",
+ "rzup",
+ "semver 1.0.27",
+ "serde",
+ "sha2 0.10.9",
+ "stability",
+ "tempfile",
+ "tracing",
+]
+
+[[package]]
+name = "risc0-zkvm-platform"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4db893788c416287e2e1a87e6b8f5302511a04a45329e699d6a32a16874fd24f"
+dependencies = [
+ "bytemuck",
+ "cfg-if",
+ "critical-section",
+ "embedded-alloc",
+ "getrandom 0.2.16",
+ "getrandom 0.3.4",
+ "libm",
+ "num_enum",
+ "paste",
+ "stability",
+]
+
+[[package]]
+name = "rlimit"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f35ee2729c56bb610f6dba436bf78135f728b7373bdffae2ec815b2d3eb98cc3"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "rlp"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5033,6 +6602,19 @@ checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
 dependencies = [
  "bytes",
  "rustc-hex",
+]
+
+[[package]]
+name = "rlsf"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1646a59a9734b8b7a0ac51689388a60fe1625d4b956348e9de07591a1478457a"
+dependencies = [
+ "cfg-if",
+ "const-default",
+ "libc",
+ "rustversion",
+ "svgbobdoc",
 ]
 
 [[package]]
@@ -5049,6 +6631,36 @@ name = "route-recognizer"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
+
+[[package]]
+name = "rrs-lib"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4382d3af3a4ebdae7f64ba6edd9114fff92c89808004c4943b393377a25d001"
+dependencies = [
+ "downcast-rs",
+ "paste",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid",
+ "digest 0.10.7",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "rug"
@@ -5072,6 +6684,7 @@ dependencies = [
  "ark-ff 0.3.0",
  "ark-ff 0.4.2",
  "ark-ff 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "borsh",
  "bytes",
  "fastrlp 0.3.1",
  "fastrlp 0.4.0",
@@ -5132,7 +6745,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -5205,9 +6818,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd29631678d6fb0903b69223673e122c32e9ae559d0960a38d574695ebc0ea15"
 
 [[package]]
+name = "rzup"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d2aed296f203fa64bcb4b52069356dd86d6ec578593985b919b6995bee1f0ae"
+dependencies = [
+ "hex",
+ "rsa",
+ "semver 1.0.27",
+ "serde",
+ "serde_with",
+ "sha2 0.10.9",
+ "strum",
+ "tempfile",
+ "thiserror",
+ "toml 0.8.23",
+ "yaml-rust2",
+]
+
+[[package]]
 name = "salt"
-version = "1.0.5"
-source = "git+https://github.com/megaeth-labs/salt.git?tag=v1.0.5#b6b30e733276f50855a2d3c0781177803ba8f8d9"
+version = "1.0.3"
+source = "git+https://github.com/megaeth-labs/salt.git?rev=80c02eb1e5d85c3348fc7f3075d80440eeebe1fb#80c02eb1e5d85c3348fc7f3075d80440eeebe1fb"
 dependencies = [
  "auto_impl",
  "banderwagon",
@@ -5222,16 +6854,28 @@ dependencies = [
  "serde",
  "serde_arrays",
  "spin 0.10.0",
- "thiserror 2.0.17",
+ "thiserror",
  "zerocopy 0.7.35",
 ]
 
 [[package]]
 name = "salt-macros"
 version = "0.1.0"
-source = "git+https://github.com/megaeth-labs/salt.git?tag=v1.0.5#b6b30e733276f50855a2d3c0781177803ba8f8d9"
+source = "git+https://github.com/megaeth-labs/salt.git?rev=80c02eb1e5d85c3348fc7f3075d80440eeebe1fb#80c02eb1e5d85c3348fc7f3075d80440eeebe1fb"
 dependencies = [
  "rayon",
+]
+
+[[package]]
+name = "salt-stateless"
+version = "1.0.0"
+source = "git+https://github.com/megaeth-labs/mega-kona.git?branch=clay%2Ffeat%2Fregist_pnet_config#0e12e4a4380aa46f06daca81afb72a1b91645dfc"
+dependencies = [
+ "alloy-eips",
+ "alloy-primitives",
+ "anyhow",
+ "mega-evm 1.5.1",
+ "salt",
 ]
 
 [[package]]
@@ -5402,6 +7046,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5419,7 +7092,7 @@ version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10574371d41b0d9b2cff89418eda27da52bcaff2cc8741db26382a77c29131f1"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -5438,7 +7111,7 @@ version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08a72d8216842fdd57820dc78d840bef99248e35fb2554ff923319e60f2d686b"
 dependencies = [
- "darling",
+ "darling 0.21.3",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5550,6 +7223,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simd-json"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c962f626b54771990066e5435ec8331d1462576cd2d1e62f24076ae014f92112"
+dependencies = [
+ "getrandom 0.3.4",
+ "halfbrown",
+ "ref-cast",
+ "serde",
+ "serde_json",
+ "simdutf8",
+ "value-trait",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "siphasher"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5577,6 +7271,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "snap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
+
+[[package]]
 name = "socket2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5592,7 +7292,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e859df029d160cb88608f5d7df7fb4753fd20fdfb4de5644f3d8b8440841721"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures",
  "http",
@@ -5659,6 +7359,9 @@ name = "spin"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "spki"
@@ -5677,6 +7380,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b9b39299b249ad65f3b7e96443bad61c02ca5cd3589f46cb6d610a0fd6c0d6a"
 
 [[package]]
+name = "stability"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d904e7009df136af5297832a3ace3370cd14ff1546a232f4f185036c2736fcac"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5691,7 +7404,7 @@ dependencies = [
  "alloy-provider",
  "alloy-rpc-types-eth",
  "alloy-trie",
- "base64",
+ "base64 0.22.1",
  "bincode 2.0.1",
  "clap",
  "eyre",
@@ -5700,7 +7413,7 @@ dependencies = [
  "jsonrpsee",
  "kanal",
  "op-alloy-network",
- "op-alloy-rpc-types",
+ "op-alloy-rpc-types 0.18.14",
  "reqwest 0.12.24",
  "revm",
  "rolling-file",
@@ -5708,7 +7421,7 @@ dependencies = [
  "serde",
  "stateless-core",
  "stateless-test-utils",
- "thiserror 2.0.17",
+ "thiserror",
  "tokio",
  "tokio-util",
  "tracing",
@@ -5725,22 +7438,33 @@ dependencies = [
  "alloy-eips",
  "alloy-evm",
  "alloy-genesis",
- "alloy-hardforks",
+ "alloy-hardforks 0.2.13",
  "alloy-op-evm",
- "alloy-op-hardforks",
+ "alloy-op-hardforks 0.2.13",
  "alloy-primitives",
  "alloy-rlp",
+ "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
  "alloy-serde",
+ "alloy-tx-macros",
  "bincode 2.0.1",
  "dyn-clone",
  "eyre",
  "hashbrown 0.16.1",
  "kanal",
- "mega-evm",
+ "kona-driver",
+ "kona-executor",
+ "kona-genesis",
+ "kona-megaevm",
+ "kona-mpt",
+ "kona-proof",
+ "kona-registry",
+ "mega-evm 1.5.1",
+ "mega-evm 1.6.1",
  "num_cpus",
- "op-alloy-consensus",
- "op-alloy-rpc-types",
+ "op-alloy-consensus 0.18.14",
+ "op-alloy-rpc-types 0.18.14",
+ "op-alloy-rpc-types-engine",
  "reth-ethereum-forks",
  "reth-optimism-chainspec",
  "reth-trie-common",
@@ -5748,10 +7472,11 @@ dependencies = [
  "revm",
  "rustc-hash",
  "salt",
+ "salt-stateless",
  "serde",
  "serde_json",
  "stateless-test-utils",
- "thiserror 2.0.17",
+ "thiserror",
  "tokio",
  "tokio-util",
  "tracing",
@@ -5766,7 +7491,7 @@ dependencies = [
  "bincode 2.0.1",
  "dashmap",
  "lz4_flex",
- "op-alloy-rpc-types",
+ "op-alloy-rpc-types 0.18.14",
  "quick_cache",
  "redb",
  "revm",
@@ -5785,7 +7510,7 @@ dependencies = [
  "alloy-rpc-types-eth",
  "bincode 2.0.1",
  "eyre",
- "op-alloy-rpc-types",
+ "op-alloy-rpc-types 0.18.14",
  "revm",
  "salt",
  "serde",
@@ -5798,6 +7523,7 @@ dependencies = [
 name = "stateless-validator"
 version = "2.0.14"
 dependencies = [
+ "alloy-consensus",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -5807,7 +7533,7 @@ dependencies = [
  "jsonrpsee-types",
  "metrics",
  "metrics-exporter-prometheus",
- "op-alloy-rpc-types",
+ "op-alloy-rpc-types 0.18.14",
  "redb",
  "revm",
  "salt",
@@ -5817,7 +7543,7 @@ dependencies = [
  "stateless-db",
  "stateless-test-utils",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror",
  "tokio",
  "tokio-util",
  "tracing",
@@ -5861,6 +7587,25 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "svgbobdoc"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2c04b93fc15d79b39c63218f15e3fdffaa4c227830686e3b7c5f41244eb3e50"
+dependencies = [
+ "base64 0.13.1",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
 
 [[package]]
 name = "syn"
@@ -5917,6 +7662,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "tabled"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e39a2ee1fbcd360805a771e1b300f78cc88fec7b8d3e2f71cd37bbf23e725c7d"
+dependencies = [
+ "papergrid",
+ "tabled_derive",
+ "testing_table",
+]
+
+[[package]]
+name = "tabled_derive"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ea5d1b13ca6cff1f9231ffd62f15eefd72543dab5e468735f1a456728a02846"
+dependencies = [
+ "heck",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5936,6 +7705,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "testing_table"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f8daae29995a24f65619e19d8d31dea5b389f3d853d8bf297bbf607cd0014cc"
+dependencies = [
+ "unicode-width 0.2.2",
+]
+
+[[package]]
 name = "thin-vec"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5943,31 +7721,11 @@ checksum = "144f754d318415ac792f9d69fc87abbbfc043ce2ef041c60f16ad828f638717d"
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
 version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
 dependencies = [
- "thiserror-impl 2.0.17",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -6086,6 +7844,7 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -6141,12 +7900,60 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_datetime"
-version = "0.7.3"
+name = "toml"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2cdb639ebbc97961c51720f858597f7f24c4fc295327923af55b74c3c724533"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml"
+version = "0.9.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
  "serde_core",
+ "serde_spanned 1.1.1",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "winnow 0.7.13",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap 2.12.1",
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow 0.7.13",
 ]
 
 [[package]]
@@ -6156,19 +7963,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6485ef6d0d9b5d0ec17244ff7eb05310113c3f316f2d14200d4de56b3cb98f8d"
 dependencies = [
  "indexmap 2.12.1",
- "toml_datetime",
+ "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
- "winnow",
+ "winnow 0.7.13",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.4"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0cbe268d35bdb4bb5a56a2de88d0ad0eb70af5384a99d648cd4b3d04039800e"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.3",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
@@ -6191,7 +8004,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "bytes",
  "futures-util",
  "http",
@@ -6221,6 +8034,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -6228,12 +8042,13 @@ dependencies = [
 
 [[package]]
 name = "tracing-appender"
-version = "0.2.3"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
 dependencies = [
  "crossbeam-channel",
- "thiserror 1.0.69",
+ "symlink",
+ "thiserror",
  "time",
  "tracing-subscriber 0.3.23",
 ]
@@ -6257,6 +8072,17 @@ checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
  "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
 ]
 
 [[package]]
@@ -6291,9 +8117,11 @@ dependencies = [
  "serde",
  "serde_json",
  "sharded-slab",
+ "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
+ "tracing-log",
  "tracing-serde",
 ]
 
@@ -6346,10 +8174,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unsigned-varint"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb066959b24b5196ae73cb057f45598450d2c5f71460e98c49b738086eff9c06"
 
 [[package]]
 name = "untrusted"
@@ -6388,16 +8234,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "value-trait"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0508fce11ad19e0aab49ce20b6bec7f8f82902ded31df1c9fc61b90f0eb396b8"
+dependencies = [
+ "float-cmp",
+ "halfbrown",
+ "itoa",
+ "ryu",
+]
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "virtue"
+version = "0.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "wait-timeout"
@@ -6491,6 +8361,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wasmtimer"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6556,6 +8439,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6566,6 +8470,17 @@ dependencies = [
  "windows-link",
  "windows-result",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -6595,6 +8510,16 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
 
 [[package]]
 name = "windows-result"
@@ -6672,6 +8597,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -6780,6 +8714,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+
+[[package]]
 name = "wit-bindgen"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6810,6 +8750,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "yaml-rust2"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2462ea039c445496d8793d052e13787f2b90e750b833afee748e601c17621ed9"
+dependencies = [
+ "arraydeque",
+ "encoding_rs",
+ "hashlink",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,20 +33,34 @@ alloy-provider = { version = "1.0.23", features = [
     "reqwest-rustls-tls",
 ], default-features = false }
 alloy-rlp = { version = "0.3.10", default-features = false }
+alloy-rpc-types-engine = { version = ">=1.1.3, <1.7", default-features = false }
 alloy-rpc-types-eth = { version = "1.0.23", default-features = false }
 alloy-rpc-types-trace = "1.0.23"
 alloy-serde = { version = "1.0.23", default-features = false }
 alloy-signer-local = "1.0.23"
 alloy-trie = { version = "0.9.0", default-features = false }
+alloy-tx-macros = { version = "=1.3.0", default-features = false }
 
 # mega
 mega-evm = { git = "https://github.com/megaeth-labs/mega-evm.git", tag = "v1.6.1", default-features = false }
-salt = { git = "https://github.com/megaeth-labs/salt.git", tag = "v1.0.5", default-features = false }
+salt = { git = "https://github.com/megaeth-labs/salt.git", rev = "80c02eb1e5d85c3348fc7f3075d80440eeebe1fb", default-features = false }
+
+# kona
+kona-driver = { git = "https://github.com/megaeth-labs/mega-kona.git", branch = "clay/feat/regist_pnet_config", package = "kona-driver", default-features = false }
+kona-executor = { git = "https://github.com/megaeth-labs/mega-kona.git", branch = "clay/feat/regist_pnet_config", package = "kona-executor", default-features = false }
+kona-genesis = { git = "https://github.com/megaeth-labs/mega-kona.git", branch = "clay/feat/regist_pnet_config", package = "kona-genesis", features = ["serde"], default-features = false }
+kona-megaevm = { git = "https://github.com/megaeth-labs/mega-kona.git", branch = "clay/feat/regist_pnet_config", package = "kona-megaevm", default-features = false }
+kona-mpt = { git = "https://github.com/megaeth-labs/mega-kona.git", branch = "clay/feat/regist_pnet_config", package = "kona-mpt", default-features = false }
+kona-proof = { git = "https://github.com/megaeth-labs/mega-kona.git", branch = "clay/feat/regist_pnet_config", package = "kona-proof", default-features = false }
+kona-registry = { git = "https://github.com/megaeth-labs/mega-kona.git", branch = "clay/feat/regist_pnet_config", package = "kona-registry", default-features = false }
+mega-evm-kona = { git = "https://github.com/megaeth-labs/mega-evm-internal", rev = "b3d8cb645e1caed3f3bf19046431be7d39beb1cf", package = "mega-evm", default-features = false }
+salt-stateless = { git = "https://github.com/megaeth-labs/mega-kona.git", branch = "clay/feat/regist_pnet_config", package = "salt-stateless", default-features = false }
 
 # op
 op-alloy-consensus = { version = "0.18.12", default-features = false }
 op-alloy-network = { version = "0.18.12", default-features = false }
 op-alloy-rpc-types = { version = "0.18.12", default-features = false }
+op-alloy-rpc-types-engine = { version = "0.22.4", default-features = false }
 
 # reth
 reth-ethereum-forks = { git = "https://github.com/paradigmxyz/reth", tag = "v1.6.0", default-features = false }

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The stateless approach eliminates the need for validators to run on high-end har
 
 ## Project Structure
 
-The workspace contains two binaries and four library crates:
+The workspace contains three binaries and four library crates:
 
 | Crate                  | Path                          | Purpose                                                                             |
 | ---------------------- | ----------------------------- | ----------------------------------------------------------------------------------- |
@@ -35,7 +35,8 @@ The workspace contains two binaries and four library crates:
 | `stateless-db`         | `crates/stateless-db`         | redb-backed persistence: table definitions, read/write helpers, bounded `ContractCache` |
 | `stateless-common`     | `crates/stateless-common`     | Shared utilities: RPC client, logging, metrics                                      |
 | `stateless-test-utils` | `crates/stateless-test-utils` | Test fixtures (blocks, witnesses, contracts) and env-var lock for integration tests |
-| `stateless-validator`  | `bin/stateless-validator`     | Main binary: chain sync, parallel validation workers                                |
+| `stateless-validator`  | `bin/stateless-validator`     | Main binary: chain sync, parallel validation workers backed by `MegaEvmValidator`   |
+| `kona-validator`       | `bin/stateless-validator`     | Kona-backed validator binary sharing the validator pipeline                         |
 | `debug-trace-server`   | `bin/debug-trace-server`      | Standalone RPC server for debug/trace methods                                       |
 
 Additional directories: `test_data/` (integration test fixtures including genesis config), `audits/` (security audit reports).
@@ -52,6 +53,17 @@ cargo build --release
 
 ```bash
 cargo run --release --bin stateless-validator -- \
+  --data-dir /path/to/validator/data \
+  --rpc-endpoint <public-rpc-endpoint> \
+  --witness-endpoint <witness-rpc-endpoint> \
+  --genesis-file /path/to/genesis.json \
+  --start-block <trusted-block-hash>
+```
+
+The `kona-validator` binary accepts the same flags and runs the same pipeline with `KonaValidator` as the block-validation backend:
+
+```bash
+cargo run --release --bin kona-validator -- \
   --data-dir /path/to/validator/data \
   --rpc-endpoint <public-rpc-endpoint> \
   --witness-endpoint <witness-rpc-endpoint> \
@@ -168,7 +180,7 @@ This forms a **trust-minimized pipeline**: you rely only on L1 + DA (the rollup'
 
 ### Pipeline
 
-Both binaries share a generic three-stage pipeline defined in `stateless-core`:
+The validator binaries and trace server share a generic three-stage pipeline defined in `stateless-core`:
 
 ```
  Stage 1: FETCH          block_fetcher
@@ -191,7 +203,7 @@ Both binaries share a generic three-stage pipeline defined in `stateless-core`:
 
 The pipeline is configured via `PipelineConfig` and customized through trait implementations:
 - `BlockProcessor`: Processing logic per block (validation or pass-through)
-- `BlockValidator`: The per-block validation backend behind the validator's processor (`MegaEvmValidator` is the in-repo mega-evm implementation; alternative executors implement it out-of-tree)
+- `BlockValidator`: The per-block validation backend behind the validator's processor (`stateless-validator` wires `MegaEvmValidator`; `kona-validator` wires `KonaValidator`)
 - `PipelineHooks`: Callbacks for advance/reorg/stale events
 - `ProcessedBlock`: Output type of the processing stage
 - `ReorgResolver`: Decides the rollback floor on a detected reorg (`BisectResolver` walks local history; embedders can supply an externally-resolved floor)

--- a/bin/stateless-validator/Cargo.toml
+++ b/bin/stateless-validator/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/main.rs"
 
 [dependencies]
 # alloy
+alloy-consensus.workspace = true
 alloy-genesis.workspace = true
 alloy-primitives.workspace = true
 alloy-rpc-types-eth.workspace = true

--- a/bin/stateless-validator/Cargo.toml
+++ b/bin/stateless-validator/Cargo.toml
@@ -11,6 +11,10 @@ exclude.workspace = true
 name = "stateless-validator"
 path = "src/main.rs"
 
+[[bin]]
+name = "kona-validator"
+path = "src/bin/kona-validator.rs"
+
 [dependencies]
 # alloy
 alloy-consensus.workspace = true

--- a/bin/stateless-validator/src/app.rs
+++ b/bin/stateless-validator/src/app.rs
@@ -4,15 +4,19 @@ use std::{path::PathBuf, sync::Arc, time::Duration};
 
 use alloy_genesis::Genesis;
 use alloy_primitives::BlockHash;
-use alloy_rpc_types_eth::BlockId;
+use alloy_rpc_types_eth::{Block, BlockId};
 use clap::Parser;
 use eyre::Result;
+use op_alloy_rpc_types::Transaction;
 use stateless_common::{BackoffPolicy, RpcClient, RpcClientConfig, logging::LogArgs};
-use stateless_core::{ChainStore, ContractStore, chain_spec::ChainSpec, db::BlockMeta};
+use stateless_core::{
+    ChainStore, ContractStore, KonaValidator, MegaEvmValidator, chain_spec::ChainSpec,
+    db::BlockMeta, executor::BlockValidator,
+};
 use stateless_db::ContractCache;
 use tracing::info;
 
-use crate::{metrics, validator_db::ValidatorDB, workers};
+use crate::{metrics, validator_db::ValidatorDB};
 
 /// Database filename for the validator.
 pub const VALIDATOR_DB_FILENAME: &str = "validator.redb";
@@ -168,6 +172,20 @@ pub struct CommandLineArgs {
 /// validator DB, loads or initializes the chain spec + anchor, then hands off to
 /// [`workers::run_with_signals`].
 pub async fn run() -> Result<()> {
+    run_with_validator(false, |chain_spec| Ok(MegaEvmValidator::new(chain_spec.clone()))).await
+}
+
+pub async fn run_kona() -> Result<()> {
+    run_with_validator(true, |chain_spec| Ok(KonaValidator::new(chain_spec)?)).await
+}
+
+async fn run_with_validator<V>(
+    fetch_parent_header: bool,
+    make_validator: impl FnOnce(&ChainSpec) -> Result<V>,
+) -> Result<()>
+where
+    V: BlockValidator<Block<Transaction>> + Send + Sync + 'static,
+{
     let args = CommandLineArgs::parse();
     let _log_guard = args.log.init_tracing()?;
     let start = std::time::Instant::now();
@@ -223,6 +241,7 @@ pub async fn run() -> Result<()> {
 
     let chain_spec =
         Arc::new(load_or_create_chain_spec(&validator_db, args.genesis_file.as_deref())?);
+    let validator = Arc::new(make_validator(chain_spec.as_ref())?);
     info!("Chain spec loaded successfully");
 
     if let Some(start_block_str) = &args.start_block {
@@ -272,13 +291,14 @@ pub async fn run() -> Result<()> {
         override_ms(args.error_restart_delay_ms, pipeline_config.error_restart_delay);
     pipeline_config.tip_buffer = args.tip_buffer.unwrap_or(DEFAULT_TIP_BUFFER);
 
-    let result = workers::run_with_signals(
+    let result = crate::workers::run_with_signals(
         client,
         validator_db,
         contract_cache,
-        chain_spec,
+        validator,
         args.report_validation_endpoint,
         pipeline_config,
+        fetch_parent_header,
     )
     .await;
 

--- a/bin/stateless-validator/src/bin/kona-validator.rs
+++ b/bin/stateless-validator/src/bin/kona-validator.rs
@@ -1,0 +1,4 @@
+#[tokio::main]
+async fn main() -> eyre::Result<()> {
+    stateless_validator::run_kona().await
+}

--- a/bin/stateless-validator/src/chain_sync.rs
+++ b/bin/stateless-validator/src/chain_sync.rs
@@ -6,6 +6,7 @@
 
 use std::{collections::HashSet, sync::Arc};
 
+use alloy_consensus::Header;
 use alloy_primitives::{B256, BlockHash, BlockNumber};
 use alloy_rpc_types_eth::{Block, BlockId};
 use eyre::{Result, ensure};
@@ -44,7 +45,9 @@ impl BlockFetcher for ValidatorFetcher {
             self.rpc_client.get_witness(block_number, block_hash),
             self.rpc_client.get_block(BlockId::Hash(block_hash.into()), true),
         );
-        Ok(ValidationTask { block, salt_witness, mpt_witness })
+        let parent_header =
+            self.rpc_client.get_header(BlockId::Hash(block.header.parent_hash.into()), false).await;
+        Ok(ValidationTask { block, parent_header: parent_header.inner, salt_witness, mpt_witness })
     }
 
     async fn latest_block_number(&self) -> Result<u64> {
@@ -72,6 +75,7 @@ impl BlockFetcher for ValidatorFetcher {
 #[derive(Clone, Debug)]
 pub struct ValidationTask {
     pub block: Block<Transaction>,
+    pub parent_header: Header,
     pub salt_witness: SaltWitness,
     pub mpt_witness: MptWitness,
 }
@@ -226,13 +230,11 @@ where
         // Validate in a blocking thread
         let validator = Arc::clone(&self.validator);
         let validation_result = task::spawn_blocking(move || {
-            let ValidationTask { block, salt_witness, mpt_witness } = task;
-            validator.validate_block(ValidationInput::new(
-                &block,
-                salt_witness,
-                mpt_witness,
-                &contracts,
-            ))
+            let ValidationTask { block, parent_header, salt_witness, mpt_witness } = task;
+            validator.validate_block(
+                ValidationInput::new(&block, salt_witness, mpt_witness, &contracts)
+                    .with_parent_header(&parent_header),
+            )
         })
         .await
         .map_err(|e| fail(format!("Validation task panicked: {e}"), false))?;

--- a/bin/stateless-validator/src/chain_sync.rs
+++ b/bin/stateless-validator/src/chain_sync.rs
@@ -32,6 +32,7 @@ use crate::metrics;
 pub struct ValidatorFetcher {
     pub rpc_client: Arc<RpcClient>,
     pub on_remote_height: fn(u64),
+    pub fetch_parent_header: bool,
 }
 
 impl BlockFetcher for ValidatorFetcher {
@@ -45,9 +46,17 @@ impl BlockFetcher for ValidatorFetcher {
             self.rpc_client.get_witness(block_number, block_hash),
             self.rpc_client.get_block(BlockId::Hash(block_hash.into()), true),
         );
-        let parent_header =
-            self.rpc_client.get_header(BlockId::Hash(block.header.parent_hash.into()), false).await;
-        Ok(ValidationTask { block, parent_header: parent_header.inner, salt_witness, mpt_witness })
+        let parent_header = if self.fetch_parent_header {
+            Some(
+                self.rpc_client
+                    .get_header(BlockId::Hash(block.header.parent_hash.into()), false)
+                    .await
+                    .inner,
+            )
+        } else {
+            None
+        };
+        Ok(ValidationTask { block, parent_header, salt_witness, mpt_witness })
     }
 
     async fn latest_block_number(&self) -> Result<u64> {
@@ -75,7 +84,7 @@ impl BlockFetcher for ValidatorFetcher {
 #[derive(Clone, Debug)]
 pub struct ValidationTask {
     pub block: Block<Transaction>,
-    pub parent_header: Header,
+    pub parent_header: Option<Header>,
     pub salt_witness: SaltWitness,
     pub mpt_witness: MptWitness,
 }
@@ -231,10 +240,13 @@ where
         let validator = Arc::clone(&self.validator);
         let validation_result = task::spawn_blocking(move || {
             let ValidationTask { block, parent_header, salt_witness, mpt_witness } = task;
-            validator.validate_block(
-                ValidationInput::new(&block, salt_witness, mpt_witness, &contracts)
-                    .with_parent_header(&parent_header),
-            )
+            let input = ValidationInput::new(&block, salt_witness, mpt_witness, &contracts);
+            match &parent_header {
+                Some(parent_header) => {
+                    validator.validate_block(input.with_parent_header(parent_header))
+                }
+                None => validator.validate_block(input),
+            }
         })
         .await
         .map_err(|e| fail(format!("Validation task panicked: {e}"), false))?;

--- a/bin/stateless-validator/src/lib.rs
+++ b/bin/stateless-validator/src/lib.rs
@@ -9,6 +9,6 @@ pub(crate) mod metrics;
 pub(crate) mod validator_db;
 pub(crate) mod workers;
 
-pub use app::{CommandLineArgs, VALIDATOR_DB_FILENAME, load_or_create_chain_spec, run};
+pub use app::{CommandLineArgs, VALIDATOR_DB_FILENAME, load_or_create_chain_spec, run, run_kona};
 pub use chain_sync::{ValidatorFetcher, ValidatorHooks, ValidatorProcessor};
 pub use validator_db::ValidatorDB;

--- a/bin/stateless-validator/src/workers.rs
+++ b/bin/stateless-validator/src/workers.rs
@@ -6,7 +6,7 @@ use alloy_primitives::B256;
 use eyre::Result;
 use stateless_common::RpcClient;
 use stateless_core::{
-    BisectResolver, ChainStore, MegaEvmValidator, PipelineConfig, chain_spec::ChainSpec,
+    BisectResolver, ChainStore, KonaValidator, PipelineConfig, chain_spec::ChainSpec,
     pipeline::run_pipeline,
 };
 use stateless_db::ContractCache;
@@ -51,7 +51,7 @@ pub async fn run_with_signals(
         on_remote_height: metrics::set_remote_chain_height,
     });
     let processor = Arc::new(ValidatorProcessor {
-        validator: Arc::new(MegaEvmValidator::new(chain_spec.as_ref().clone())),
+        validator: Arc::new(KonaValidator::new(chain_spec.as_ref())?),
         contract_cache,
         rpc_client: client.clone(),
     });

--- a/bin/stateless-validator/src/workers.rs
+++ b/bin/stateless-validator/src/workers.rs
@@ -3,11 +3,12 @@
 use std::{sync::Arc, time::Duration};
 
 use alloy_primitives::B256;
+use alloy_rpc_types_eth::Block;
 use eyre::Result;
+use op_alloy_rpc_types::Transaction;
 use stateless_common::RpcClient;
 use stateless_core::{
-    BisectResolver, ChainStore, KonaValidator, PipelineConfig, chain_spec::ChainSpec,
-    pipeline::run_pipeline,
+    BisectResolver, ChainStore, PipelineConfig, executor::BlockValidator, pipeline::run_pipeline,
 };
 use stateless_db::ContractCache;
 use tokio::{signal, task};
@@ -24,14 +25,18 @@ use crate::{
 ///
 /// Cleanly drains on SIGINT/SIGTERM and returns either the pipeline result or `Ok(())`
 /// on signal.
-pub async fn run_with_signals(
+pub async fn run_with_signals<V>(
     client: Arc<RpcClient>,
     validator_db: Arc<ValidatorDB>,
     contract_cache: Arc<ContractCache>,
-    chain_spec: Arc<ChainSpec>,
+    validator: Arc<V>,
     report_validation_endpoint: Option<String>,
     pipeline_config: PipelineConfig,
-) -> Result<()> {
+    fetch_parent_header: bool,
+) -> Result<()>
+where
+    V: BlockValidator<Block<Transaction>> + Send + Sync + 'static,
+{
     let report_validation = report_validation_endpoint.is_some();
     let config = Arc::new(pipeline_config);
     info!(
@@ -49,12 +54,10 @@ pub async fn run_with_signals(
     let fetcher = Arc::new(ValidatorFetcher {
         rpc_client: client.clone(),
         on_remote_height: metrics::set_remote_chain_height,
+        fetch_parent_header,
     });
-    let processor = Arc::new(ValidatorProcessor {
-        validator: Arc::new(KonaValidator::new(chain_spec.as_ref())?),
-        contract_cache,
-        rpc_client: client.clone(),
-    });
+    let processor =
+        Arc::new(ValidatorProcessor { validator, contract_cache, rpc_client: client.clone() });
     let hooks = Arc::new(ValidatorHooks);
 
     let reporter = if report_validation {

--- a/bin/stateless-validator/tests/integration.rs
+++ b/bin/stateless-validator/tests/integration.rs
@@ -3,7 +3,7 @@
 //! Covers CLI argument parsing and end-to-end pipeline validation against a mock RPC server.
 //! Mainnet single-block validation is covered in `crates/stateless-core/src/executor.rs::tests`.
 
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, process::Command, sync::Arc};
 
 use alloy_primitives::{B256, BlockHash};
 use alloy_rpc_types_eth::Block;
@@ -17,8 +17,12 @@ use jsonrpsee_types::error::{
 };
 use stateless_common::{RpcClient, WitnessRequestKeys, encode_witness_response};
 use stateless_core::{
-    BisectResolver, ChainStore, ContractStore, MegaEvmValidator, PipelineConfig, db::BlockMeta,
-    pipeline::run_pipeline, withdrawals::MptWitness,
+    BisectResolver, BlockValidator, ChainStore, ContractStore, KonaValidator, MegaEvmValidator,
+    PipelineConfig,
+    chain_spec::ChainSpec,
+    db::BlockMeta,
+    pipeline::{BlockFetcher, run_pipeline},
+    withdrawals::MptWitness,
 };
 use stateless_db::ContractCache;
 use stateless_test_utils::{fixtures::TestFixtures, logging::init_test_logging};
@@ -155,6 +159,15 @@ fn canonical_chain_max_length_rejects_zero() {
         || parse(&[]),
     );
     assert!(from_env_zero.is_err(), "env-var 0 must also be rejected");
+}
+
+#[test]
+fn kona_validator_binary_exposes_cli() {
+    let output = Command::new(env!("CARGO_BIN_EXE_kona-validator")).arg("--help").output().unwrap();
+
+    assert!(output.status.success(), "kona-validator --help failed: {output:?}");
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("Usage: kona-validator"), "unexpected help output: {stdout}");
 }
 
 const MAX_RESPONSE_BODY_SIZE: u32 = 1024 * 1024 * 100;
@@ -364,11 +377,43 @@ async fn setup_mock_rpc_server(
     (server.start(module), url)
 }
 
-/// Synthetic data integration test: validates consecutive blocks via the streaming pipeline.
 #[tokio::test]
-async fn integration_test() {
+async fn kona_fetcher_includes_parent_header() {
+    let fx = TestFixtures::synthetic();
+    let (block_number, block_hash) = fx
+        .paired_blocks()
+        .into_iter()
+        .find(|(_, hash)| fx.blocks.contains_key(&fx.blocks[hash].header.parent_hash))
+        .expect("fixture block with local parent");
+    let state = MockServerState::new(fx);
+    let (handle, url) = setup_mock_rpc_server(state).await;
+    let client = Arc::new(RpcClient::new(&[url.as_str()], &[url.as_str()]).unwrap());
+    let fetcher = ValidatorFetcher {
+        rpc_client: client,
+        on_remote_height: |_| {},
+        fetch_parent_header: true,
+    };
+
+    let task = fetcher.fetch(block_number).await.unwrap();
+    let parent_header = task.parent_header.expect("Kona fetcher should fetch parent header");
+
+    assert_eq!(task.block.header.hash, block_hash);
+    assert_eq!(parent_header.hash_slow(), task.block.header.parent_hash);
+
+    handle.stop().unwrap();
+}
+
+/// Synthetic data integration test: validates consecutive blocks via the streaming pipeline.
+async fn run_integration_test_with_validator<V, E>(
+    validator_name: &str,
+    fetch_parent_header: bool,
+    make_validator: impl FnOnce(&ChainSpec) -> Result<V, E>,
+) where
+    E: std::fmt::Debug,
+    V: BlockValidator<Block<op_alloy_rpc_types::Transaction>> + Send + Sync + 'static,
+{
     let _logging = init_test_logging("stateless_validator");
-    debug!("=== Loading Synthetic Test Data ===");
+    debug!("=== Loading Synthetic Test Data for {validator_name} ===");
     let fx = TestFixtures::synthetic();
     let genesis_file = fx.data_dir.join("genesis.json");
 
@@ -391,10 +436,13 @@ async fn integration_test() {
     let config = Arc::new(cfg);
 
     let shutdown = CancellationToken::new();
-    let fetcher =
-        Arc::new(ValidatorFetcher { rpc_client: client.clone(), on_remote_height: |_| {} });
+    let fetcher = Arc::new(ValidatorFetcher {
+        rpc_client: client.clone(),
+        on_remote_height: |_| {},
+        fetch_parent_header,
+    });
     let processor = Arc::new(ValidatorProcessor {
-        validator: Arc::new(MegaEvmValidator::new(chain_spec)),
+        validator: Arc::new(make_validator(&chain_spec).unwrap()),
         contract_cache,
         rpc_client: client,
     });
@@ -417,9 +465,22 @@ async fn integration_test() {
     assert_eq!(
         validator_db.get_canonical_tip().unwrap().unwrap().block_number,
         max_block_number,
-        "expected validator DB tip to reach max fixture block",
+        "expected {validator_name} validator DB tip to reach max fixture block",
     );
 
     handle.stop().unwrap();
-    info!("Mock RPC server has been shut down");
+    info!("Mock RPC server has been shut down for {validator_name}");
+}
+
+#[tokio::test]
+async fn integration_test_mega_evm_validator() {
+    run_integration_test_with_validator("MegaEVM", false, |chain_spec| {
+        Ok::<_, std::convert::Infallible>(MegaEvmValidator::new(chain_spec.clone()))
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn integration_test_kona_validator() {
+    run_integration_test_with_validator("Kona", true, KonaValidator::new).await;
 }

--- a/crates/stateless-core/Cargo.toml
+++ b/crates/stateless-core/Cargo.toml
@@ -18,15 +18,29 @@ alloy-op-evm.workspace = true
 alloy-op-hardforks = { workspace = true, default-features = false }
 alloy-primitives.workspace = true
 alloy-rlp.workspace = true
+alloy-rpc-types-engine.workspace = true
 alloy-rpc-types-eth.workspace = true
 alloy-serde.workspace = true
+alloy-tx-macros.workspace = true
 
 # mega
 mega-evm = { workspace = true, default-features = false }
 salt = { workspace = true, default-features = false }
 
+# kona
+kona-driver.workspace = true
+kona-executor.workspace = true
+kona-genesis.workspace = true
+kona-megaevm.workspace = true
+kona-mpt.workspace = true
+kona-proof.workspace = true
+kona-registry.workspace = true
+mega-evm-kona.workspace = true
+salt-stateless.workspace = true
+
 # op
 op-alloy-consensus.workspace = true
+op-alloy-rpc-types-engine.workspace = true
 op-alloy-rpc-types.workspace = true
 
 # reth
@@ -39,6 +53,7 @@ reth-trie-sparse.workspace = true
 revm.workspace = true
 
 # misc
+bincode.workspace = true
 dyn-clone.workspace = true
 eyre = { workspace = true, optional = true }
 hashbrown.workspace = true
@@ -74,10 +89,15 @@ std = [
     "alloy-op-evm/std",
     "alloy-primitives/std",
     "alloy-rlp/std",
+    "alloy-rpc-types-engine/std",
     "alloy-rpc-types-eth/std",
     "alloy-serde/std",
+    "kona-genesis/std",
+    "kona-proof/std",
+    "kona-registry/std",
     "mega-evm/default",
     "op-alloy-consensus/std",
+    "op-alloy-rpc-types-engine/std",
     "op-alloy-rpc-types/std",
     "reth-ethereum-forks/std",
     "reth-optimism-chainspec/std",

--- a/crates/stateless-core/Cargo.toml
+++ b/crates/stateless-core/Cargo.toml
@@ -40,8 +40,8 @@ salt-stateless.workspace = true
 
 # op
 op-alloy-consensus.workspace = true
-op-alloy-rpc-types-engine.workspace = true
 op-alloy-rpc-types.workspace = true
+op-alloy-rpc-types-engine.workspace = true
 
 # reth
 reth-ethereum-forks.workspace = true

--- a/crates/stateless-core/src/kona_replay.rs
+++ b/crates/stateless-core/src/kona_replay.rs
@@ -1,0 +1,912 @@
+//! Kona-backed block validation for stateless validation.
+
+use std::{boxed::Box, collections::BTreeMap, fmt, vec::Vec};
+#[cfg(feature = "std")]
+use std::{io::Write, time::Instant};
+
+use alloy_consensus::{
+    BlockHeader, Header, TxReceipt, crypto::RecoveryError, proofs::calculate_receipt_root,
+    transaction::Recovered,
+};
+use alloy_eips::{
+    calc_next_block_base_fee,
+    eip1559::BaseFeeParams,
+    eip2718::{Decodable2718, Encodable2718, WithEncoded},
+};
+use alloy_primitives::{
+    Address, B64, Bloom, Bytes, keccak256,
+    map::{B256Map, HashMap},
+};
+use alloy_rlp::Decodable;
+use alloy_rpc_types_engine::PayloadAttributes;
+use bincode::serde::encode_to_vec;
+use kona_driver::Executor;
+use kona_executor::{BlockBuildingOutcome, TrieDBProvider};
+use kona_genesis::RollupConfig;
+use kona_megaevm::{
+    LazyMegaBlockExecutorFactory, LazyMegaEvmFactory, MegaChainSpec,
+    WitnessExternalEnv as KonaWitnessExternalEnv,
+};
+use kona_mpt::{NoopTrieHinter, TrieNode, TrieProvider};
+use kona_proof::executor::KonaExecutor;
+use mega_evm_kona::{
+    BlockLimits, MegaBlockExecutionCtx, MegaHardforks, MegaSpecId, MegaTxEnvelope,
+    SequencerRegistryConfig,
+    alloy_evm::{
+        EvmEnv,
+        block::{BlockExecutionError, BlockExecutor},
+    },
+    alloy_op_evm::block::OpAlloyReceiptBuilder,
+    revm::{
+        context::{BlockEnv, CfgEnv},
+        context_interface::block::BlobExcessGasAndPrice,
+        database::{
+            State,
+            in_memory_db::CacheDB,
+            states::{BundleAccount, bundle_state::BundleRetention},
+        },
+        primitives::eip4844::{
+            BLOB_BASE_FEE_UPDATE_FRACTION_CANCUN, BLOB_BASE_FEE_UPDATE_FRACTION_PRAGUE,
+        },
+    },
+};
+use op_alloy_consensus::decode_holocene_extra_data;
+use op_alloy_rpc_types_engine::OpPayloadAttributes;
+use revm::{
+    primitives::{B256, KECCAK_EMPTY, U256},
+    state::Bytecode,
+};
+use salt::{EphemeralSaltState, SaltValue, SaltWitness, StateRoot, StateUpdates, Witness};
+use salt_stateless::WitnessProvider;
+use thiserror::Error;
+use tracing::{debug, trace};
+
+use crate::{
+    chain_spec::ChainSpec,
+    data_types::{Account, PlainKey, PlainValue},
+    executor::{
+        BlockExecutionOutput, BlockInput, BlockValidator, ValidationError, ValidationInput,
+        ValidationStats,
+    },
+    withdrawals::{ADDRESS_L2_TO_L1_MESSAGE_PASSER, MptWitness},
+};
+
+/// Errors raised while adapting stateless-validator inputs to Kona execution.
+#[derive(Debug, Error)]
+pub enum KonaReplayError {
+    #[error("block contains only transaction hashes")]
+    BlockIncomplete,
+
+    #[error("Kona validator requires parent header in ValidationInput")]
+    MissingParentHeader,
+
+    #[error("parent header hash mismatch: expected {expected:?}, got {actual:?}")]
+    ParentHeaderHashMismatch { expected: alloy_primitives::B256, actual: alloy_primitives::B256 },
+
+    #[error("rollup config for chain_id {0} is not present in mega-kona registry")]
+    MissingRollupConfig(u64),
+
+    #[error("failed to encode SALT witness for Kona executor: {0}")]
+    SaltWitnessEncoding(#[from] bincode::error::EncodeError),
+
+    #[error("Kona provider error: {0}")]
+    Provider(#[from] KonaReplayProviderError),
+
+    #[error("Kona execution failed: {0}")]
+    Execution(#[from] kona_executor::ExecutorError),
+
+    #[error("Kona block replay failed during transaction execution: {0}")]
+    BlockReplayFailed(#[source] BlockExecutionError),
+
+    #[error("Failed to construct Kona mega-evm environment oracle: {0}")]
+    EnvOracleConstructionFailed(#[source] kona_megaevm::WitnessDatabaseError),
+
+    #[error("Invalid Kona EIP-1559 header extra data: {0}")]
+    InvalidExtraData(String),
+
+    #[error("Kona transaction signer recovery failed: {0}")]
+    Recovery(#[from] RecoveryError),
+
+    #[error("Kona bundle-state generation or validation failed: {0}")]
+    BundleStateValidation(#[from] ValidationError),
+
+    #[error("Kona block hash mismatch: claimed {claimed:?}, got {actual:?}")]
+    BlockHashMismatch { actual: B256, claimed: B256 },
+
+    #[error("Kona state root mismatch: claimed {claimed}, got {actual}")]
+    StateRootMismatch { actual: B256, claimed: B256 },
+
+    #[error("Kona withdrawals root mismatch: claimed {claimed:?}, got {actual:?}")]
+    WithdrawalsRootMismatch { actual: Option<B256>, claimed: Option<B256> },
+
+    #[error("Kona receipts root mismatch: claimed {claimed}, got {actual}")]
+    ReceiptsRootMismatch { actual: B256, claimed: B256 },
+
+    #[error("Kona logs bloom mismatch: claimed {claimed}, got {actual}")]
+    LogsBloomMismatch { actual: Box<Bloom>, claimed: Box<Bloom> },
+
+    #[error("Kona gas used mismatch: claimed {claimed}, got {actual}")]
+    GasUsedMismatch { actual: u64, claimed: u64 },
+}
+
+/// Kona execution result normalized to the fields the validator checks.
+#[derive(Debug, Clone)]
+pub struct KonaReplayOutput {
+    pub block_hash: B256,
+    pub state_root: B256,
+    pub receipts_root: B256,
+    pub logs_bloom: Bloom,
+    pub gas_used: u64,
+    pub withdrawals_root: Option<B256>,
+    pub receipt_count: usize,
+}
+
+/// A [`BlockValidator`] backend that validates blocks by rebuilding them through Kona.
+#[derive(Debug, Clone)]
+pub struct KonaValidator {
+    chain_spec: ChainSpec,
+    rollup_config: RollupConfig,
+}
+
+impl KonaValidator {
+    /// Creates a Kona backend for the given chain spec.
+    pub fn new(chain_spec: &ChainSpec) -> Result<Self, KonaReplayError> {
+        Ok(Self {
+            chain_spec: chain_spec.clone(),
+            rollup_config: rollup_config_for_chain_id(chain_spec.chain_id)?,
+        })
+    }
+}
+
+impl<B: BlockInput> BlockValidator<B> for KonaValidator {
+    type Error = KonaReplayError;
+
+    fn validate_block(
+        &self,
+        input: ValidationInput<'_, B>,
+    ) -> Result<ValidationStats, KonaReplayError> {
+        self::validate_block(
+            &self.chain_spec,
+            input.block,
+            input.parent_header.ok_or(KonaReplayError::MissingParentHeader)?,
+            input.salt_witness,
+            input.mpt_witness,
+            input.contracts,
+            &self.rollup_config,
+            #[cfg(feature = "std")]
+            None,
+        )
+    }
+}
+
+/// In-memory [`TrieDBProvider`] backed by the validator's witness bundle.
+#[derive(Clone, Debug)]
+struct KonaReplayProvider {
+    salt_witness: Bytes,
+    bytecodes: HashMap<B256, Bytes>,
+    trie_nodes: B256Map<Bytes>,
+    headers: HashMap<B256, Header>,
+}
+
+impl KonaReplayProvider {
+    fn new(
+        salt_witness: &SaltWitness,
+        mpt_witness: &MptWitness,
+        contracts: &HashMap<B256, Bytecode>,
+        parent_header: &Header,
+        parent_hash: B256,
+    ) -> Result<Self, KonaReplayError> {
+        let actual_parent_hash = parent_header.hash_slow();
+        if actual_parent_hash != parent_hash {
+            return Err(KonaReplayError::ParentHeaderHashMismatch {
+                expected: parent_hash,
+                actual: actual_parent_hash,
+            });
+        }
+
+        let salt_witness = Bytes::from(encode_to_vec(salt_witness, bincode::config::legacy())?);
+        let bytecodes = contracts
+            .iter()
+            .map(|(hash, bytecode)| (*hash, Bytes::copy_from_slice(bytecode.bytes_slice())))
+            .collect();
+        let trie_nodes =
+            mpt_witness.state.iter().map(|node| (keccak256(node), node.clone())).collect();
+        let headers = HashMap::from_iter([(parent_hash, parent_header.clone())]);
+
+        Ok(Self { salt_witness, bytecodes, trie_nodes, headers })
+    }
+}
+
+impl TrieProvider for KonaReplayProvider {
+    type Error = KonaReplayProviderError;
+
+    fn trie_node_by_hash(&self, key: B256) -> Result<TrieNode, Self::Error> {
+        trace!(?key, "Kona trie node lookup");
+        let bytes = self.trie_nodes.get(&key).ok_or(KonaReplayProviderError::TrieNode(key))?;
+        TrieNode::decode(&mut bytes.as_ref()).map_err(KonaReplayProviderError::TrieNodeDecode)
+    }
+}
+
+impl TrieDBProvider for KonaReplayProvider {
+    fn bytecode_by_hash(&self, code_hash: B256) -> Result<Bytes, Self::Error> {
+        trace!(?code_hash, "Kona bytecode lookup");
+        self.bytecodes.get(&code_hash).cloned().ok_or(KonaReplayProviderError::Bytecode(code_hash))
+    }
+
+    fn header_by_hash(&self, hash: B256) -> Result<Header, Self::Error> {
+        trace!(?hash, "Kona header lookup");
+        self.headers.get(&hash).cloned().ok_or(KonaReplayProviderError::Header(hash))
+    }
+
+    fn salt_witness_by_state_root(
+        &self,
+        _block_number: u64,
+        _parent_hash: B256,
+        _state_root: B256,
+        _payload_attributes_hash: B256,
+    ) -> Result<Bytes, Self::Error> {
+        Ok(self.salt_witness.clone())
+    }
+}
+
+#[derive(Debug, Clone, Error)]
+pub enum KonaReplayProviderError {
+    #[error("missing trie node preimage for {0:?}")]
+    TrieNode(B256),
+
+    #[error("failed to decode trie node: {0}")]
+    TrieNodeDecode(alloy_rlp::Error),
+
+    #[error("missing bytecode for {0:?}")]
+    Bytecode(B256),
+
+    #[error("missing header for {0:?}")]
+    Header(B256),
+}
+
+/// Replays one block through Kona's `execute_payload` path.
+pub fn execute_payload_with_kona<B: BlockInput>(
+    block: &B,
+    parent_header: &Header,
+    salt_witness: &SaltWitness,
+    mpt_witness: &MptWitness,
+    contracts: &HashMap<B256, Bytecode>,
+    rollup_config: &RollupConfig,
+) -> Result<KonaReplayOutput, KonaReplayError> {
+    if !block.is_complete() {
+        return Err(KonaReplayError::BlockIncomplete);
+    }
+
+    let parent_hash = block.consensus_header().parent_hash;
+    let provider =
+        KonaReplayProvider::new(salt_witness, mpt_witness, contracts, parent_header, parent_hash)?;
+    let parent_header = alloy_primitives::Sealed::new_unchecked(parent_header.clone(), parent_hash);
+    let mut executor = KonaExecutor::new(
+        rollup_config,
+        provider,
+        NoopTrieHinter,
+        LazyMegaEvmFactory::default(),
+        None,
+    );
+    executor.update_safe_head(parent_header);
+
+    let attrs = payload_attrs_from_block(block, rollup_config)?;
+    debug!(
+        block_number = block.consensus_header().number,
+        block_hash = ?block.block_hash(),
+        "Executing block via Kona execute_payload"
+    );
+    let outcome = kona_proof::block_on(executor.execute_payload(attrs))?;
+
+    Ok(output_from_outcome(outcome))
+}
+
+/// Generates the bundle-state artifacts used by the Kona validator's local checks.
+pub fn generate_bundle_state<B: BlockInput>(
+    block: &B,
+    parent_header: &Header,
+    salt_witness: SaltWitness,
+    contracts: &HashMap<B256, Bytecode>,
+    rollup_config: &RollupConfig,
+) -> Result<HashMap<Address, BundleAccount>, KonaReplayError> {
+    if !block.is_complete() {
+        return Err(KonaReplayError::BlockIncomplete);
+    }
+
+    let header = block.consensus_header();
+    let attrs = payload_attrs_from_block(block, rollup_config)?;
+    let parent_hash = header.parent_hash;
+    let parent_header = alloy_primitives::Sealed::new_unchecked(parent_header.clone(), parent_hash);
+    let evm_env = kona_evm_env(header, parent_header.as_ref(), &attrs, rollup_config)?;
+    let block_env = evm_env.block_env().clone();
+
+    let contracts = contracts.iter().map(|(hash, bytecode)| (*hash, bytecode.clone())).collect();
+    let witness_provider = WitnessProvider::new_with_parent_block(
+        salt_witness.clone(),
+        contracts,
+        parent_header.number,
+        parent_hash,
+    );
+    let mut db = CacheDB::new(witness_provider);
+    let mut state = State::builder().with_database(&mut db).with_bundle_update().build();
+    let env_oracle = KonaWitnessExternalEnv::new(&salt_witness, block_env.number.saturating_to())
+        .map_err(KonaReplayError::EnvOracleConstructionFailed)?;
+
+    let mut executor_factory = LazyMegaBlockExecutorFactory::new(
+        mega_chain_spec(rollup_config),
+        LazyMegaEvmFactory::default(),
+        OpAlloyReceiptBuilder::default(),
+    );
+    executor_factory.set_ext_envs(env_oracle);
+
+    let timestamp = attrs.payload_attributes.timestamp;
+    let mega_chain_spec = mega_chain_spec(rollup_config);
+    let block_limits = MegaHardforks::hardfork(&mega_chain_spec, timestamp)
+        .map(|fork| BlockLimits::from_hardfork_and_block_gas_limit(fork, block_env.gas_limit))
+        .unwrap_or_else(|| BlockLimits::no_limits().with_block_gas_limit(block_env.gas_limit));
+
+    let execution_context = MegaBlockExecutionCtx::new(
+        parent_hash,
+        attrs.payload_attributes.parent_beacon_block_root,
+        Default::default(),
+        block_limits,
+    );
+    let executor = executor_factory.create_executor(&mut state, execution_context, evm_env);
+    execute_kona_transactions(executor, attrs)?;
+
+    state.merge_transitions(BundleRetention::PlainState);
+    Ok(state.take_bundle().state)
+}
+
+/// Replays one block through Kona, then locally regenerates the bundle-state artifacts.
+#[allow(clippy::too_many_arguments)]
+pub fn replay_block_with_kona<B: BlockInput>(
+    block: &B,
+    parent_header: &Header,
+    salt_witness: &SaltWitness,
+    mpt_witness: &MptWitness,
+    contracts: &HashMap<B256, Bytecode>,
+    rollup_config: &RollupConfig,
+) -> Result<(HashMap<Address, BundleAccount>, BlockExecutionOutput), KonaReplayError> {
+    let output = execute_payload_with_kona(
+        block,
+        parent_header,
+        salt_witness,
+        mpt_witness,
+        contracts,
+        rollup_config,
+    )?;
+    let accounts = generate_bundle_state(
+        block,
+        parent_header,
+        salt_witness.clone(),
+        contracts,
+        rollup_config,
+    )?;
+    let (state_reads, state_writes) = bundle_state_access_counts(&accounts);
+
+    Ok((
+        accounts,
+        BlockExecutionOutput {
+            receipts_root: output.receipts_root,
+            logs_bloom: output.logs_bloom,
+            gas_used: output.gas_used,
+            state_reads,
+            state_writes,
+        },
+    ))
+}
+
+/// Validates a block through Kona and then verifies the locally generated bundle-state artifacts.
+#[allow(clippy::too_many_arguments)]
+pub fn validate_block<B: BlockInput>(
+    _chain_spec: &ChainSpec,
+    block: &B,
+    parent_header: &Header,
+    salt_witness: SaltWitness,
+    mpt_witness: MptWitness,
+    contracts: &HashMap<B256, Bytecode>,
+    rollup_config: &RollupConfig,
+    #[cfg(feature = "std")] _writer: Option<Box<dyn Write>>,
+) -> Result<ValidationStats, KonaReplayError> {
+    // A block carrying only transaction hashes can't be replayed — fail fast before paying
+    // the witness proof verification. `replay_block_with_kona` re-checks for direct callers.
+    if !block.is_complete() {
+        return Err(KonaReplayError::BlockIncomplete);
+    }
+    let header = block.consensus_header();
+
+    // Verify witness proof against the current state root
+    #[cfg(feature = "std")]
+    let start = Instant::now();
+    let witness = Witness::from(salt_witness.clone());
+    witness.verify().map_err(ValidationError::WitnessVerificationFailed)?;
+    #[cfg(feature = "std")]
+    let witness_verification_time = start.elapsed().as_secs_f64();
+    #[cfg(not(feature = "std"))]
+    let witness_verification_time = 0.0_f64; // no_std: timing unavailable
+
+    // Replay block transactions
+    let (accounts, output) = replay_block_with_kona(
+        block,
+        parent_header,
+        &salt_witness,
+        &mpt_witness,
+        contracts,
+        rollup_config,
+    )?;
+    #[cfg(feature = "std")]
+    let block_replay_time = start.elapsed().as_secs_f64() - witness_verification_time;
+    #[cfg(not(feature = "std"))]
+    let block_replay_time = 0.0_f64; // no_std: timing unavailable
+
+    // Extract and hash storage updates (only changed values)
+    let withdrawal_storage: B256Map<U256> = accounts
+        .get(&ADDRESS_L2_TO_L1_MESSAGE_PASSER)
+        .map(|a| {
+            a.storage
+                .iter()
+                .filter(|(_, v)| v.previous_or_original_value != v.present_value)
+                .map(|(&slot, v)| (keccak256(B256::from(slot)), v.present_value))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    // Flatten Revm's BundleAccount format into plain key-value pairs
+    let mut kv_updates: BTreeMap<Vec<u8>, Option<Vec<u8>>> = BTreeMap::new();
+    for (address, bundle_account) in accounts {
+        if bundle_account.info != bundle_account.original_info {
+            // Process account changes
+            let account = bundle_account.info.map(|info| Account {
+                nonce: info.nonce,
+                balance: info.balance,
+                codehash: (info.code_hash != KECCAK_EMPTY).then_some(info.code_hash),
+            });
+
+            let account_key = PlainKey::Account(address).encode();
+            let account_value = account.and_then(|account| {
+                (!account.is_empty()).then(|| PlainValue::Account(account).encode())
+            });
+            kv_updates.insert(account_key, account_value);
+        }
+
+        // Process storage changes
+        for (slot, value) in bundle_account.storage {
+            if value.previous_or_original_value != value.present_value {
+                let storage_key =
+                    PlainKey::Storage(address, B256::new(slot.to_be_bytes())).encode();
+                let storage_value = (!value.present_value.is_zero())
+                    .then(|| PlainValue::Storage(value.present_value).encode());
+                kv_updates.insert(storage_key, storage_value);
+            }
+        }
+    }
+
+    // Update the SALT state: Apply updates first, then inserts/deletes in deterministic key
+    // order (same as Witness::create). This ordering is critical: inserts/deletes may trigger
+    // key displacement or bucket expansion, invalidating the witness's direct lookup table.
+    let mut witness_state = EphemeralSaltState::new(&witness);
+    let mut state_updates = StateUpdates::default();
+    let mut inserts_or_deletes = BTreeMap::new();
+
+    for (plain_key, opt_plain_value) in kv_updates {
+        if let (Ok(Some((salt_key, old_value))), Some(new_value)) =
+            (witness_state.find(&plain_key), &opt_plain_value)
+        {
+            // Update operation: key exists and new value is not None
+            witness_state.update_value(
+                &mut state_updates,
+                salt_key,
+                Some(old_value),
+                Some(SaltValue::new(&plain_key, new_value)),
+            );
+        } else {
+            inserts_or_deletes.insert(plain_key, opt_plain_value);
+        }
+    }
+    state_updates.merge(
+        witness_state
+            .update_fin(&inserts_or_deletes)
+            .map_err(ValidationError::StateUpdateFailed)?,
+    );
+
+    // Update the state root
+    let (state_root, _) = StateRoot::new(&witness)
+        .update_fin(&state_updates)
+        .map_err(ValidationError::TrieUpdateFailed)?;
+    #[cfg(feature = "std")]
+    let salt_update_time =
+        start.elapsed().as_secs_f64() - witness_verification_time - block_replay_time;
+    #[cfg(not(feature = "std"))]
+    let salt_update_time = 0.0_f64; // no_std: timing unavailable
+
+    // Check if computed withdrawals root matches the claimed one
+    mpt_witness
+        .verify(header, withdrawal_storage)
+        .map_err(ValidationError::WithdrawalValidationFailed)?;
+
+    // Verify receipts root matches the block header
+    if output.receipts_root != header.receipts_root {
+        return Err(ValidationError::ReceiptsRootMismatch {
+            actual: output.receipts_root,
+            claimed: header.receipts_root,
+        }
+        .into());
+    }
+
+    // Verify logs bloom matches the block header
+    if output.logs_bloom != header.logs_bloom {
+        return Err(ValidationError::LogsBloomMismatch {
+            actual: Box::new(output.logs_bloom),
+            claimed: Box::new(header.logs_bloom),
+        }
+        .into());
+    }
+
+    // Verify gas used matches the block header
+    if output.gas_used != header.gas_used {
+        return Err(ValidationError::GasUsedMismatch {
+            actual: output.gas_used,
+            claimed: header.gas_used,
+        }
+        .into());
+    }
+
+    // Check if computed state root matches claimed state root
+    let state_root = B256::from(state_root);
+    if state_root != header.state_root {
+        return Err(ValidationError::StateRootMismatch {
+            actual: state_root,
+            claimed: header.state_root,
+        }
+        .into());
+    }
+
+    Ok(ValidationStats {
+        state_reads: output.state_reads,
+        state_writes: output.state_writes,
+        witness_verification_time,
+        block_replay_time,
+        salt_update_time,
+    })
+}
+
+/// Loads the registered MegaETH rollup config for the L2 chain id.
+pub fn rollup_config_for_chain_id(chain_id: u64) -> Result<RollupConfig, KonaReplayError> {
+    kona_registry::ROLLUP_CONFIGS
+        .get(&chain_id)
+        .cloned()
+        .ok_or(KonaReplayError::MissingRollupConfig(chain_id))
+}
+
+fn bundle_state_access_counts(accounts: &HashMap<Address, BundleAccount>) -> (usize, usize) {
+    let total_accessed: usize = accounts.values().map(|a| 1 + a.storage.len()).sum();
+
+    let state_writes: usize = accounts
+        .values()
+        .map(|a| {
+            (a.info != a.original_info) as usize +
+                a.storage
+                    .values()
+                    .filter(|s| s.previous_or_original_value != s.present_value)
+                    .count()
+        })
+        .sum();
+
+    (total_accessed.saturating_sub(state_writes), state_writes)
+}
+
+fn mega_chain_spec(config: &RollupConfig) -> MegaChainSpec {
+    let h = &config.hardforks;
+    let sequencer_registry_config = match (h.rex5_initial_sequencer, h.rex5_initial_admin) {
+        (Some(rex5_initial_sequencer), Some(rex5_initial_admin)) => {
+            Some(SequencerRegistryConfig { rex5_initial_sequencer, rex5_initial_admin })
+        }
+        _ => None,
+    };
+
+    MegaChainSpec {
+        isthmus_time: h.isthmus_time,
+        mini_rex_time: h.mini_rex_time,
+        mini_rex_1_time: h.mini_rex_1_time,
+        mini_rex_2_time: h.mini_rex_2_time,
+        rex_time: h.rex_time,
+        rex_1_time: h.rex_1_time,
+        rex_2_time: h.rex_2_time,
+        rex_3_time: h.rex_3_time,
+        rex_4_time: h.rex_4_time,
+        rex_5_time: h.rex_5_time,
+        sequencer_registry_config,
+    }
+}
+
+fn kona_evm_env(
+    header: &Header,
+    parent_header: &Header,
+    attrs: &OpPayloadAttributes,
+    rollup_config: &RollupConfig,
+) -> Result<EvmEnv<MegaSpecId>, KonaReplayError> {
+    let (base_fee_params, config_min_base_fee) =
+        active_base_fee_params(rollup_config, parent_header, attrs.payload_attributes.timestamp)?;
+    let min_base_fee = attrs.min_base_fee.unwrap_or(config_min_base_fee);
+    let spec_id = rollup_config.spec_id(attrs.payload_attributes.timestamp);
+    let blob_excess_gas_and_price = header.excess_blob_gas.map(|excess| {
+        let fraction = if spec_id.is_enabled_in(mega_evm_kona::op_revm::OpSpecId::ISTHMUS) {
+            BLOB_BASE_FEE_UPDATE_FRACTION_PRAGUE
+        } else {
+            BLOB_BASE_FEE_UPDATE_FRACTION_CANCUN
+        };
+        BlobExcessGasAndPrice::new(excess, fraction)
+    });
+    let next_block_base_fee =
+        next_block_base_fee(rollup_config, base_fee_params, parent_header, min_base_fee)
+            .unwrap_or_default();
+
+    let block_env = BlockEnv {
+        number: U256::from(parent_header.number + 1),
+        beneficiary: attrs.payload_attributes.suggested_fee_recipient,
+        timestamp: U256::from(attrs.payload_attributes.timestamp),
+        gas_limit: attrs.gas_limit.ok_or(kona_executor::ExecutorError::MissingGasLimit)?,
+        basefee: next_block_base_fee,
+        prevrandao: Some(attrs.payload_attributes.prev_randao),
+        blob_excess_gas_and_price,
+        ..Default::default()
+    };
+    let cfg_env = CfgEnv::new()
+        .with_chain_id(rollup_config.l2_chain_id.id())
+        .with_spec(mega_chain_spec(rollup_config).spec_id(attrs.payload_attributes.timestamp));
+    Ok(EvmEnv::new(cfg_env, block_env))
+}
+
+fn active_base_fee_params(
+    config: &RollupConfig,
+    parent_header: &Header,
+    payload_timestamp: u64,
+) -> Result<(BaseFeeParams, u64), KonaReplayError> {
+    if config.is_jovian_active(parent_header.timestamp) {
+        return decode_jovian_eip_1559_params_block_header(parent_header);
+    }
+    if config.is_holocene_active(parent_header.timestamp) {
+        return decode_holocene_eip_1559_params_block_header(parent_header)
+            .map(|base_fee_params| (base_fee_params, 0));
+    }
+    if config.is_canyon_active(payload_timestamp) {
+        return Ok((config.chain_op_config.post_canyon_params(), 0));
+    }
+    Ok((config.chain_op_config.pre_canyon_params(), 0))
+}
+
+fn decode_holocene_eip_1559_params_block_header(
+    header: &Header,
+) -> Result<BaseFeeParams, KonaReplayError> {
+    let (elasticity, denominator) = decode_holocene_extra_data(header.extra_data())
+        .map_err(|e| KonaReplayError::InvalidExtraData(e.to_string()))?;
+    if denominator == 0 {
+        return Err(KonaReplayError::InvalidExtraData(
+            "EIP-1559 denominator cannot be zero".to_string(),
+        ));
+    }
+    Ok(BaseFeeParams {
+        elasticity_multiplier: u128::from(elasticity),
+        max_change_denominator: u128::from(denominator),
+    })
+}
+
+fn decode_jovian_eip_1559_params_block_header(
+    header: &Header,
+) -> Result<(BaseFeeParams, u64), KonaReplayError> {
+    let extra_data = header.extra_data();
+    if extra_data.len() != 17 {
+        return Err(KonaReplayError::InvalidExtraData(
+            "Jovian extra data is not the correct length".to_string(),
+        ));
+    }
+    if extra_data[0] != 1 {
+        return Err(KonaReplayError::InvalidExtraData(format!(
+            "Invalid Jovian EIP-1559 version byte: {}",
+            extra_data[0]
+        )));
+    }
+    let denominator =
+        u32::from_be_bytes([extra_data[1], extra_data[2], extra_data[3], extra_data[4]]);
+    let elasticity =
+        u32::from_be_bytes([extra_data[5], extra_data[6], extra_data[7], extra_data[8]]);
+    let min_base_fee = u64::from_be_bytes([
+        extra_data[9],
+        extra_data[10],
+        extra_data[11],
+        extra_data[12],
+        extra_data[13],
+        extra_data[14],
+        extra_data[15],
+        extra_data[16],
+    ]);
+    if denominator == 0 {
+        return Err(KonaReplayError::InvalidExtraData(
+            "EIP-1559 denominator cannot be zero".to_string(),
+        ));
+    }
+    Ok((
+        BaseFeeParams {
+            elasticity_multiplier: u128::from(elasticity),
+            max_change_denominator: u128::from(denominator),
+        },
+        min_base_fee,
+    ))
+}
+
+fn next_block_base_fee(
+    config: &RollupConfig,
+    params: BaseFeeParams,
+    parent: &Header,
+    min_base_fee: u64,
+) -> Option<u64> {
+    let next = if !config.is_jovian_active(parent.timestamp()) {
+        parent.next_block_base_fee(params)?
+    } else {
+        let gas_used = parent.blob_gas_used().unwrap_or_default().max(parent.gas_used());
+        calc_next_block_base_fee(
+            gas_used,
+            parent.gas_limit(),
+            parent.base_fee_per_gas().unwrap_or_default(),
+            params,
+        )
+    };
+
+    Some(next.max(min_base_fee))
+}
+
+fn execute_kona_transactions<E>(
+    executor: E,
+    attrs: OpPayloadAttributes,
+) -> Result<(), KonaReplayError>
+where
+    E: BlockExecutor<Transaction = MegaTxEnvelope>,
+{
+    let transactions: Vec<WithEncoded<Recovered<MegaTxEnvelope>>> = attrs
+        .recovered_transactions_with_encoded()
+        .map(|result| {
+            result.map(|with_encoded| {
+                let raw_bytes: Bytes = with_encoded.encoded_bytes().clone();
+                let signer: Address = with_encoded.1.signer();
+                let envelope = MegaTxEnvelope::decode_2718(&mut raw_bytes.as_ref())
+                    .expect("transaction was already decoded successfully");
+                WithEncoded::new(raw_bytes, Recovered::new_unchecked(envelope, signer))
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    executor.execute_block(transactions.iter()).map_err(KonaReplayError::BlockReplayFailed)?;
+    Ok(())
+}
+
+fn output_from_outcome(outcome: BlockBuildingOutcome) -> KonaReplayOutput {
+    let logs_bloom = outcome
+        .execution_result
+        .receipts
+        .iter()
+        .fold(Bloom::ZERO, |acc, receipt| acc | receipt.bloom());
+    let receipts_root = calculate_receipt_root(&outcome.execution_result.receipts);
+    KonaReplayOutput {
+        block_hash: outcome.header.hash(),
+        state_root: outcome.header.state_root,
+        receipts_root,
+        logs_bloom,
+        gas_used: outcome.execution_result.gas_used,
+        withdrawals_root: outcome.header.withdrawals_root,
+        receipt_count: outcome.execution_result.receipts.len(),
+    }
+}
+
+fn payload_attrs_from_block<B: BlockInput>(
+    block: &B,
+    rollup_config: &RollupConfig,
+) -> Result<OpPayloadAttributes, KonaReplayError> {
+    let header = block.consensus_header();
+    let transactions = block
+        .txs_recovered()
+        .map(|recovered| {
+            let mut bytes = Vec::new();
+            recovered.inner().encode_2718(&mut bytes);
+            Bytes::from(bytes)
+        })
+        .collect::<Vec<_>>();
+
+    Ok(OpPayloadAttributes {
+        payload_attributes: PayloadAttributes {
+            timestamp: header.timestamp,
+            prev_randao: header.mix_hash,
+            suggested_fee_recipient: header.beneficiary,
+            withdrawals: Default::default(),
+            parent_beacon_block_root: header.parent_beacon_block_root,
+        },
+        transactions: Some(transactions),
+        no_tx_pool: None,
+        gas_limit: Some(header.gas_limit),
+        eip_1559_params: Some(holocene_eip_1559_params_from_extra_data(
+            &header.extra_data,
+            rollup_config,
+        )),
+        min_base_fee: Some(1_000_000),
+    })
+}
+
+fn holocene_eip_1559_params_from_extra_data(
+    extra_data: &[u8],
+    rollup_config: &RollupConfig,
+) -> B64 {
+    let default = rollup_config.chain_op_config.post_canyon_params();
+    let (elasticity, denominator) = decode_holocene_extra_data(extra_data)
+        .unwrap_or((default.elasticity_multiplier as u32, default.max_change_denominator as u32));
+    let mut out = [0u8; 8];
+    out[..4].copy_from_slice(&denominator.to_be_bytes());
+    out[4..].copy_from_slice(&elasticity.to_be_bytes());
+    B64::from(out)
+}
+
+impl fmt::Display for KonaReplayOutput {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "hash={:?} state_root={:?} receipts_root={:?} gas_used={} receipts={}",
+            self.block_hash, self.state_root, self.receipts_root, self.gas_used, self.receipt_count
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use stateless_test_utils::{fixtures::TestFixtures, logging::init_test_logging};
+
+    use super::*;
+
+    #[test]
+    fn kona_validator_requires_parent_header() {
+        let fx = TestFixtures::mainnet_shared();
+        let chain_spec = ChainSpec::from_genesis(fx.load_genesis().unwrap());
+        let validator = KonaValidator::new(&chain_spec).unwrap();
+        let (_, hash) = *fx.paired_blocks().first().expect("paired mainnet fixtures");
+
+        let err = validator
+            .validate_block(ValidationInput::new(
+                &fx.blocks[&hash],
+                fx.salt_witnesses[&hash].clone(),
+                fx.mpt_witness(&hash),
+                &fx.contracts,
+            ))
+            .unwrap_err();
+        assert!(matches!(err, KonaReplayError::MissingParentHeader), "{err:?}");
+    }
+
+    #[test]
+    fn kona_validator_replays_mainnet_fixture() {
+        let _logging = init_test_logging("stateless_core");
+        let fx = TestFixtures::mainnet_shared();
+        let chain_spec = ChainSpec::from_genesis(fx.load_genesis().unwrap());
+        let validator = KonaValidator::new(&chain_spec).unwrap();
+        let (number, hash) = *fx.paired_blocks().first().expect("paired mainnet fixtures");
+        let block = &fx.blocks[&hash];
+        let parent = &fx
+            .blocks
+            .get(&block.header.parent_hash)
+            .unwrap_or_else(|| {
+                panic!(
+                    "parent block {} missing for fixture block {number} ({hash})",
+                    block.header.parent_hash
+                )
+            })
+            .header
+            .inner;
+
+        let input = ValidationInput::new(
+            block,
+            fx.salt_witnesses[&hash].clone(),
+            fx.mpt_witness(&hash),
+            &fx.contracts,
+        )
+        .with_parent_header(parent);
+
+        validator
+            .validate_block(input)
+            .unwrap_or_else(|e| panic!("Kona validation failed for {number} ({hash}): {e:?}"));
+    }
+}

--- a/crates/stateless-core/src/kona_replay.rs
+++ b/crates/stateless-core/src/kona_replay.rs
@@ -878,35 +878,39 @@ mod tests {
     }
 
     #[test]
-    fn kona_validator_replays_mainnet_fixture() {
+    fn kona_validator_validate_block_mainnet_fixtures() {
         let _logging = init_test_logging("stateless_core");
         let fx = TestFixtures::mainnet_shared();
         let chain_spec = ChainSpec::from_genesis(fx.load_genesis().unwrap());
         let validator = KonaValidator::new(&chain_spec).unwrap();
-        let (number, hash) = *fx.paired_blocks().first().expect("paired mainnet fixtures");
-        let block = &fx.blocks[&hash];
-        let parent = &fx
-            .blocks
-            .get(&block.header.parent_hash)
-            .unwrap_or_else(|| {
-                panic!(
-                    "parent block {} missing for fixture block {number} ({hash})",
-                    block.header.parent_hash
-                )
-            })
-            .header
-            .inner;
+        let paired = fx.paired_blocks();
+        assert!(!paired.is_empty(), "no paired mainnet fixtures in test_data/mainnet");
 
-        let input = ValidationInput::new(
-            block,
-            fx.salt_witnesses[&hash].clone(),
-            fx.mpt_witness(&hash),
-            &fx.contracts,
-        )
-        .with_parent_header(parent);
+        for (number, hash) in paired {
+            let block = &fx.blocks[&hash];
+            let parent = &fx
+                .blocks
+                .get(&block.header.parent_hash)
+                .unwrap_or_else(|| {
+                    panic!(
+                        "parent block {} missing for fixture block {number} ({hash})",
+                        block.header.parent_hash
+                    )
+                })
+                .header
+                .inner;
 
-        validator
-            .validate_block(input)
-            .unwrap_or_else(|e| panic!("Kona validation failed for {number} ({hash}): {e:?}"));
+            let input = ValidationInput::new(
+                block,
+                fx.salt_witnesses[&hash].clone(),
+                fx.mpt_witness(&hash),
+                &fx.contracts,
+            )
+            .with_parent_header(parent);
+
+            validator
+                .validate_block(input)
+                .unwrap_or_else(|e| panic!("Kona validation failed for {number} ({hash}): {e:?}"));
+        }
     }
 }

--- a/crates/stateless-core/src/lib.rs
+++ b/crates/stateless-core/src/lib.rs
@@ -37,6 +37,8 @@ pub use executor::{
     BlockInput, BlockValidator, MegaEvmValidator, ValidationError, ValidationInput,
     ValidationStats, replay_block, validate_block,
 };
+pub mod kona_replay;
+pub use kona_replay::{KonaReplayError, KonaValidator};
 #[cfg(feature = "std")]
 pub mod pipeline;
 #[cfg(feature = "std")]


### PR DESCRIPTION
Summary
- Add a `KonaValidator` backend and a `kona-validator` binary so the same stateless validator pipeline can validate blocks with either the MegaEVM or Kona execution backend.

Background
The validator pipeline already separates block fetching, contract caching, chain advancement, and reorg handling from per-block execution through the `BlockValidator` abstraction.
This branch uses that abstraction to add Kona replay as a second execution backend without duplicating the pipeline.
That gives us a dedicated binary for running and debugging the Kona validation path while keeping the existing MegaEVM validator behavior intact.

One important difference between the backends is that Kona replay needs the parent header to re-derive parts of the header / payload, while the MegaEVM backend reads the execution parameters from the current block header.
For that reason, this PR does not make parent headers mandatory for every validator path.
Instead, the fetcher has a `fetch_parent_header` switch that is enabled by `kona-validator` and left disabled by the default `stateless-validator` binary.

Approach
- Add the `kona_replay` module in `stateless-core` and export `KonaValidator`.
- Implement `BlockValidator` for `KonaValidator`, replaying through Kona and validating the derived block hash, state root, withdrawals root, receipts root, logs bloom, and gas used.
- Keep `ValidationInput::parent_header` optional for MegaEVM, while the Kona backend returns a backend error when it is missing.
- Add a `fetch_parent_header` switch to `ValidatorFetcher` so only the Kona path performs the extra parent-header RPC read.
- Generalize `ValidatorProcessor<V>` and `workers::run_with_signals<V>` over any `BlockValidator<Block<Transaction>>`, leaving production wiring to choose the backend.
- Keep `stateless-validator` wired to `MegaEvmValidator`, and add `kona-validator` wired to `KonaValidator` with the same CLI surface.
- Replace local `mega-kona` path dependencies with Git dependencies on `megaeth-labs/mega-kona` branch `clay/feat/regist_pnet_config`.

Tests
- `cargo test --package stateless-core --lib -- kona_replay::tests::kona_validator_validate_block_mainnet_fixtures --exact --nocapture`
- `cargo test --package stateless-validator --test integration -- kona_validator_binary_exposes_cli --exact --nocapture`
- `cargo test --package stateless-validator --test integration -- kona_fetcher_includes_parent_header --exact --nocapture`
- `cargo test -p stateless-validator integration_test_ --test integration`

