### PR TITLE
feat: fetch witnesses directly from R2 and rehome megaeth-witness-r2 as stateless-r2

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,14 +34,15 @@ The project uses nightly `2026-02-03` toolchain (edition 2024, rust-version 1.95
 
 ## Workspace Structure
 
-| Crate                  | Path                          | Purpose                                                                                    |
-| ---------------------- | ----------------------------- | ------------------------------------------------------------------------------------------ |
-| `stateless-core`       | `crates/stateless-core`       | Storage traits, pipeline, EVM execution, SALT witness handling, chain spec, error types    |
-| `stateless-db`         | `crates/stateless-db`         | redb-backed persistence: table definitions, read/write helpers, `ContractCache`            |
-| `stateless-common`     | `crates/stateless-common`     | RPC client, metrics/logging utilities, witness size estimation                             |
-| `stateless-test-utils` | `crates/stateless-test-utils` | Test fixtures (blocks, witnesses, contracts) and env-var lock for integration tests        |
-| `stateless-validator`  | `bin/stateless-validator`     | Main binary: chain sync, parallel validation workers (`app.rs` / `workers.rs` / `main.rs`) |
-| `debug-trace-server`   | `bin/debug-trace-server`      | Standalone RPC server for debug/trace methods                                              |
+| Crate                  | Path                          | Purpose                                                                                                                                                                                  |
+| ---------------------- | ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `stateless-core`       | `crates/stateless-core`       | Storage traits, pipeline, EVM execution, SALT witness handling, chain spec, error types                                                                                                  |
+| `stateless-db`         | `crates/stateless-db`         | redb-backed persistence: table definitions, read/write helpers, `ContractCache`                                                                                                          |
+| `stateless-common`     | `crates/stateless-common`     | RPC client, metrics/logging utilities, witness size estimation                                                                                                                           |
+| `stateless-test-utils` | `crates/stateless-test-utils` | Test fixtures (blocks, witnesses, contracts) and env-var lock for integration tests                                                                                                      |
+| `stateless-r2`         | `crates/stateless-r2`         | Shared R2 (S3) witness primitives: SigV4 signer, object-key layout, endpoint parsing, signed PUT; consumed by mega-reth's uploaders (write) and the validator's R2 witness source (read) |
+| `stateless-validator`  | `bin/stateless-validator`     | Main binary: chain sync, parallel validation workers (`app.rs` / `workers.rs` / `main.rs`)                                                                                               |
+| `debug-trace-server`   | `bin/debug-trace-server`      | Standalone RPC server for debug/trace methods                                                                                                                                            |
 
 Additional directories: `test_data/` (integration test fixtures including genesis config), `audits/` (security audit reports).
 
@@ -109,21 +110,21 @@ The server includes an HTTP response cache (`quick_cache`) for pre-serialized JS
 
 ### Key Source Files
 
-| File                                                                                           | Purpose                                                                  |
-| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
-| `crates/stateless-core/src/pipeline/{mod,config,traits,fetcher,divergence,advancer,worker}.rs` | Generic three-stage pipeline split by responsibility                     |
-| `crates/stateless-core/src/executor.rs`                                                        | Block validation and EVM replay (generic over the `BlockInput` projection) |
-| `crates/stateless-core/src/evm_database.rs`                                                    | WitnessDatabase implementing `revm::DatabaseRef`                         |
-| `crates/stateless-core/src/db.rs`                                                              | Shared storage traits (`ContractStore`, `ChainStore`) + `StoreError` / `StoreResult`                   |
-| `crates/stateless-core/src/withdrawals.rs`                                                     | Withdrawal validation and MPT witness handling                           |
-| `crates/stateless-db/src/{lib,tables,helpers,serialize,cache}.rs`                              | Shared redb tables, helpers, serialization, and `ContractCache`          |
-| `crates/stateless-common/src/rpc_client.rs`                                                    | RPC client for blocks, witnesses, and bytecode                           |
-| `crates/stateless-common/src/metrics.rs`                                                       | RpcMethod, RpcMetrics, RpcClientConfig                                   |
-| `bin/stateless-validator/src/{main,app,workers,chain_sync,validator_db,metrics}.rs`            | Thin entry, CLI/startup wiring, pipeline+reporter, fetcher/processor, DB |
-| `bin/debug-trace-server/src/chain_sync.rs`                                                     | TraceFetcher, TraceProcessor, TraceHooks                                 |
-| `bin/debug-trace-server/src/rpc_service.rs`                                                    | RPC method definitions and handlers                                      |
-| `bin/debug-trace-server/src/data_provider.rs`                                                  | Block data fetching with single-flight coalescing                        |
-| `bin/debug-trace-server/src/server_db.rs`                                                      | Defines + implements the bin-local `BlockStore` trait (backed by `stateless-db`)            |
+| File                                                                                           | Purpose                                                                              |
+| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| `crates/stateless-core/src/pipeline/{mod,config,traits,fetcher,divergence,advancer,worker}.rs` | Generic three-stage pipeline split by responsibility                                 |
+| `crates/stateless-core/src/executor.rs`                                                        | Block validation and EVM replay (generic over the `BlockInput` projection)           |
+| `crates/stateless-core/src/evm_database.rs`                                                    | WitnessDatabase implementing `revm::DatabaseRef`                                     |
+| `crates/stateless-core/src/db.rs`                                                              | Shared storage traits (`ContractStore`, `ChainStore`) + `StoreError` / `StoreResult` |
+| `crates/stateless-core/src/withdrawals.rs`                                                     | Withdrawal validation and MPT witness handling                                       |
+| `crates/stateless-db/src/{lib,tables,helpers,serialize,cache}.rs`                              | Shared redb tables, helpers, serialization, and `ContractCache`                      |
+| `crates/stateless-common/src/rpc_client.rs`                                                    | RPC client for blocks, witnesses, and bytecode                                       |
+| `crates/stateless-common/src/metrics.rs`                                                       | RpcMethod, RpcMetrics, RpcClientConfig                                               |
+| `bin/stateless-validator/src/{main,app,workers,chain_sync,validator_db,metrics}.rs`            | Thin entry, CLI/startup wiring, pipeline+reporter, fetcher/processor, DB             |
+| `bin/debug-trace-server/src/chain_sync.rs`                                                     | TraceFetcher, TraceProcessor, TraceHooks                                             |
+| `bin/debug-trace-server/src/rpc_service.rs`                                                    | RPC method definitions and handlers                                                  |
+| `bin/debug-trace-server/src/data_provider.rs`                                                  | Block data fetching with single-flight coalescing                                    |
+| `bin/debug-trace-server/src/server_db.rs`                                                      | Defines + implements the bin-local `BlockStore` trait (backed by `stateless-db`)     |
 
 ## Test Organization
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3379,6 +3379,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "megaeth-witness-r2"
+version = "2.1.0"
+source = "git+https://github.com/megaeth-labs/mega-reth.git?rev=c290c3e37f16b129ccaa290478e055857b4c6d01#c290c3e37f16b129ccaa290478e055857b4c6d01"
+dependencies = [
+ "bytes",
+ "chrono",
+ "hex",
+ "hmac",
+ "percent-encoding",
+ "reqwest 0.12.24",
+ "sha2 0.10.9",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5801,14 +5815,17 @@ dependencies = [
  "alloy-genesis",
  "alloy-primitives",
  "alloy-rpc-types-eth",
+ "chrono",
  "clap",
  "eyre",
  "jsonrpsee",
  "jsonrpsee-types",
+ "megaeth-witness-r2",
  "metrics",
  "metrics-exporter-prometheus",
  "op-alloy-rpc-types",
  "redb",
+ "reqwest 0.12.24",
  "revm",
  "salt",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5815,6 +5815,7 @@ dependencies = [
  "alloy-genesis",
  "alloy-primitives",
  "alloy-rpc-types-eth",
+ "bytes",
  "chrono",
  "clap",
  "eyre",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -376,7 +376,7 @@ dependencies = [
  "lru",
  "parking_lot",
  "pin-project",
- "reqwest 0.12.24",
+ "reqwest",
  "serde",
  "serde_json",
  "thiserror 2.0.17",
@@ -420,7 +420,7 @@ dependencies = [
  "alloy-transport-http",
  "futures",
  "pin-project",
- "reqwest 0.12.24",
+ "reqwest",
  "serde",
  "serde_json",
  "tokio",
@@ -620,7 +620,7 @@ checksum = "90aa6825760905898c106aba9c804b131816a15041523e80b6d4fe7af6380ada"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
- "reqwest 0.12.24",
+ "reqwest",
  "serde_json",
  "tower",
  "tracing",
@@ -1916,7 +1916,7 @@ dependencies = [
  "quick_cache",
  "rayon",
  "redb",
- "reqwest 0.13.2",
+ "reqwest",
  "revm",
  "revm-inspectors",
  "salt",
@@ -3379,20 +3379,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "megaeth-witness-r2"
-version = "2.1.0"
-source = "git+https://github.com/megaeth-labs/mega-reth.git?rev=c290c3e37f16b129ccaa290478e055857b4c6d01#c290c3e37f16b129ccaa290478e055857b4c6d01"
-dependencies = [
- "bytes",
- "chrono",
- "hex",
- "hmac",
- "percent-encoding",
- "reqwest 0.12.24",
- "sha2 0.10.9",
-]
-
-[[package]]
 name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4473,6 +4459,7 @@ dependencies = [
  "async-compression",
  "base64",
  "bytes",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "http",
@@ -4503,39 +4490,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "webpki-roots",
-]
-
-[[package]]
-name = "reqwest"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
-dependencies = [
- "base64",
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-util",
- "js-sys",
- "log",
- "percent-encoding",
- "pin-project-lite",
- "serde",
- "serde_json",
- "sync_wrapper",
- "tokio",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
 ]
 
 [[package]]
@@ -5715,7 +5669,7 @@ dependencies = [
  "kanal",
  "op-alloy-network",
  "op-alloy-rpc-types",
- "reqwest 0.12.24",
+ "reqwest",
  "revm",
  "rolling-file",
  "salt",
@@ -5791,6 +5745,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "stateless-r2"
+version = "2.0.14"
+dependencies = [
+ "bytes",
+ "chrono",
+ "hex",
+ "hmac",
+ "percent-encoding",
+ "reqwest",
+ "sha2 0.10.9",
+]
+
+[[package]]
 name = "stateless-test-utils"
 version = "2.0.14"
 dependencies = [
@@ -5821,18 +5788,18 @@ dependencies = [
  "eyre",
  "jsonrpsee",
  "jsonrpsee-types",
- "megaeth-witness-r2",
  "metrics",
  "metrics-exporter-prometheus",
  "op-alloy-rpc-types",
  "redb",
- "reqwest 0.12.24",
+ "reqwest",
  "revm",
  "salt",
  "serde_json",
  "stateless-common",
  "stateless-core",
  "stateless-db",
+ "stateless-r2",
  "stateless-test-utils",
  "tempfile",
  "thiserror 2.0.17",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5786,6 +5786,7 @@ dependencies = [
  "chrono",
  "clap",
  "eyre",
+ "fastrand",
  "jsonrpsee",
  "jsonrpsee-types",
  "metrics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/stateless-common",
     "crates/stateless-core",
     "crates/stateless-db",
+    "crates/stateless-r2",
     "crates/stateless-test-utils",
 ]
 resolver = "2"
@@ -62,6 +63,7 @@ revm-inspectors = { version = "0.27.3", features = ["std", "js-tracer"], default
 base64 = { version = "0.22", default-features = false }
 bincode = { version = "2.0", features = ["serde", "alloc"], default-features = false }
 bytes = "1.11"
+chrono = { version = "0.4", default-features = false }
 clap = { version = "4.6", features = ["derive", "env", "std"], default-features = false }
 dashmap = { version = "6.1", default-features = false }
 dotenvy = "0.15"
@@ -70,6 +72,8 @@ eyre = { version = "0.6", features = ["auto-install"], default-features = false 
 fastrand = { version = "2.4", default-features = false }
 futures = { version = "0.3", default-features = false }
 hashbrown = { version = "0.16", default-features = false }
+hex = { version = "0.4", default-features = false }
+hmac = { version = "0.12", default-features = false }
 http = "1.4"
 http-body = "1.0"
 http-body-util = "0.1"
@@ -82,15 +86,17 @@ metrics = "0.24"
 metrics-derive = "0.1"
 metrics-exporter-prometheus = { version = "0.18", features = ["http-listener"], default-features = false }
 num_cpus = "1.17"
+percent-encoding = { version = "2.3", default-features = false }
 pin-project-lite = "0.2"
 quick_cache = { version = "0.6", default-features = false }
 rayon = "1.11"
 redb = "4.0"
-reqwest = { version = "0.13", features = ["json", "blocking"], default-features = false }
+reqwest = { version = "0.12", default-features = false }
 rolling-file = "0.2"
 rustc-hash = { version = "2.1", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
+sha2 = { version = "0.10", default-features = false }
 tempfile = { version = "3.27", default-features = false }
 thiserror = { version = "2.0", default-features = false }
 tokio = { version = "1.51", features = ["rt-multi-thread", "signal"], default-features = false }

--- a/README.md
+++ b/README.md
@@ -68,10 +68,14 @@ cargo run --release --bin stateless-validator -- \
 - `--witness-endpoint`: MegaETH JSON-RPC API endpoint URL(s) to retrieve witness data.
   Multiple endpoints can be provided via repeated flags or as a comma-separated list (tried in order on failure).
   The env var `STATELESS_VALIDATOR_WITNESS_ENDPOINT` accepts the same comma-separated form (e.g. `http://a:8545,http://b:8545`).
+  Required with `--witness-source rpc` (the default); ignored with `--witness-source r2`.
 
 **Optional Arguments:**
 - `--genesis-file`: Path to genesis JSON file containing hardfork activation configuration (required on first run, stored in database for subsequent runs)
 - `--start-block`: Trusted block hash to initialize validation from (required for first-time setup)
+- `--end-block`: Inclusive end block; validate up to this height, then stop cleanly (useful to slice a fixed range across multiple servers)
+- `--witness-source`: Where to fetch witnesses from: `rpc` (default) or `r2` (straight from the R2 bucket over the S3 API)
+- `--r2-endpoint`, `--r2-bucket`, `--r2-access-key-id`, `--r2-secret-access-key`: R2 connection settings, all required with `--witness-source r2` (prefer the env var for the secret)
 - `--report-validation-endpoint`: RPC endpoint URL for reporting validated blocks via `mega_setValidatedBlocks` (disabled if not provided)
 - `--metrics-enabled`: Enable Prometheus metrics endpoint (disabled by default)
 - `--metrics-port`: Port for Prometheus metrics HTTP endpoint (default: 9090)
@@ -103,6 +107,9 @@ Each command-line flag has an equivalent environment variable:
 - `STATELESS_VALIDATOR_WITNESS_ENDPOINT` → `--witness-endpoint`
 - `STATELESS_VALIDATOR_GENESIS_FILE` → `--genesis-file`
 - `STATELESS_VALIDATOR_START_BLOCK` → `--start-block`
+- `STATELESS_VALIDATOR_END_BLOCK` → `--end-block`
+- `STATELESS_VALIDATOR_WITNESS_SOURCE` → `--witness-source`
+- `STATELESS_VALIDATOR_R2_ENDPOINT` / `_R2_BUCKET` / `_R2_ACCESS_KEY_ID` / `_R2_SECRET_ACCESS_KEY` → `--r2-*`
 - `STATELESS_VALIDATOR_REPORT_VALIDATION_ENDPOINT` → `--report-validation-endpoint`
 - `STATELESS_VALIDATOR_METRICS_ENABLED` → `--metrics-enabled` (set to `true` to enable)
 - `STATELESS_VALIDATOR_METRICS_PORT` → `--metrics-port`

--- a/README.md
+++ b/README.md
@@ -27,16 +27,17 @@ The stateless approach eliminates the need for validators to run on high-end har
 
 ## Project Structure
 
-The workspace contains two binaries and four library crates:
+The workspace contains two binaries and five library crates:
 
-| Crate                  | Path                          | Purpose                                                                             |
-| ---------------------- | ----------------------------- | ----------------------------------------------------------------------------------- |
-| `stateless-core`       | `crates/stateless-core`       | Core validation logic, abstract storage traits, generic pipeline, EVM execution     |
-| `stateless-db`         | `crates/stateless-db`         | redb-backed persistence: table definitions, read/write helpers, bounded `ContractCache` |
-| `stateless-common`     | `crates/stateless-common`     | Shared utilities: RPC client, logging, metrics                                      |
-| `stateless-test-utils` | `crates/stateless-test-utils` | Test fixtures (blocks, witnesses, contracts) and env-var lock for integration tests |
-| `stateless-validator`  | `bin/stateless-validator`     | Main binary: chain sync, parallel validation workers                                |
-| `debug-trace-server`   | `bin/debug-trace-server`      | Standalone RPC server for debug/trace methods                                       |
+| Crate                  | Path                          | Purpose                                                                                                                                                                              |
+| ---------------------- | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `stateless-core`       | `crates/stateless-core`       | Core validation logic, abstract storage traits, generic pipeline, EVM execution                                                                                                      |
+| `stateless-db`         | `crates/stateless-db`         | redb-backed persistence: table definitions, read/write helpers, bounded `ContractCache`                                                                                              |
+| `stateless-common`     | `crates/stateless-common`     | Shared utilities: RPC client, logging, metrics                                                                                                                                       |
+| `stateless-test-utils` | `crates/stateless-test-utils` | Test fixtures (blocks, witnesses, contracts) and env-var lock for integration tests                                                                                                  |
+| `stateless-r2`         | `crates/stateless-r2`         | Shared R2 (S3) witness primitives: SigV4 signer, object-key layout, endpoint parsing, signed PUT; consumed by mega-reth's witness uploaders (write) and this repo's validator (read) |
+| `stateless-validator`  | `bin/stateless-validator`     | Main binary: chain sync, parallel validation workers                                                                                                                                 |
+| `debug-trace-server`   | `bin/debug-trace-server`      | Standalone RPC server for debug/trace methods                                                                                                                                        |
 
 Additional directories: `test_data/` (integration test fixtures including genesis config), `audits/` (security audit reports).
 
@@ -197,23 +198,23 @@ The pipeline is configured via `PipelineConfig` and customized through trait imp
 
 ### Key Source Files
 
-| File                                                                                           | Purpose                                                                             |
-| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
-| `crates/stateless-core/src/pipeline/{mod,config,traits,fetcher,divergence,advancer,worker}.rs` | Generic three-stage pipeline split by responsibility                                |
-| `crates/stateless-core/src/executor.rs`                                                        | Block validation and EVM replay                                                     |
-| `crates/stateless-core/src/db.rs`                                                              | Shared storage traits: `ChainStore`, `ContractStore`, `StoreError` (scenario stores live in their binaries)  |
-| `crates/stateless-core/src/evm_database.rs`                                                    | `WitnessDatabase` implementing `revm::DatabaseRef`                                  |
-| `crates/stateless-core/src/withdrawals.rs`                                                     | Withdrawal validation and MPT witness handling                                      |
-| `crates/stateless-db/src/{lib,tables,helpers,serialize,cache}.rs`                              | Shared redb tables, helpers, serialization, and bounded `ContractCache`             |
-| `crates/stateless-common/src/rpc_client.rs`                                                    | `RpcClient`: multi-endpoint HTTP client for blocks, witnesses, and bytecode         |
-| `crates/stateless-common/src/metrics.rs`                                                       | `RpcMethod`, `RpcMetrics`, `RpcClientConfig`                                        |
-| `crates/stateless-common/src/witness_size.rs`                                                  | `WitnessSizeBreakdown` + `estimate_witness_size` for RPC and trace-server metrics   |
-| `crates/stateless-test-utils/src/fixtures.rs`                                                  | `TestFixtures` loader (blocks, SALT/MPT witnesses, contracts, genesis)              |
-| `bin/stateless-validator/src/{main,app,workers,chain_sync,validator_db,metrics}.rs`            | Thin entry, CLI/startup wiring, pipeline+reporter, fetcher/processor, DB            |
-| `bin/debug-trace-server/src/chain_sync.rs`                                                     | `TraceFetcher`, `TraceProcessor`, `TraceHooks`                                      |
-| `bin/debug-trace-server/src/rpc_service.rs`                                                    | RPC method definitions and handlers                                                 |
-| `bin/debug-trace-server/src/data_provider.rs`                                                  | Block data fetching with single-flight coalescing                                   |
-| `bin/debug-trace-server/src/server_db.rs`                                                      | Defines + implements the bin-local `BlockStore` trait, backed by `stateless-db`     |
+| File                                                                                           | Purpose                                                                                                     |
+| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `crates/stateless-core/src/pipeline/{mod,config,traits,fetcher,divergence,advancer,worker}.rs` | Generic three-stage pipeline split by responsibility                                                        |
+| `crates/stateless-core/src/executor.rs`                                                        | Block validation and EVM replay                                                                             |
+| `crates/stateless-core/src/db.rs`                                                              | Shared storage traits: `ChainStore`, `ContractStore`, `StoreError` (scenario stores live in their binaries) |
+| `crates/stateless-core/src/evm_database.rs`                                                    | `WitnessDatabase` implementing `revm::DatabaseRef`                                                          |
+| `crates/stateless-core/src/withdrawals.rs`                                                     | Withdrawal validation and MPT witness handling                                                              |
+| `crates/stateless-db/src/{lib,tables,helpers,serialize,cache}.rs`                              | Shared redb tables, helpers, serialization, and bounded `ContractCache`                                     |
+| `crates/stateless-common/src/rpc_client.rs`                                                    | `RpcClient`: multi-endpoint HTTP client for blocks, witnesses, and bytecode                                 |
+| `crates/stateless-common/src/metrics.rs`                                                       | `RpcMethod`, `RpcMetrics`, `RpcClientConfig`                                                                |
+| `crates/stateless-common/src/witness_size.rs`                                                  | `WitnessSizeBreakdown` + `estimate_witness_size` for RPC and trace-server metrics                           |
+| `crates/stateless-test-utils/src/fixtures.rs`                                                  | `TestFixtures` loader (blocks, SALT/MPT witnesses, contracts, genesis)                                      |
+| `bin/stateless-validator/src/{main,app,workers,chain_sync,validator_db,metrics}.rs`            | Thin entry, CLI/startup wiring, pipeline+reporter, fetcher/processor, DB                                    |
+| `bin/debug-trace-server/src/chain_sync.rs`                                                     | `TraceFetcher`, `TraceProcessor`, `TraceHooks`                                                              |
+| `bin/debug-trace-server/src/rpc_service.rs`                                                    | RPC method definitions and handlers                                                                         |
+| `bin/debug-trace-server/src/data_provider.rs`                                                  | Block data fetching with single-flight coalescing                                                           |
+| `bin/debug-trace-server/src/server_db.rs`                                                      | Defines + implements the bin-local `BlockStore` trait, backed by `stateless-db`                             |
 
 ### Database
 

--- a/bin/debug-trace-server/Cargo.toml
+++ b/bin/debug-trace-server/Cargo.toml
@@ -69,7 +69,7 @@ dotenvy.workspace = true
 http-body-util.workspace = true
 
 # HTTP client for integration tests
-reqwest.workspace = true
+reqwest = { workspace = true, features = ["blocking", "json"] }
 tempfile.workspace = true
 
 # stateless

--- a/bin/stateless-validator/Cargo.toml
+++ b/bin/stateless-validator/Cargo.toml
@@ -18,11 +18,6 @@ alloy-primitives.workspace = true
 alloy-rpc-types-eth.workspace = true
 
 # mega
-# R2 witness-source validation reuses the authoritative object-key layout + SigV4 signer from the
-# witness generator/uploader crate, so the read path cannot drift from the write path. Leaf crate,
-# so no dependency cycle with mega-reth's git-tag dep on stateless-* (see the crate docs). Pinned to
-# a mega-reth develop rev so all four validation servers build reproducibly without a local checkout.
-megaeth-witness-r2 = { git = "https://github.com/megaeth-labs/mega-reth.git", rev = "c290c3e37f16b129ccaa290478e055857b4c6d01" }
 salt.workspace = true
 
 # op
@@ -35,18 +30,18 @@ revm = { workspace = true, features = ["serde"] }
 stateless-common = { path = "../../crates/stateless-common" }
 stateless-core = { path = "../../crates/stateless-core" }
 stateless-db = { path = "../../crates/stateless-db" }
+stateless-r2 = { path = "../../crates/stateless-r2" }
 
 # misc
 bytes.workspace = true
-chrono = { version = "0.4", default-features = false, features = ["clock"] }
+chrono = { workspace = true, features = ["clock"] }
 clap = { workspace = true, features = ["env"] }
 eyre.workspace = true
 metrics.workspace = true
 metrics-exporter-prometheus.workspace = true
 redb.workspace = true
-# Pinned to 0.12 (not the workspace 0.13) to unify with stateless-common / alloy-provider /
-# megaeth-witness-r2; rustls-tls gives the R2 witness client HTTPS without a system TLS backend.
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
+# rustls-tls gives the R2 witness client HTTPS without a system TLS backend.
+reqwest = { workspace = true, features = ["rustls-tls"] }
 serde_json.workspace = true
 thiserror.workspace = true
 tokio.workspace = true

--- a/bin/stateless-validator/Cargo.toml
+++ b/bin/stateless-validator/Cargo.toml
@@ -37,6 +37,7 @@ bytes.workspace = true
 chrono = { workspace = true, features = ["clock"] }
 clap = { workspace = true, features = ["env"] }
 eyre.workspace = true
+fastrand = { workspace = true, features = ["std"] }
 metrics.workspace = true
 metrics-exporter-prometheus.workspace = true
 redb.workspace = true

--- a/bin/stateless-validator/Cargo.toml
+++ b/bin/stateless-validator/Cargo.toml
@@ -18,12 +18,12 @@ alloy-primitives.workspace = true
 alloy-rpc-types-eth.workspace = true
 
 # mega
-salt.workspace = true
 # R2 witness-source validation reuses the authoritative object-key layout + SigV4 signer from the
 # witness generator/uploader crate, so the read path cannot drift from the write path. Leaf crate,
 # so no dependency cycle with mega-reth's git-tag dep on stateless-* (see the crate docs). Pinned to
 # a mega-reth develop rev so all four validation servers build reproducibly without a local checkout.
 megaeth-witness-r2 = { git = "https://github.com/megaeth-labs/mega-reth.git", rev = "c290c3e37f16b129ccaa290478e055857b4c6d01" }
+salt.workspace = true
 
 # op
 op-alloy-rpc-types.workspace = true
@@ -37,15 +37,16 @@ stateless-core = { path = "../../crates/stateless-core" }
 stateless-db = { path = "../../crates/stateless-db" }
 
 # misc
-chrono = { version = "0.4", features = ["clock"] }
+bytes.workspace = true
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
 clap = { workspace = true, features = ["env"] }
 eyre.workspace = true
-# Pinned to 0.12 (not the workspace 0.13) to unify with stateless-common / alloy-provider /
-# megaeth-witness-r2; rustls-tls gives the R2 witness client HTTPS without a system TLS backend.
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 metrics.workspace = true
 metrics-exporter-prometheus.workspace = true
 redb.workspace = true
+# Pinned to 0.12 (not the workspace 0.13) to unify with stateless-common / alloy-provider /
+# megaeth-witness-r2; rustls-tls gives the R2 witness client HTTPS without a system TLS backend.
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 serde_json.workspace = true
 thiserror.workspace = true
 tokio.workspace = true

--- a/bin/stateless-validator/Cargo.toml
+++ b/bin/stateless-validator/Cargo.toml
@@ -19,6 +19,11 @@ alloy-rpc-types-eth.workspace = true
 
 # mega
 salt.workspace = true
+# R2 witness-source validation reuses the authoritative object-key layout + SigV4 signer from the
+# witness generator/uploader crate, so the read path cannot drift from the write path. Leaf crate,
+# so no dependency cycle with mega-reth's git-tag dep on stateless-* (see the crate docs). Pinned to
+# a mega-reth develop rev so all four validation servers build reproducibly without a local checkout.
+megaeth-witness-r2 = { git = "https://github.com/megaeth-labs/mega-reth.git", rev = "c290c3e37f16b129ccaa290478e055857b4c6d01" }
 
 # op
 op-alloy-rpc-types.workspace = true
@@ -32,8 +37,12 @@ stateless-core = { path = "../../crates/stateless-core" }
 stateless-db = { path = "../../crates/stateless-db" }
 
 # misc
+chrono = { version = "0.4", features = ["clock"] }
 clap = { workspace = true, features = ["env"] }
 eyre.workspace = true
+# Pinned to 0.12 (not the workspace 0.13) to unify with stateless-common / alloy-provider /
+# megaeth-witness-r2; rustls-tls gives the R2 witness client HTTPS without a system TLS backend.
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 metrics.workspace = true
 metrics-exporter-prometheus.workspace = true
 redb.workspace = true

--- a/bin/stateless-validator/src/app.rs
+++ b/bin/stateless-validator/src/app.rs
@@ -5,14 +5,26 @@ use std::{path::PathBuf, sync::Arc, time::Duration};
 use alloy_genesis::Genesis;
 use alloy_primitives::BlockHash;
 use alloy_rpc_types_eth::BlockId;
-use clap::Parser;
+use clap::{Parser, ValueEnum};
 use eyre::Result;
 use stateless_common::{BackoffPolicy, RpcClient, RpcClientConfig, logging::LogArgs};
 use stateless_core::{ChainStore, ContractStore, chain_spec::ChainSpec, db::BlockMeta};
 use stateless_db::ContractCache;
 use tracing::info;
 
-use crate::{metrics, validator_db::ValidatorDB, workers};
+use crate::{metrics, r2_witness::R2WitnessClient, validator_db::ValidatorDB, workers};
+
+/// Where the validator sources witnesses from.
+#[derive(ValueEnum, Clone, Debug, PartialEq, Eq, Default)]
+#[clap(rename_all = "lowercase")]
+pub enum WitnessSource {
+    /// `mega_getBlockWitness` RPC (the production path; may fall back to KV upstream).
+    #[default]
+    Rpc,
+    /// Straight from the R2 bucket over the S3 API — bypasses RPC/KV to validate the migrated
+    /// archive end to end. Requires the `--r2-*` flags.
+    R2,
+}
 
 /// Database filename for the validator.
 pub const VALIDATOR_DB_FILENAME: &str = "validator.redb";
@@ -68,14 +80,43 @@ pub struct CommandLineArgs {
     /// One or more MegaETH JSON-RPC API endpoints for fetching witness data (tried in order).
     /// Accepts repeated flags (`--witness-endpoint a --witness-endpoint b`) or a comma-separated
     /// list (`--witness-endpoint a,b`, also via the env var).
+    ///
+    /// Required when `--witness-source rpc` (the default); ignored when `--witness-source r2`.
     #[clap(
         long,
         env = "STATELESS_VALIDATOR_WITNESS_ENDPOINT",
-        required = true,
         value_delimiter = ',',
         action = clap::ArgAction::Append,
     )]
     pub witness_endpoint: Vec<String>,
+
+    /// Where to source witnesses from: `rpc` (default) or `r2`. `r2` fetches each witness straight
+    /// from the R2 bucket over the S3 API (bypassing the RPC/KV path) to validate the migrated
+    /// archive end to end; it requires the `--r2-*` flags below.
+    #[clap(long, env = "STATELESS_VALIDATOR_WITNESS_SOURCE", value_enum, default_value_t = WitnessSource::Rpc)]
+    pub witness_source: WitnessSource,
+
+    /// R2 S3 endpoint origin, e.g. `https://<account>.r2.cloudflarestorage.com` (no bucket path).
+    /// Required when `--witness-source r2`.
+    #[clap(long, env = "STATELESS_VALIDATOR_R2_ENDPOINT")]
+    pub r2_endpoint: Option<String>,
+
+    /// R2 bucket holding the witnesses (e.g. `witness-mainnet`). Required when `--witness-source r2`.
+    #[clap(long, env = "STATELESS_VALIDATOR_R2_BUCKET")]
+    pub r2_bucket: Option<String>,
+
+    /// R2 access key id (Object Read). Required when `--witness-source r2`.
+    #[clap(long, env = "STATELESS_VALIDATOR_R2_ACCESS_KEY_ID")]
+    pub r2_access_key_id: Option<String>,
+
+    /// R2 secret access key. Required when `--witness-source r2`. Prefer the env var over the flag.
+    #[clap(long, env = "STATELESS_VALIDATOR_R2_SECRET_ACCESS_KEY")]
+    pub r2_secret_access_key: Option<String>,
+
+    /// Optional inclusive end block: validate up to this height, then stop cleanly. Used to slice a
+    /// fixed block range across multiple servers. Omit to follow the chain tip indefinitely.
+    #[clap(long, env = "STATELESS_VALIDATOR_END_BLOCK")]
+    pub end_block: Option<u64>,
 
     /// Optional trusted block hash to start validation from.
     #[clap(long, env = "STATELESS_VALIDATOR_START_BLOCK")]
@@ -206,8 +247,40 @@ pub async fn run() -> Result<()> {
         ..rpc_defaults
     }
     .with_metrics(Arc::new(metrics::ValidatorMetrics));
+    // Resolve the witness source. In R2 mode the witness comes straight from the bucket, so the
+    // RpcClient's witness providers are never touched — but its constructor still requires a
+    // non-empty witness-endpoint list, so we hand it the data endpoints as an unused placeholder.
     let data_apis: Vec<&str> = args.rpc_endpoint.iter().map(String::as_str).collect();
-    let witness_apis: Vec<&str> = args.witness_endpoint.iter().map(String::as_str).collect();
+    let r2_witness = match args.witness_source {
+        WitnessSource::Rpc => {
+            if args.witness_endpoint.is_empty() {
+                return Err(eyre::eyre!(
+                    "--witness-endpoint is required with --witness-source rpc (the default)"
+                ));
+            }
+            None
+        }
+        WitnessSource::R2 => {
+            let endpoint = require_r2(&args.r2_endpoint, "--r2-endpoint")?;
+            let bucket = require_r2(&args.r2_bucket, "--r2-bucket")?;
+            let access_key_id = require_r2(&args.r2_access_key_id, "--r2-access-key-id")?;
+            let secret_access_key =
+                require_r2(&args.r2_secret_access_key, "--r2-secret-access-key")?;
+            info!(endpoint, bucket, "Witness source: R2 (direct S3, bypassing RPC/KV)");
+            Some(Arc::new(R2WitnessClient::new(
+                endpoint,
+                bucket.to_string(),
+                access_key_id.to_string(),
+                secret_access_key.to_string(),
+                per_attempt_timeout,
+            )?))
+        }
+    };
+
+    let witness_apis: Vec<&str> =
+        if r2_witness.is_some() { data_apis.clone() } else {
+            args.witness_endpoint.iter().map(String::as_str).collect()
+        };
     let client = Arc::new(RpcClient::new_with_config(
         &data_apis,
         &witness_apis,
@@ -271,9 +344,16 @@ pub async fn run() -> Result<()> {
     pipeline_config.error_restart_delay =
         override_ms(args.error_restart_delay_ms, pipeline_config.error_restart_delay);
     pipeline_config.tip_buffer = args.tip_buffer.unwrap_or(DEFAULT_TIP_BUFFER);
+    // Optional inclusive end block: the fetcher stops after this height. Slices a fixed range
+    // across servers (each server validates [start_block, end_block]).
+    pipeline_config.sync_target = args.end_block;
+    if let Some(end) = args.end_block {
+        info!(end_block = end, "Validating up to end block, then stopping");
+    }
 
     let result = workers::run_with_signals(
         client,
+        r2_witness,
         validator_db,
         contract_cache,
         chain_spec,
@@ -292,4 +372,12 @@ pub async fn run() -> Result<()> {
 /// otherwise spread across the backoff + pipeline-config overrides.
 fn override_ms(ms: Option<u64>, default: Duration) -> Duration {
     ms.map(Duration::from_millis).unwrap_or(default)
+}
+
+/// Unwraps a required `--r2-*` argument, erroring with the flag name when it is absent.
+fn require_r2<'a>(value: &'a Option<String>, flag: &str) -> Result<&'a str> {
+    value
+        .as_deref()
+        .filter(|v| !v.is_empty())
+        .ok_or_else(|| eyre::eyre!("{flag} is required with --witness-source r2"))
 }

--- a/bin/stateless-validator/src/app.rs
+++ b/bin/stateless-validator/src/app.rs
@@ -10,7 +10,7 @@ use eyre::Result;
 use stateless_common::{BackoffPolicy, RpcClient, RpcClientConfig, logging::LogArgs};
 use stateless_core::{ChainStore, ContractStore, chain_spec::ChainSpec, db::BlockMeta};
 use stateless_db::ContractCache;
-use tracing::info;
+use tracing::{info, warn};
 
 use crate::{metrics, r2_witness::R2WitnessClient, validator_db::ValidatorDB, workers};
 
@@ -289,6 +289,12 @@ pub async fn run() -> Result<()> {
             None
         }
         WitnessSource::R2 => {
+            if !args.witness_endpoint.is_empty() {
+                warn!(
+                    "--witness-endpoint is ignored with --witness-source r2: witnesses come \
+                     straight from the R2 bucket, and there is no RPC witness fallback"
+                );
+            }
             let endpoint = require_r2(&args.r2_endpoint, "--r2-endpoint")?;
             let bucket = require_r2(&args.r2_bucket, "--r2-bucket")?;
             let access_key_id = require_r2(&args.r2_access_key_id, "--r2-access-key-id")?;

--- a/bin/stateless-validator/src/app.rs
+++ b/bin/stateless-validator/src/app.rs
@@ -160,7 +160,7 @@ pub struct CommandLineArgs {
     pub report_validation_endpoint: Option<String>,
 
     /// Enable Prometheus metrics endpoint.
-    /// When enabled, metrics are exposed at http://0.0.0.0:<metrics-port>/metrics
+    /// When enabled, metrics are exposed at `http://0.0.0.0:<metrics-port>/metrics`.
     #[clap(long, env = "STATELESS_VALIDATOR_METRICS_ENABLED")]
     pub metrics_enabled: bool,
 

--- a/bin/stateless-validator/src/app.rs
+++ b/bin/stateless-validator/src/app.rs
@@ -25,6 +25,31 @@ pub enum WitnessSource {
     R2,
 }
 
+/// A CLI/env secret that redacts itself in `Debug` output — [`CommandLineArgs`] derives `Debug`,
+/// and a secret must never ride along if the args are ever logged.
+#[derive(Clone)]
+pub struct RedactedSecret(String);
+
+impl std::str::FromStr for RedactedSecret {
+    type Err = std::convert::Infallible;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self(s.to_string()))
+    }
+}
+
+impl std::fmt::Debug for RedactedSecret {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("[redacted]")
+    }
+}
+
+impl AsRef<str> for RedactedSecret {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
 /// Database filename for the validator.
 pub const VALIDATOR_DB_FILENAME: &str = "validator.redb";
 
@@ -111,10 +136,12 @@ pub struct CommandLineArgs {
     /// R2 secret access key. Required when `--witness-source r2`. Prefer the env var over the
     /// flag.
     #[clap(long, env = "STATELESS_VALIDATOR_R2_SECRET_ACCESS_KEY")]
-    pub r2_secret_access_key: Option<String>,
+    pub r2_secret_access_key: Option<RedactedSecret>,
 
     /// Optional inclusive end block: validate up to this height, then stop cleanly. Used to slice
     /// a fixed block range across multiple servers. Omit to follow the chain tip indefinitely.
+    /// Note: the fetcher stays `--tip-buffer` blocks behind the remote tip, so the run only
+    /// completes once the chain has advanced to `end_block + tip_buffer`.
     #[clap(long, env = "STATELESS_VALIDATOR_END_BLOCK")]
     pub end_block: Option<u64>,
 
@@ -176,7 +203,8 @@ pub struct CommandLineArgs {
     #[clap(long, env = "STATELESS_VALIDATOR_RPC_MAX_BACKOFF_MS")]
     pub rpc_max_backoff_ms: Option<u64>,
 
-    /// Per-attempt RPC timeout (milliseconds). Must be ≥ 100ms.
+    /// Per-attempt RPC timeout (milliseconds). Must be ≥ 100ms. With `--witness-source r2` this
+    /// also bounds each R2 witness GET.
     #[clap(
         long,
         env = "STATELESS_VALIDATOR_RPC_PER_ATTEMPT_TIMEOUT_MS",
@@ -376,9 +404,35 @@ fn override_ms(ms: Option<u64>, default: Duration) -> Duration {
 }
 
 /// Unwraps a required `--r2-*` argument, erroring with the flag name when it is absent.
-fn require_r2<'a>(value: &'a Option<String>, flag: &str) -> Result<&'a str> {
+fn require_r2<'a, T: AsRef<str>>(value: &'a Option<T>, flag: &str) -> Result<&'a str> {
     value
-        .as_deref()
+        .as_ref()
+        .map(AsRef::as_ref)
         .filter(|v| !v.is_empty())
         .ok_or_else(|| eyre::eyre!("{flag} is required with --witness-source r2"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn require_r2_rejects_absent_and_empty_values() {
+        assert!(require_r2(&None::<String>, "--r2-endpoint").is_err());
+        // An env var set to the empty string must not pass as configured.
+        assert!(require_r2(&Some(String::new()), "--r2-endpoint").is_err());
+        assert_eq!(
+            require_r2(&Some("https://x".to_string()), "--r2-endpoint").unwrap(),
+            "https://x"
+        );
+    }
+
+    /// `CommandLineArgs` derives `Debug`; the secret must never appear in that output.
+    #[test]
+    fn redacted_secret_never_debug_prints_its_value() {
+        let secret: RedactedSecret = "super-secret-key".parse().unwrap();
+        assert_eq!(format!("{secret:?}"), "[redacted]");
+        assert_eq!(format!("{:?}", Some(&secret)), "Some([redacted])");
+        assert_eq!(secret.as_ref(), "super-secret-key");
+    }
 }

--- a/bin/stateless-validator/src/app.rs
+++ b/bin/stateless-validator/src/app.rs
@@ -25,8 +25,8 @@ pub enum WitnessSource {
     R2,
 }
 
-/// A CLI/env secret that redacts itself in `Debug` output — [`CommandLineArgs`] derives `Debug`,
-/// and a secret must never ride along if the args are ever logged.
+/// A CLI/env secret that renders as `[redacted]` in `Debug` output, so it cannot leak when
+/// [`CommandLineArgs`] (which derives `Debug`) is logged.
 #[derive(Clone)]
 pub struct RedactedSecret(String);
 
@@ -114,8 +114,7 @@ pub struct CommandLineArgs {
     )]
     pub witness_endpoint: Vec<String>,
 
-    /// Where to source witnesses from: `rpc` (default) or `r2`. `r2` fetches each witness straight
-    /// from the R2 bucket over the S3 API; it requires the `--r2-*` flags below.
+    /// Where to source witnesses from: `rpc` (default) or `r2` (requires the `--r2-*` flags).
     #[clap(long, env = "STATELESS_VALIDATOR_WITNESS_SOURCE", value_enum, default_value_t = WitnessSource::Rpc)]
     pub witness_source: WitnessSource,
 
@@ -140,8 +139,7 @@ pub struct CommandLineArgs {
 
     /// Optional inclusive end block: validate up to this height, then stop cleanly. Used to slice
     /// a fixed block range across multiple servers. Omit to follow the chain tip indefinitely.
-    /// Note: the fetcher stays `--tip-buffer` blocks behind the remote tip, so the run only
-    /// completes once the chain has advanced to `end_block + tip_buffer`.
+    /// Note: the run only completes once the chain reaches `end_block + tip_buffer`.
     #[clap(long, env = "STATELESS_VALIDATOR_END_BLOCK")]
     pub end_block: Option<u64>,
 
@@ -173,9 +171,8 @@ pub struct CommandLineArgs {
     #[clap(long, env = "STATELESS_VALIDATOR_DATA_MAX_CONCURRENT_REQUESTS")]
     pub data_max_concurrent_requests: Option<usize>,
 
-    /// Maximum concurrent in-flight witness fetches, independent of the data cap.
-    /// Omit for unlimited. Applies to both witness sources: `mega_getBlockWitness` RPC calls
-    /// and, with `--witness-source r2`, direct R2 GETs.
+    /// Maximum concurrent in-flight witness fetches, independent of the data cap. Omit for
+    /// unlimited. Applies to both RPC witness calls and, with `--witness-source r2`, R2 GETs.
     #[clap(long, env = "STATELESS_VALIDATOR_WITNESS_MAX_CONCURRENT_REQUESTS")]
     pub witness_max_concurrent_requests: Option<usize>,
 
@@ -276,9 +273,8 @@ pub async fn run() -> Result<()> {
         ..rpc_defaults
     }
     .with_metrics(Arc::new(metrics::ValidatorMetrics));
-    // Resolve the witness source. In R2 mode the witness comes straight from the bucket, so the
-    // RpcClient's witness providers are never touched — but its constructor still requires a
-    // non-empty witness-endpoint list, so we hand it the data endpoints as an unused placeholder.
+    // In R2 mode the RpcClient's witness providers are never used, but its constructor requires
+    // a non-empty list — hand it the data endpoints as a placeholder.
     let data_apis: Vec<&str> = args.rpc_endpoint.iter().map(String::as_str).collect();
     let r2_witness = match args.witness_source {
         WitnessSource::Rpc => {
@@ -381,8 +377,6 @@ pub async fn run() -> Result<()> {
     pipeline_config.error_restart_delay =
         override_ms(args.error_restart_delay_ms, pipeline_config.error_restart_delay);
     pipeline_config.tip_buffer = args.tip_buffer.unwrap_or(DEFAULT_TIP_BUFFER);
-    // Optional inclusive end block: the fetcher stops after this height. Slices a fixed range
-    // across servers (each server validates [start_block, end_block]).
     pipeline_config.sync_target = args.end_block;
     if let Some(end) = args.end_block {
         info!(end_block = end, "Validating up to end block, then stopping");

--- a/bin/stateless-validator/src/app.rs
+++ b/bin/stateless-validator/src/app.rs
@@ -18,11 +18,10 @@ use crate::{metrics, r2_witness::R2WitnessClient, validator_db::ValidatorDB, wor
 #[derive(ValueEnum, Clone, Debug, PartialEq, Eq, Default)]
 #[clap(rename_all = "lowercase")]
 pub enum WitnessSource {
-    /// `mega_getBlockWitness` RPC (the production path; may fall back to KV upstream).
+    /// `mega_getBlockWitness` RPC.
     #[default]
     Rpc,
-    /// Straight from the R2 bucket over the S3 API — bypasses RPC/KV to validate the migrated
-    /// archive end to end. Requires the `--r2-*` flags.
+    /// Straight from the R2 bucket over the S3 API. Requires the `--r2-*` flags.
     R2,
 }
 
@@ -91,8 +90,7 @@ pub struct CommandLineArgs {
     pub witness_endpoint: Vec<String>,
 
     /// Where to source witnesses from: `rpc` (default) or `r2`. `r2` fetches each witness straight
-    /// from the R2 bucket over the S3 API (bypassing the RPC/KV path) to validate the migrated
-    /// archive end to end; it requires the `--r2-*` flags below.
+    /// from the R2 bucket over the S3 API; it requires the `--r2-*` flags below.
     #[clap(long, env = "STATELESS_VALIDATOR_WITNESS_SOURCE", value_enum, default_value_t = WitnessSource::Rpc)]
     pub witness_source: WitnessSource,
 
@@ -268,7 +266,7 @@ pub async fn run() -> Result<()> {
             let access_key_id = require_r2(&args.r2_access_key_id, "--r2-access-key-id")?;
             let secret_access_key =
                 require_r2(&args.r2_secret_access_key, "--r2-secret-access-key")?;
-            info!(endpoint, bucket, "Witness source: R2 (direct S3, bypassing RPC/KV)");
+            info!(endpoint, bucket, "Witness source: R2 (direct S3)");
             Some(Arc::new(R2WitnessClient::new(
                 endpoint,
                 bucket.to_string(),

--- a/bin/stateless-validator/src/app.rs
+++ b/bin/stateless-validator/src/app.rs
@@ -193,11 +193,13 @@ pub struct CommandLineArgs {
     pub tip_buffer: Option<u64>,
 
     /// Initial round-level RPC retry backoff (milliseconds). Applied after every provider in a
-    /// round has failed; doubles each round up to `--rpc-max-backoff-ms`.
+    /// round has failed; doubles each round up to `--rpc-max-backoff-ms`. With
+    /// `--witness-source r2` this also paces R2 witness GET retries.
     #[clap(long, env = "STATELESS_VALIDATOR_RPC_INITIAL_BACKOFF_MS")]
     pub rpc_initial_backoff_ms: Option<u64>,
 
-    /// Cap on round-level RPC retry backoff (milliseconds).
+    /// Cap on round-level RPC retry backoff (milliseconds). With `--witness-source r2` this
+    /// also caps R2 witness GET retry backoff.
     #[clap(long, env = "STATELESS_VALIDATOR_RPC_MAX_BACKOFF_MS")]
     pub rpc_max_backoff_ms: Option<u64>,
 
@@ -304,6 +306,7 @@ pub async fn run() -> Result<()> {
                 access_key_id.to_string(),
                 secret_access_key.to_string(),
                 per_attempt_timeout,
+                rpc_config.rpc_retry.clone(),
                 args.witness_max_concurrent_requests,
             )?))
         }

--- a/bin/stateless-validator/src/app.rs
+++ b/bin/stateless-validator/src/app.rs
@@ -174,7 +174,8 @@ pub struct CommandLineArgs {
     pub data_max_concurrent_requests: Option<usize>,
 
     /// Maximum concurrent in-flight witness fetches, independent of the data cap.
-    /// Omit for unlimited.
+    /// Omit for unlimited. Applies to both witness sources: `mega_getBlockWitness` RPC calls
+    /// and, with `--witness-source r2`, direct R2 GETs.
     #[clap(long, env = "STATELESS_VALIDATOR_WITNESS_MAX_CONCURRENT_REQUESTS")]
     pub witness_max_concurrent_requests: Option<usize>,
 
@@ -307,6 +308,7 @@ pub async fn run() -> Result<()> {
                 access_key_id.to_string(),
                 secret_access_key.to_string(),
                 per_attempt_timeout,
+                args.witness_max_concurrent_requests,
             )?))
         }
     };

--- a/bin/stateless-validator/src/app.rs
+++ b/bin/stateless-validator/src/app.rs
@@ -101,7 +101,8 @@ pub struct CommandLineArgs {
     #[clap(long, env = "STATELESS_VALIDATOR_R2_ENDPOINT")]
     pub r2_endpoint: Option<String>,
 
-    /// R2 bucket holding the witnesses (e.g. `witness-mainnet`). Required when `--witness-source r2`.
+    /// R2 bucket holding the witnesses (e.g. `witness-mainnet`). Required when `--witness-source
+    /// r2`.
     #[clap(long, env = "STATELESS_VALIDATOR_R2_BUCKET")]
     pub r2_bucket: Option<String>,
 
@@ -109,12 +110,13 @@ pub struct CommandLineArgs {
     #[clap(long, env = "STATELESS_VALIDATOR_R2_ACCESS_KEY_ID")]
     pub r2_access_key_id: Option<String>,
 
-    /// R2 secret access key. Required when `--witness-source r2`. Prefer the env var over the flag.
+    /// R2 secret access key. Required when `--witness-source r2`. Prefer the env var over the
+    /// flag.
     #[clap(long, env = "STATELESS_VALIDATOR_R2_SECRET_ACCESS_KEY")]
     pub r2_secret_access_key: Option<String>,
 
-    /// Optional inclusive end block: validate up to this height, then stop cleanly. Used to slice a
-    /// fixed block range across multiple servers. Omit to follow the chain tip indefinitely.
+    /// Optional inclusive end block: validate up to this height, then stop cleanly. Used to slice
+    /// a fixed block range across multiple servers. Omit to follow the chain tip indefinitely.
     #[clap(long, env = "STATELESS_VALIDATOR_END_BLOCK")]
     pub end_block: Option<u64>,
 
@@ -277,10 +279,11 @@ pub async fn run() -> Result<()> {
         }
     };
 
-    let witness_apis: Vec<&str> =
-        if r2_witness.is_some() { data_apis.clone() } else {
-            args.witness_endpoint.iter().map(String::as_str).collect()
-        };
+    let witness_apis: Vec<&str> = if r2_witness.is_some() {
+        data_apis.clone()
+    } else {
+        args.witness_endpoint.iter().map(String::as_str).collect()
+    };
     let client = Arc::new(RpcClient::new_with_config(
         &data_apis,
         &witness_apis,

--- a/bin/stateless-validator/src/chain_sync.rs
+++ b/bin/stateless-validator/src/chain_sync.rs
@@ -31,12 +31,11 @@ use crate::{metrics, r2_witness::R2WitnessClient};
 /// remote chain height for metrics.
 ///
 /// Blocks, headers, and contract code always come from the data RPC ([`rpc_client`]). The witness
-/// comes from whichever [`witness_source`] is configured: the default RPC path
-/// (`mega_getBlockWitness`, which may fall back to KV), or — for validating the migrated archive —
-/// straight from R2 via [`R2WitnessClient`].
+/// comes from the configured source: the `mega_getBlockWitness` RPC (default), or straight from
+/// R2 via [`R2WitnessClient`].
 pub struct ValidatorFetcher {
     pub rpc_client: Arc<RpcClient>,
-    /// `Some` ⇒ fetch witnesses directly from R2 (bypassing the RPC/KV path); `None` ⇒ RPC.
+    /// `Some` ⇒ fetch witnesses directly from R2; `None` ⇒ RPC.
     pub r2_witness: Option<Arc<R2WitnessClient>>,
     pub on_remote_height: fn(u64),
 }
@@ -50,9 +49,8 @@ impl BlockFetcher for ValidatorFetcher {
         // surfaces as a hash mismatch rather than silently swapping the block under us.
         let block_fut = self.rpc_client.get_block(BlockId::Hash(block_hash.into()), true);
         // The RPC witness path retries internally until it succeeds, but an R2 fetch is fallible:
-        // a 404 (`Missing`) or a decode failure is a genuine finding about the archive and
-        // propagates as a fetch error (the pipeline re-enqueues, so the stuck block with its loud
-        // MISSING/decode error is unmistakable).
+        // a 404 (`Missing`) or a decode failure propagates as a fetch error (the pipeline
+        // re-enqueues, so the stuck block with its loud MISSING/decode error is unmistakable).
         let witness_fut = async {
             match &self.r2_witness {
                 Some(r2) => Ok::<_, eyre::Report>(r2.get_witness(block_number, block_hash).await?),

--- a/bin/stateless-validator/src/chain_sync.rs
+++ b/bin/stateless-validator/src/chain_sync.rs
@@ -25,12 +25,19 @@ use stateless_db::ContractCache;
 use tokio::task;
 use tracing::{debug, error};
 
-use crate::metrics;
+use crate::{metrics, r2_witness::R2WitnessClient};
 
-/// Fetcher for the validator: fetches blocks + witnesses from RPC,
-/// wraps in [`ValidationTask`], and records remote chain height for metrics.
+/// Fetcher for the validator: fetches blocks + witnesses, wraps in [`ValidationTask`], and records
+/// remote chain height for metrics.
+///
+/// Blocks, headers, and contract code always come from the data RPC ([`rpc_client`]). The witness
+/// comes from whichever [`witness_source`] is configured: the default RPC path
+/// (`mega_getBlockWitness`, which may fall back to KV), or — for validating the migrated archive —
+/// straight from R2 via [`R2WitnessClient`].
 pub struct ValidatorFetcher {
     pub rpc_client: Arc<RpcClient>,
+    /// `Some` ⇒ fetch witnesses directly from R2 (bypassing the RPC/KV path); `None` ⇒ RPC.
+    pub r2_witness: Option<Arc<R2WitnessClient>>,
     pub on_remote_height: fn(u64),
 }
 
@@ -41,10 +48,25 @@ impl BlockFetcher for ValidatorFetcher {
         let block_hash = self.rpc_client.get_block_hash(block_number).await;
         // Fetch by hash (not number) so a reorg between the hash lookup and the block fetch
         // surfaces as a hash mismatch rather than silently swapping the block under us.
-        let ((salt_witness, mpt_witness), block) = tokio::join!(
-            self.rpc_client.get_witness(block_number, block_hash),
-            self.rpc_client.get_block(BlockId::Hash(block_hash.into()), true),
-        );
+        let block_fut = self.rpc_client.get_block(BlockId::Hash(block_hash.into()), true);
+        let (salt_witness, mpt_witness, block) = match &self.r2_witness {
+            // R2 fetch is fallible: a 404 (`Missing`) or a decode failure is a genuine finding
+            // about the archive and propagates as a fetch error (the pipeline re-enqueues, so the
+            // stuck block with its loud MISSING/decode error is unmistakable).
+            Some(r2) => {
+                let (witness, block) =
+                    tokio::join!(r2.get_witness(block_number, block_hash, None), block_fut);
+                let (salt_witness, mpt_witness) = witness?;
+                (salt_witness, mpt_witness, block)
+            }
+            None => {
+                let ((salt_witness, mpt_witness), block) = tokio::join!(
+                    self.rpc_client.get_witness(block_number, block_hash),
+                    block_fut,
+                );
+                (salt_witness, mpt_witness, block)
+            }
+        };
         Ok(ValidationTask { block, salt_witness, mpt_witness })
     }
 

--- a/bin/stateless-validator/src/chain_sync.rs
+++ b/bin/stateless-validator/src/chain_sync.rs
@@ -49,24 +49,18 @@ impl BlockFetcher for ValidatorFetcher {
         // Fetch by hash (not number) so a reorg between the hash lookup and the block fetch
         // surfaces as a hash mismatch rather than silently swapping the block under us.
         let block_fut = self.rpc_client.get_block(BlockId::Hash(block_hash.into()), true);
-        let (salt_witness, mpt_witness, block) = match &self.r2_witness {
-            // R2 fetch is fallible: a 404 (`Missing`) or a decode failure is a genuine finding
-            // about the archive and propagates as a fetch error (the pipeline re-enqueues, so the
-            // stuck block with its loud MISSING/decode error is unmistakable).
-            Some(r2) => {
-                let (witness, block) =
-                    tokio::join!(r2.get_witness(block_number, block_hash, None), block_fut);
-                let (salt_witness, mpt_witness) = witness?;
-                (salt_witness, mpt_witness, block)
-            }
-            None => {
-                let ((salt_witness, mpt_witness), block) = tokio::join!(
-                    self.rpc_client.get_witness(block_number, block_hash),
-                    block_fut,
-                );
-                (salt_witness, mpt_witness, block)
+        // The RPC witness path retries internally until it succeeds, but an R2 fetch is fallible:
+        // a 404 (`Missing`) or a decode failure is a genuine finding about the archive and
+        // propagates as a fetch error (the pipeline re-enqueues, so the stuck block with its loud
+        // MISSING/decode error is unmistakable).
+        let witness_fut = async {
+            match &self.r2_witness {
+                Some(r2) => Ok::<_, eyre::Report>(r2.get_witness(block_number, block_hash).await?),
+                None => Ok(self.rpc_client.get_witness(block_number, block_hash).await),
             }
         };
+        let (witness, block) = tokio::join!(witness_fut, block_fut);
+        let (salt_witness, mpt_witness) = witness?;
         Ok(ValidationTask { block, salt_witness, mpt_witness })
     }
 

--- a/bin/stateless-validator/src/chain_sync.rs
+++ b/bin/stateless-validator/src/chain_sync.rs
@@ -30,9 +30,8 @@ use crate::{metrics, r2_witness::R2WitnessClient};
 /// Fetcher for the validator: fetches blocks + witnesses, wraps in [`ValidationTask`], and records
 /// remote chain height for metrics.
 ///
-/// Blocks, headers, and contract code always come from the data RPC ([`Self::rpc_client`]). The
-/// witness comes from the configured source: the `mega_getBlockWitness` RPC (default), or
-/// straight from R2 via [`R2WitnessClient`].
+/// Blocks, headers, and contract code always come from the data RPC; the witness comes from
+/// `mega_getBlockWitness` (default) or straight from R2 ([`R2WitnessClient`]).
 pub struct ValidatorFetcher {
     pub rpc_client: Arc<RpcClient>,
     /// `Some` ⇒ fetch witnesses directly from R2; `None` ⇒ RPC.
@@ -48,9 +47,9 @@ impl BlockFetcher for ValidatorFetcher {
         // Fetch by hash (not number) so a reorg between the hash lookup and the block fetch
         // surfaces as a hash mismatch rather than silently swapping the block under us.
         let block_fut = self.rpc_client.get_block(BlockId::Hash(block_hash.into()), true);
-        // The RPC witness path retries internally until it succeeds, but an R2 fetch is fallible:
-        // a 404 (`Missing`) or a decode failure propagates as a fetch error (the pipeline
-        // re-enqueues, so the stuck block with its loud MISSING/decode error is unmistakable).
+        // The RPC witness path retries internally until it succeeds; an R2 fetch is fallible —
+        // a 404 (`Missing`) or decode failure surfaces as a fetch error and the pipeline
+        // re-enqueues.
         let witness_fut = async {
             match &self.r2_witness {
                 Some(r2) => Ok::<_, eyre::Report>(r2.get_witness(block_number, block_hash).await?),

--- a/bin/stateless-validator/src/chain_sync.rs
+++ b/bin/stateless-validator/src/chain_sync.rs
@@ -30,9 +30,9 @@ use crate::{metrics, r2_witness::R2WitnessClient};
 /// Fetcher for the validator: fetches blocks + witnesses, wraps in [`ValidationTask`], and records
 /// remote chain height for metrics.
 ///
-/// Blocks, headers, and contract code always come from the data RPC ([`rpc_client`]). The witness
-/// comes from the configured source: the `mega_getBlockWitness` RPC (default), or straight from
-/// R2 via [`R2WitnessClient`].
+/// Blocks, headers, and contract code always come from the data RPC ([`Self::rpc_client`]). The
+/// witness comes from the configured source: the `mega_getBlockWitness` RPC (default), or
+/// straight from R2 via [`R2WitnessClient`].
 pub struct ValidatorFetcher {
     pub rpc_client: Arc<RpcClient>,
     /// `Some` ⇒ fetch witnesses directly from R2; `None` ⇒ RPC.

--- a/bin/stateless-validator/src/lib.rs
+++ b/bin/stateless-validator/src/lib.rs
@@ -16,3 +16,4 @@ pub use app::{
 pub use chain_sync::{ValidatorFetcher, ValidatorHooks, ValidatorProcessor};
 pub use r2_witness::{R2WitnessClient, R2WitnessError};
 pub use validator_db::ValidatorDB;
+pub use workers::run_with_signals;

--- a/bin/stateless-validator/src/lib.rs
+++ b/bin/stateless-validator/src/lib.rs
@@ -13,7 +13,7 @@ pub(crate) mod workers;
 pub use app::{
     CommandLineArgs, VALIDATOR_DB_FILENAME, WitnessSource, load_or_create_chain_spec, run,
 };
-pub use chain_sync::{ValidatorFetcher, ValidatorHooks, ValidatorProcessor};
+pub use chain_sync::{ValidationTask, ValidatorFetcher, ValidatorHooks, ValidatorProcessor};
 pub use r2_witness::{R2WitnessClient, R2WitnessError};
 pub use validator_db::ValidatorDB;
 pub use workers::run_with_signals;

--- a/bin/stateless-validator/src/lib.rs
+++ b/bin/stateless-validator/src/lib.rs
@@ -10,7 +10,9 @@ pub(crate) mod r2_witness;
 pub(crate) mod validator_db;
 pub(crate) mod workers;
 
-pub use app::{CommandLineArgs, VALIDATOR_DB_FILENAME, load_or_create_chain_spec, run};
+pub use app::{
+    CommandLineArgs, VALIDATOR_DB_FILENAME, WitnessSource, load_or_create_chain_spec, run,
+};
 pub use chain_sync::{ValidatorFetcher, ValidatorHooks, ValidatorProcessor};
 pub use r2_witness::{R2WitnessClient, R2WitnessError};
 pub use validator_db::ValidatorDB;

--- a/bin/stateless-validator/src/lib.rs
+++ b/bin/stateless-validator/src/lib.rs
@@ -6,9 +6,11 @@
 pub(crate) mod app;
 pub(crate) mod chain_sync;
 pub(crate) mod metrics;
+pub(crate) mod r2_witness;
 pub(crate) mod validator_db;
 pub(crate) mod workers;
 
 pub use app::{CommandLineArgs, VALIDATOR_DB_FILENAME, load_or_create_chain_spec, run};
 pub use chain_sync::{ValidatorFetcher, ValidatorHooks, ValidatorProcessor};
+pub use r2_witness::{R2WitnessClient, R2WitnessError};
 pub use validator_db::ValidatorDB;

--- a/bin/stateless-validator/src/metrics.rs
+++ b/bin/stateless-validator/src/metrics.rs
@@ -328,11 +328,9 @@ pub fn on_witness_fetch(b: WitnessSizeBreakdown) {
 
 // R2 witness source metrics (`--witness-source r2`)
 
-/// Record a successful R2 witness fetch: duration (GET incl. internal retries, plus decode —
-/// excluding time queued on the witness concurrency cap, which is self-imposed and would mask
-/// genuine R2 latency) and the same size breakdown the RPC path reports via
-/// [`on_witness_fetch`], so the witness-size histograms stay populated when the witness source
-/// is R2.
+/// Record a successful R2 witness fetch: duration (see [`names::WITNESS_FETCH_R2_TIME`]'s
+/// description for what it covers) plus the same size breakdown as [`on_witness_fetch`], so the
+/// witness-size histograms stay populated in R2 mode.
 pub fn on_r2_witness_fetch_success(duration: f64, breakdown: WitnessSizeBreakdown) {
     histogram!(names::WITNESS_FETCH_R2_TIME).record(duration);
     on_witness_fetch(breakdown);

--- a/bin/stateless-validator/src/metrics.rs
+++ b/bin/stateless-validator/src/metrics.rs
@@ -170,7 +170,7 @@ fn register_metric_descriptions() {
     // R2 witness source
     describe_histogram!(
         names::WITNESS_FETCH_R2_TIME,
-        "R2 witness fetch+decode time incl. internal retries (s)"
+        "R2 witness fetch+decode time incl. internal retries, excl. concurrency-cap queue wait (s)"
     );
     describe_counter!(
         names::R2_WITNESS_RETRY_ATTEMPTS_TOTAL,
@@ -328,9 +328,11 @@ pub fn on_witness_fetch(b: WitnessSizeBreakdown) {
 
 // R2 witness source metrics (`--witness-source r2`)
 
-/// Record a successful R2 witness fetch: duration (GET incl. internal retries, plus decode) and
-/// the same size breakdown the RPC path reports via [`on_witness_fetch`], so the witness-size
-/// histograms stay populated when the witness source is R2.
+/// Record a successful R2 witness fetch: duration (GET incl. internal retries, plus decode —
+/// excluding time queued on the witness concurrency cap, which is self-imposed and would mask
+/// genuine R2 latency) and the same size breakdown the RPC path reports via
+/// [`on_witness_fetch`], so the witness-size histograms stay populated when the witness source
+/// is R2.
 pub fn on_r2_witness_fetch_success(duration: f64, breakdown: WitnessSizeBreakdown) {
     histogram!(names::WITNESS_FETCH_R2_TIME).record(duration);
     on_witness_fetch(breakdown);

--- a/bin/stateless-validator/src/metrics.rs
+++ b/bin/stateless-validator/src/metrics.rs
@@ -17,6 +17,8 @@ pub use stateless_common::{
 };
 use tracing::info;
 
+use crate::r2_witness::R2WitnessError;
+
 /// Metrics callback implementation for RPC client.
 ///
 /// This struct implements the `RpcMetrics` trait from stateless-core,
@@ -75,6 +77,11 @@ pub mod names {
     metric!(CODE_FETCH_TIME, "code_fetch_time_seconds");
     metric!(WITNESS_FETCH_RPC_TIME, "witness_fetch_rpc_time_seconds");
 
+    // R2 witness source (`--witness-source r2`)
+    metric!(WITNESS_FETCH_R2_TIME, "witness_fetch_r2_time_seconds");
+    metric!(R2_WITNESS_RETRY_ATTEMPTS_TOTAL, "r2_witness_retry_attempts_total");
+    metric!(R2_WITNESS_ERRORS_TOTAL, "r2_witness_errors_total");
+
     // Contract cache
     metric!(CONTRACT_CACHE_HITS, "contract_cache_hits_total");
     metric!(CONTRACT_CACHE_MISSES, "contract_cache_misses_total");
@@ -118,6 +125,7 @@ pub fn init_metrics(addr: SocketAddr) -> Result<()> {
 
     register_metric_descriptions();
     init_rpc_method_counters();
+    init_r2_witness_counters();
     info!("Prometheus exporter listening on {}", addr);
     Ok(())
 }
@@ -159,6 +167,20 @@ fn register_metric_descriptions() {
     describe_histogram!(names::CODE_FETCH_TIME, "Code fetch time (s)");
     describe_histogram!(names::WITNESS_FETCH_RPC_TIME, "Witness RPC fetch time (s)");
 
+    // R2 witness source
+    describe_histogram!(
+        names::WITNESS_FETCH_R2_TIME,
+        "R2 witness fetch+decode time incl. internal retries (s)"
+    );
+    describe_counter!(
+        names::R2_WITNESS_RETRY_ATTEMPTS_TOTAL,
+        "R2 witness GET retry attempts (before final outcome)"
+    );
+    describe_counter!(
+        names::R2_WITNESS_ERRORS_TOTAL,
+        "R2 witness fetches that surfaced an error to the pipeline, by kind"
+    );
+
     // Contract cache
     describe_counter!(names::CONTRACT_CACHE_HITS, "Contract cache hits");
     describe_counter!(names::CONTRACT_CACHE_MISSES, "Contract cache misses");
@@ -187,6 +209,15 @@ fn init_rpc_method_counters() {
         counter!(names::RPC_REQUESTS_TOTAL, "method" => method_str).increment(0);
         counter!(names::RPC_ERRORS_TOTAL, "method" => method_str).increment(0);
         counter!(names::RPC_RETRY_ATTEMPTS_TOTAL, "method" => method_str).increment(0);
+    }
+}
+
+/// Pre-register the R2 witness-source counters (every error kind) so they appear in Prometheus
+/// output from startup, like the RPC method counters above.
+fn init_r2_witness_counters() {
+    counter!(names::R2_WITNESS_RETRY_ATTEMPTS_TOTAL).increment(0);
+    for kind in R2WitnessError::KINDS {
+        counter!(names::R2_WITNESS_ERRORS_TOTAL, "kind" => *kind).increment(0);
     }
 }
 
@@ -293,4 +324,25 @@ pub fn on_witness_fetch(b: WitnessSizeBreakdown) {
     histogram!(names::SALT_WITNESS_KEYS).record(b.kvs_count as f64);
     histogram!(names::SALT_WITNESS_KVS_SIZE).record(b.salt_kvs_size as f64);
     histogram!(names::MPT_WITNESS_SIZE).record(b.mpt_size as f64);
+}
+
+// R2 witness source metrics (`--witness-source r2`)
+
+/// Record a successful R2 witness fetch: duration (GET incl. internal retries, plus decode) and
+/// the same size breakdown the RPC path reports via [`on_witness_fetch`], so the witness-size
+/// histograms stay populated when the witness source is R2.
+pub fn on_r2_witness_fetch_success(duration: f64, breakdown: WitnessSizeBreakdown) {
+    histogram!(names::WITNESS_FETCH_R2_TIME).record(duration);
+    on_witness_fetch(breakdown);
+}
+
+/// Record one retried R2 witness GET attempt (transport/429/5xx, before the final outcome).
+pub fn on_r2_witness_retry() {
+    counter!(names::R2_WITNESS_RETRY_ATTEMPTS_TOTAL).increment(1);
+}
+
+/// Record an R2 witness fetch that surfaced an error to the pipeline, labelled by
+/// [`R2WitnessError::kind`].
+pub fn on_r2_witness_error(kind: &'static str) {
+    counter!(names::R2_WITNESS_ERRORS_TOTAL, "kind" => kind).increment(1);
 }

--- a/bin/stateless-validator/src/r2_witness.rs
+++ b/bin/stateless-validator/src/r2_witness.rs
@@ -14,20 +14,32 @@
 //! `zstd(bincode-legacy((SaltWitness, MptWitness)))` (see the uploader's `encode_witness_payload`),
 //! which [`stateless_common::decode_witness_payload`] inverts exactly.
 
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use alloy_primitives::B256;
+use bytes::Bytes;
 use chrono::Utc;
 use megaeth_witness_r2::{
     endpoint::parse_endpoint,
     keys,
-    sigv4::{encode_uri_path, SigV4Signer},
+    sigv4::{SigV4Signer, encode_uri_path},
 };
 use reqwest::Client;
 use salt::SaltWitness;
-use stateless_common::decode_witness_payload;
+use stateless_common::{decode_witness_payload, witness_encoding::WitnessDecodingError};
 use stateless_core::withdrawals::MptWitness;
-use tracing::{debug, trace, warn};
+use tokio::task::JoinError;
+use tracing::{Level, debug, enabled, trace, warn};
+
+/// Max retry rounds for retryable (transport/429/5xx) failures before surfacing an error.
+const MAX_RETRIES: usize = 8;
+/// First retry sleep; doubles each round up to [`MAX_BACKOFF`].
+const INITIAL_BACKOFF: Duration = Duration::from_millis(500);
+/// Upper bound on any single retry sleep.
+const MAX_BACKOFF: Duration = Duration::from_secs(30);
+/// Throttle applied before surfacing a `Missing` (404), so the pipeline's immediate re-enqueue of
+/// a failed fetch does not hot-spin GETs against R2 on a genuine gap.
+const MISSING_THROTTLE: Duration = Duration::from_secs(2);
 
 /// Failure outcome of an R2 witness fetch.
 #[derive(Debug, thiserror::Error)]
@@ -35,7 +47,9 @@ pub enum R2WitnessError {
     /// The primary object is absent from the bucket (HTTP 404). For blocks known to have a
     /// witness this is a genuine completeness gap in R2 — the whole point of the validation run
     /// is to prove this never happens.
-    #[error("R2 witness MISSING for block {number} (key {key}): object not found (404) — R2 completeness gap")]
+    #[error(
+        "R2 witness MISSING for block {number} (key {key}): object not found (404) — R2 completeness gap"
+    )]
     Missing { number: u64, key: String },
     /// Transport-level failure (connection reset/timeout) — the endpoint is effectively
     /// unreachable. Retried internally with backoff before surfacing.
@@ -52,16 +66,16 @@ pub enum R2WitnessError {
     /// The object was fetched but its bytes did not decode to a `(SaltWitness, MptWitness)` tuple
     /// — a corrupt witness in R2. Deterministic; a finding, not retried.
     #[error("R2 witness for block {number} (key {key}) failed to decode: {source}")]
-    Decode {
-        number: u64,
-        key: String,
-        source: stateless_common::witness_encoding::WitnessDecodingError,
-    },
+    Decode { number: u64, key: String, source: WitnessDecodingError },
+    /// The decode task panicked. This is a bug in our own decoder, not evidence about the archive,
+    /// so it is kept out of [`Self::Decode`] — a panic must never masquerade as an R2 finding.
+    #[error("R2 witness decode task for block {number} (key {key}) panicked: {source}")]
+    DecodePanicked { number: u64, key: String, source: JoinError },
 }
 
 impl R2WitnessError {
     /// Whether an immediate retry against the same endpoint could plausibly succeed (transport
-    /// blips, 429, 5xx). `Missing`/`Status`/`Decode` are deterministic and not retried.
+    /// blips, 429, 5xx). Every other variant is deterministic and is surfaced without retrying.
     const fn is_retryable(&self) -> bool {
         matches!(self, Self::Transport { .. } | Self::Throttled { .. })
     }
@@ -69,8 +83,9 @@ impl R2WitnessError {
 
 /// Outcome of a single (non-retrying) GET attempt.
 enum Attempt {
-    /// 2xx with the object body.
-    Found(Vec<u8>),
+    /// 2xx with the object body. Held as [`Bytes`] (refcounted) so the multi-MB witness is never
+    /// copied between the HTTP response and the decoder.
+    Found(Bytes),
     /// 404 — object absent.
     Missing,
 }
@@ -88,13 +103,6 @@ pub struct R2WitnessClient {
     /// SigV4 canonical host (`host[:port]`).
     host: String,
     bucket: String,
-    /// Max retry rounds for retryable (transport/429/5xx) failures before surfacing an error.
-    max_retries: usize,
-    initial_backoff: Duration,
-    max_backoff: Duration,
-    /// Throttle applied before surfacing a `Missing` (404), so the pipeline's immediate
-    /// re-enqueue of a failed fetch does not hot-spin GETs against R2 on a genuine gap.
-    missing_throttle: Duration,
 }
 
 impl R2WitnessClient {
@@ -126,10 +134,6 @@ impl R2WitnessClient {
             endpoint: origin,
             host,
             bucket,
-            max_retries: 8,
-            initial_backoff: Duration::from_millis(500),
-            max_backoff: Duration::from_secs(30),
-            missing_throttle: Duration::from_secs(2),
         })
     }
 
@@ -147,16 +151,15 @@ impl R2WitnessClient {
     /// Fetches and decodes the witness for `(number, hash)` from R2.
     ///
     /// Retryable failures (transport/429/5xx) are retried with exponential backoff up to
-    /// `max_retries` (respecting `deadline` when given). `Missing` (404) and `Decode` failures are
-    /// deterministic and surface immediately as findings.
+    /// [`MAX_RETRIES`] times. `Missing` (404) and `Decode` failures are deterministic and surface
+    /// immediately as findings.
     pub async fn get_witness(
         &self,
         number: u64,
         hash: B256,
-        deadline: Option<Instant>,
     ) -> Result<(SaltWitness, MptWitness), R2WitnessError> {
         let key = Self::block_key(number, hash);
-        let mut backoff = self.initial_backoff;
+        let mut backoff = INITIAL_BACKOFF;
         let mut attempt = 0usize;
 
         let bytes = loop {
@@ -166,44 +169,29 @@ impl R2WitnessClient {
                 Ok(Attempt::Missing) => {
                     // Deterministic gap. Sleep briefly first: the fetcher re-enqueues a failed
                     // fetch immediately, so returning instantly would hot-loop 404s against R2.
-                    tokio::time::sleep(self.missing_throttle).await;
+                    tokio::time::sleep(MISSING_THROTTLE).await;
                     return Err(R2WitnessError::Missing { number, key });
                 }
                 Err(e) => {
-                    let out_of_retries = attempt > self.max_retries
-                        || deadline.is_some_and(|d| Instant::now() >= d);
-                    if !e.is_retryable() || out_of_retries {
+                    if !e.is_retryable() || attempt > MAX_RETRIES {
                         return Err(e);
                     }
-                    let sleep = match deadline {
-                        Some(d) => backoff.min(d.saturating_duration_since(Instant::now())),
-                        None => backoff,
-                    };
                     warn!(number, %key, attempt, error = %e, "R2 witness GET failed, backing off");
-                    tokio::time::sleep(sleep).await;
-                    backoff = (backoff * 2).min(self.max_backoff);
+                    tokio::time::sleep(backoff).await;
+                    backoff = (backoff * 2).min(MAX_BACKOFF);
                 }
             }
         };
 
-        let decode_key = key.clone();
-        let (salt_witness, mpt_witness) = tokio::task::spawn_blocking(move || {
-            decode_witness_payload(&bytes)
-        })
-        .await
-        .map_err(|e| R2WitnessError::Decode {
-            number,
-            key: decode_key.clone(),
-            // A panic in decode is not a `WitnessDecodingError`; fold it into the same finding
-            // channel with a synthetic message rather than unwrapping and killing the worker.
-            source: stateless_common::witness_encoding::WitnessDecodingError::Decompress(
-                std::io::Error::other(format!("decode task panicked: {e}")),
-            ),
-        })?
-        .map_err(|source| R2WitnessError::Decode { number, key, source })?;
-
-        trace!(number, "R2 witness fetched and decoded");
-        Ok((salt_witness, mpt_witness))
+        // zstd + bincode over a multi-MB witness is CPU-bound; keep it off the runtime.
+        match tokio::task::spawn_blocking(move || decode_witness_payload(&bytes)).await {
+            Ok(Ok(witness)) => {
+                trace!(number, "R2 witness fetched and decoded");
+                Ok(witness)
+            }
+            Ok(Err(source)) => Err(R2WitnessError::Decode { number, key, source }),
+            Err(source) => Err(R2WitnessError::DecodePanicked { number, key, source }),
+        }
     }
 
     /// Performs one SigV4-signed GET and classifies the response. No retry.
@@ -217,57 +205,53 @@ impl R2WitnessClient {
         for (name, value) in signed {
             request = request.header(name, value);
         }
-        let response = request.send().await.map_err(|source| R2WitnessError::Transport {
-            number,
-            key: key.to_string(),
-            source,
-        })?;
+        let transport = |source| R2WitnessError::Transport { number, key: key.to_string(), source };
+        let response = request.send().await.map_err(transport)?;
 
         let status = response.status();
         if status.is_success() {
-            // Snapshot the response headers before `bytes()` consumes `response`. These prove the
-            // witness came from R2: `cf-ray` / `x-amz-request-id` are Cloudflare/S3 request ids,
-            // and the `x-amz-meta-*` set is the custom metadata the migration/uploader wrote onto
-            // the object — the RPC/KV witness path carries none of it. Cheap: header maps are tiny.
-            let headers = response.headers().clone();
-            let hdr = |name: &str| {
-                headers.get(name).and_then(|v| v.to_str().ok()).unwrap_or("").to_owned()
-            };
-            let bytes = response.bytes().await.map_err(|source| R2WitnessError::Transport {
-                number,
-                key: key.to_string(),
-                source,
-            })?;
-            debug!(
-                block_number = number,
-                bucket = %self.bucket,
-                key,
-                http_status = status.as_u16(),
-                bytes = bytes.len(),
-                content_type = %hdr("content-type"),
-                etag = %hdr("etag"),
-                last_modified = %hdr("last-modified"),
-                cf_ray = %hdr("cf-ray"),
-                x_amz_request_id = %hdr("x-amz-request-id"),
-                x_amz_meta_compression = %hdr("x-amz-meta-compression"),
-                x_amz_meta_original_size = %hdr("x-amz-meta-original-size"),
-                x_amz_meta_compressed_size = %hdr("x-amz-meta-compressed-size"),
-                x_amz_meta_sha256 = %hdr("x-amz-meta-sha256"),
-                x_amz_meta_parent_hash = %hdr("x-amz-meta-parent-hash"),
-                x_amz_meta_attr_hash = %hdr("x-amz-meta-attr-hash"),
-                "witness fetched from R2 (S3 GET)",
-            );
-            return Ok(Attempt::Found(bytes.to_vec()));
+            // Snapshot the response headers before `bytes()` consumes `response` — but only when
+            // the log will actually emit, since this sits on the per-block hot path. These prove
+            // the witness came from R2: `cf-ray` / `x-amz-request-id` are Cloudflare/S3 request
+            // ids, and the `x-amz-meta-*` set is the custom metadata the migration/uploader wrote
+            // onto the object — the RPC/KV witness path carries none of it.
+            let headers = enabled!(Level::DEBUG).then(|| response.headers().clone());
+            let bytes = response.bytes().await.map_err(transport)?;
+            if let Some(headers) = headers {
+                let hdr =
+                    |name: &str| headers.get(name).and_then(|v| v.to_str().ok()).unwrap_or("");
+                debug!(
+                    block_number = number,
+                    bucket = %self.bucket,
+                    key,
+                    http_status = status.as_u16(),
+                    bytes = bytes.len(),
+                    content_type = hdr("content-type"),
+                    etag = hdr("etag"),
+                    last_modified = hdr("last-modified"),
+                    cf_ray = hdr("cf-ray"),
+                    x_amz_request_id = hdr("x-amz-request-id"),
+                    x_amz_meta_compression = hdr("x-amz-meta-compression"),
+                    x_amz_meta_original_size = hdr("x-amz-meta-original-size"),
+                    x_amz_meta_compressed_size = hdr("x-amz-meta-compressed-size"),
+                    x_amz_meta_sha256 = hdr("x-amz-meta-sha256"),
+                    x_amz_meta_parent_hash = hdr("x-amz-meta-parent-hash"),
+                    x_amz_meta_attr_hash = hdr("x-amz-meta-attr-hash"),
+                    "witness fetched from R2 (S3 GET)",
+                );
+            }
+            return Ok(Attempt::Found(bytes));
         }
         let code = status.as_u16();
         if code == 404 {
             return Ok(Attempt::Missing);
         }
         let body = response.text().await.unwrap_or_default();
+        let key = key.to_string();
         if code == 429 || code >= 500 {
-            Err(R2WitnessError::Throttled { number, key: key.to_string(), status: code, body })
+            Err(R2WitnessError::Throttled { number, key, status: code, body })
         } else {
-            Err(R2WitnessError::Status { number, key: key.to_string(), status: code, body })
+            Err(R2WitnessError::Status { number, key, status: code, body })
         }
     }
 }
@@ -283,10 +267,9 @@ mod tests {
     /// build time rather than as a silent wall of "missing" in production.
     #[test]
     fn block_key_matches_migrated_layout() {
-        let hash = B256::from_str(
-            "0x05dd41e545b25db0ce04f628e6e1705232240c70a0435c8233ac4479176fe6b0",
-        )
-        .unwrap();
+        let hash =
+            B256::from_str("0x05dd41e545b25db0ce04f628e6e1705232240c70a0435c8233ac4479176fe6b0")
+                .unwrap();
         assert_eq!(
             R2WitnessClient::block_key(6_632_136, hash),
             "block/6632000_6632999/6632136.\

--- a/bin/stateless-validator/src/r2_witness.rs
+++ b/bin/stateless-validator/src/r2_witness.rs
@@ -20,7 +20,9 @@ use bytes::Bytes;
 use chrono::Utc;
 use reqwest::Client;
 use salt::SaltWitness;
-use stateless_common::{WitnessDecodingError, WitnessSizeBreakdown, decode_witness_payload};
+use stateless_common::{
+    BackoffPolicy, WitnessDecodingError, WitnessSizeBreakdown, decode_witness_payload,
+};
 use stateless_core::withdrawals::MptWitness;
 use stateless_r2::{
     client::is_throttle_status,
@@ -34,18 +36,14 @@ use tracing::{trace, warn};
 use crate::metrics;
 
 /// Max retry rounds for retryable (transport/429/5xx) failures before surfacing an error.
+/// Stays a local constant while the backoff pacing is injected (see [`R2WitnessClient::new`]):
+/// the RPC path retries unboundedly, so there is no operator flag to mirror.
 const MAX_RETRIES: usize = 8;
-/// First retry sleep; doubles each round up to [`MAX_BACKOFF`]. Test builds shrink all three
-/// durations so the retry-path tests run in milliseconds.
-const INITIAL_BACKOFF: Duration =
-    if cfg!(test) { Duration::from_millis(5) } else { Duration::from_millis(500) };
-/// Upper bound on any single retry sleep.
-const MAX_BACKOFF: Duration =
-    if cfg!(test) { Duration::from_millis(20) } else { Duration::from_secs(30) };
 /// Throttle applied before surfacing any deterministic (non-retryable) failure: the pipeline
 /// fetcher (`stateless-core/src/pipeline/fetcher.rs`) re-enqueues failed fetches with no delay,
 /// so returning instantly would hot-loop signed GETs against R2. Delete this once the fetcher
-/// grows per-block re-enqueue backoff.
+/// grows per-block re-enqueue backoff. Test builds shrink it so the failure-path tests run in
+/// milliseconds.
 const DETERMINISTIC_FAILURE_THROTTLE: Duration =
     if cfg!(test) { Duration::from_millis(5) } else { Duration::from_secs(2) };
 /// Cap on the response body carried inside `Throttled`/`Status` errors.
@@ -120,6 +118,10 @@ pub struct R2WitnessClient {
     /// SigV4 canonical host (`host[:port]`).
     host: String,
     bucket: String,
+    /// Paces retries of retryable GET failures: doubling with jitter, mirroring the RPC retry
+    /// loop. Injected so the `--rpc-initial-backoff-ms` / `--rpc-max-backoff-ms` flags govern
+    /// R2 pacing too.
+    retry_backoff: BackoffPolicy,
     /// Caps concurrent GETs, honoring `--witness-max-concurrent-requests` (the RPC witness path
     /// enforces it inside `RpcClient`, which R2 mode bypasses).
     concurrency: Arc<Semaphore>,
@@ -128,9 +130,12 @@ pub struct R2WitnessClient {
 impl R2WitnessClient {
     /// Builds a client from an R2 endpoint origin, bucket, and bucket-scoped S3 credentials.
     ///
-    /// `per_attempt_timeout` bounds each individual GET. `max_concurrent_requests` caps the
-    /// number of GETs in flight at once (`None` = unlimited, `Some(0)` clamps to 1 — same
-    /// semantics as the RPC witness semaphore). Fails if the endpoint is not a bare
+    /// `per_attempt_timeout` bounds each individual GET. `retry_backoff` paces the retries of
+    /// retryable failures — first sleep `initial`, doubling up to `max`, each with up to 50%
+    /// jitter — and is the same policy the RPC path builds from `--rpc-initial-backoff-ms` /
+    /// `--rpc-max-backoff-ms`, so one pair of flags tunes both paths. `max_concurrent_requests`
+    /// caps the number of GETs in flight at once (`None` = unlimited, `Some(0)` clamps to 1 —
+    /// same semantics as the RPC witness semaphore). Fails if the endpoint is not a bare
     /// `scheme://host[:port]` origin (see [`parse_endpoint`]) or the HTTP client cannot be built.
     pub fn new(
         endpoint: &str,
@@ -138,6 +143,7 @@ impl R2WitnessClient {
         access_key_id: String,
         secret_access_key: String,
         per_attempt_timeout: Duration,
+        retry_backoff: BackoffPolicy,
         max_concurrent_requests: Option<usize>,
     ) -> eyre::Result<Self> {
         let (origin, host) = parse_endpoint(endpoint);
@@ -161,6 +167,7 @@ impl R2WitnessClient {
             endpoint: origin,
             host,
             bucket,
+            retry_backoff,
             concurrency: Arc::new(Semaphore::new(
                 max_concurrent_requests.unwrap_or(Semaphore::MAX_PERMITS).max(1),
             )),
@@ -169,9 +176,9 @@ impl R2WitnessClient {
 
     /// Fetches and decodes the witness for `(number, hash)` from R2.
     ///
-    /// Transport/429/5xx failures are retried with backoff up to `MAX_RETRIES` times. Every
-    /// other failure is deterministic and surfaces after a short
-    /// `DETERMINISTIC_FAILURE_THROTTLE` sleep (see its docs for why).
+    /// Transport/429/5xx failures are retried up to `MAX_RETRIES` times, paced by the
+    /// `retry_backoff` policy given at construction. Every other failure is deterministic and
+    /// surfaces after a short `DETERMINISTIC_FAILURE_THROTTLE` sleep (see its docs for why).
     pub async fn get_witness(
         &self,
         number: u64,
@@ -198,7 +205,8 @@ impl R2WitnessClient {
         // self-imposed, and folded in it would masquerade as R2 slowness.
         let mut queue_wait = Duration::ZERO;
         let key = keys::block_object_key(number, hash);
-        let mut backoff = INITIAL_BACKOFF;
+        let max_backoff_ms = self.retry_backoff.max.as_millis() as u64;
+        let mut backoff_ms = self.retry_backoff.initial.as_millis() as u64;
         let mut attempt = 0usize;
 
         let bytes = loop {
@@ -218,9 +226,18 @@ impl R2WitnessClient {
                         return Err(e);
                     }
                     metrics::on_r2_witness_retry();
-                    warn!(number, %key, attempt, error = %e, "R2 witness GET failed, backing off");
-                    tokio::time::sleep(backoff).await;
-                    backoff = (backoff * 2).min(MAX_BACKOFF);
+                    // Jittered doubling, mirroring the RPC retry loop: jitter keeps parallel
+                    // validators (several typically slice a block range) from retrying in
+                    // lockstep through a shared R2 brownout, and `.max(1)` keeps a
+                    // zero-duration policy from busy-looping.
+                    let jitter_ms = fastrand::u64(0..=backoff_ms / 2);
+                    let sleep_ms = (backoff_ms + jitter_ms).min(max_backoff_ms).max(1);
+                    warn!(
+                        number, %key, attempt, sleep_ms, error = %e,
+                        "R2 witness GET failed, backing off",
+                    );
+                    tokio::time::sleep(Duration::from_millis(sleep_ms)).await;
+                    backoff_ms = (backoff_ms * 2).min(max_backoff_ms);
                 }
             }
         };
@@ -323,6 +340,7 @@ mod tests {
             "ak".to_string(),
             "sk".to_string(),
             Duration::from_secs(20),
+            test_backoff(),
             None,
         )
         .unwrap_err();
@@ -362,17 +380,32 @@ mod tests {
         (endpoint, hits)
     }
 
+    /// Millisecond-scale retry pacing so the retry-path tests run fast (production runs pass
+    /// the seconds-scale policy built from the `--rpc-*-backoff-ms` flags).
+    fn test_backoff() -> BackoffPolicy {
+        BackoffPolicy::new(Duration::from_millis(5), Duration::from_millis(20))
+    }
+
     fn client(endpoint: &str) -> R2WitnessClient {
         client_with_limit(endpoint, None)
     }
 
     fn client_with_limit(endpoint: &str, limit: Option<usize>) -> R2WitnessClient {
+        client_with_backoff(endpoint, limit, test_backoff())
+    }
+
+    fn client_with_backoff(
+        endpoint: &str,
+        limit: Option<usize>,
+        retry_backoff: BackoffPolicy,
+    ) -> R2WitnessClient {
         R2WitnessClient::new(
             endpoint,
             "witness-test".to_string(),
             "ak".to_string(),
             "sk".to_string(),
             Duration::from_secs(5),
+            retry_backoff,
             limit,
         )
         .unwrap()
@@ -411,6 +444,26 @@ mod tests {
         let err = fetch(&endpoint).await.unwrap_err();
         assert!(matches!(err, R2WitnessError::Status { status: 403, .. }), "{err}");
         assert_eq!(hits.load(Ordering::SeqCst), 3, "5xx must be retried, 4xx must stop the loop");
+    }
+
+    /// The injected policy actually paces retries: with `initial = 50ms`, the sleep between
+    /// the throttled first attempt and the second must be at least 50ms (jitter only adds).
+    #[tokio::test]
+    async fn retries_are_paced_by_the_injected_backoff_policy() {
+        let (endpoint, hits) = mock_r2(vec![(503, "SlowDown"), (404, "")]).await;
+        let client = client_with_backoff(
+            &endpoint,
+            None,
+            BackoffPolicy::new(Duration::from_millis(50), Duration::from_millis(200)),
+        );
+        let started = std::time::Instant::now();
+        let err = client.get_witness(1, B256::ZERO).await.unwrap_err();
+        assert!(matches!(err, R2WitnessError::Missing { .. }), "{err}");
+        assert_eq!(hits.load(Ordering::SeqCst), 2);
+        assert!(
+            started.elapsed() >= Duration::from_millis(50),
+            "retry surfaced before the policy's initial backoff elapsed",
+        );
     }
 
     #[tokio::test]

--- a/bin/stateless-validator/src/r2_witness.rs
+++ b/bin/stateless-validator/src/r2_witness.rs
@@ -10,14 +10,14 @@
 //! uploader's `encode_witness_payload`), which [`stateless_common::decode_witness_payload`]
 //! inverts exactly.
 
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use alloy_primitives::B256;
 use bytes::Bytes;
 use chrono::Utc;
 use reqwest::Client;
 use salt::SaltWitness;
-use stateless_common::{WitnessDecodingError, decode_witness_payload};
+use stateless_common::{WitnessDecodingError, WitnessSizeBreakdown, decode_witness_payload};
 use stateless_core::withdrawals::MptWitness;
 use stateless_r2::{
     client::is_throttle_status,
@@ -27,6 +27,8 @@ use stateless_r2::{
 };
 use tokio::task::JoinError;
 use tracing::{trace, warn};
+
+use crate::metrics;
 
 /// Max retry rounds for retryable (transport/429/5xx) failures before surfacing an error.
 const MAX_RETRIES: usize = 8;
@@ -81,6 +83,24 @@ pub enum R2WitnessError {
 }
 
 impl R2WitnessError {
+    /// Every label [`Self::kind`] can produce, for metrics pre-registration
+    /// (`crate::metrics::init_metrics` zero-inits the error counter per kind).
+    pub const KINDS: &'static [&'static str] =
+        &["missing", "transport", "throttled", "status", "decode", "decode_panicked"];
+
+    /// Stable lowercase label for this variant — the `kind` label on the R2 witness error
+    /// counter. Every value returned here must appear in [`Self::KINDS`].
+    pub const fn kind(&self) -> &'static str {
+        match self {
+            Self::Missing { .. } => "missing",
+            Self::Transport { .. } => "transport",
+            Self::Throttled { .. } => "throttled",
+            Self::Status { .. } => "status",
+            Self::Decode { .. } => "decode",
+            Self::DecodePanicked { .. } => "decode_panicked",
+        }
+    }
+
     /// Whether an immediate retry against the same endpoint could plausibly succeed (transport
     /// blips, 429, 5xx). Every other variant is deterministic and is surfaced without retrying.
     const fn is_retryable(&self) -> bool {
@@ -141,19 +161,20 @@ impl R2WitnessClient {
 
     /// Fetches and decodes the witness for `(number, hash)` from R2.
     ///
-    /// Transport/429/5xx failures are retried with backoff up to [`MAX_RETRIES`] times. Every
+    /// Transport/429/5xx failures are retried with backoff up to `MAX_RETRIES` times. Every
     /// other failure is deterministic and surfaces after a short
-    /// [`DETERMINISTIC_FAILURE_THROTTLE`] sleep (see its docs for why).
+    /// `DETERMINISTIC_FAILURE_THROTTLE` sleep (see its docs for why).
     pub async fn get_witness(
         &self,
         number: u64,
         hash: B256,
     ) -> Result<(SaltWitness, MptWitness), R2WitnessError> {
         let result = self.get_witness_inner(number, hash).await;
-        if let Err(e) = &result &&
-            !e.is_retryable()
-        {
-            tokio::time::sleep(DETERMINISTIC_FAILURE_THROTTLE).await;
+        if let Err(e) = &result {
+            metrics::on_r2_witness_error(e.kind());
+            if !e.is_retryable() {
+                tokio::time::sleep(DETERMINISTIC_FAILURE_THROTTLE).await;
+            }
         }
         result
     }
@@ -164,6 +185,7 @@ impl R2WitnessClient {
         number: u64,
         hash: B256,
     ) -> Result<(SaltWitness, MptWitness), R2WitnessError> {
+        let started = Instant::now();
         let key = keys::block_object_key(number, hash);
         let mut backoff = INITIAL_BACKOFF;
         let mut attempt = 0usize;
@@ -176,6 +198,7 @@ impl R2WitnessClient {
                     if !e.is_retryable() || attempt > MAX_RETRIES {
                         return Err(e);
                     }
+                    metrics::on_r2_witness_retry();
                     warn!(number, %key, attempt, error = %e, "R2 witness GET failed, backing off");
                     tokio::time::sleep(backoff).await;
                     backoff = (backoff * 2).min(MAX_BACKOFF);
@@ -187,6 +210,10 @@ impl R2WitnessClient {
         match tokio::task::spawn_blocking(move || decode_witness_payload(&bytes)).await {
             Ok(Ok(witness)) => {
                 trace!(number, "R2 witness fetched and decoded");
+                metrics::on_r2_witness_fetch_success(
+                    started.elapsed().as_secs_f64(),
+                    WitnessSizeBreakdown::new(&witness.0, &witness.1),
+                );
                 Ok(witness)
             }
             Ok(Err(source)) => Err(R2WitnessError::Decode { number, key, source }),
@@ -283,8 +310,11 @@ mod tests {
     }
 
     /// Serves one scripted HTTP/1.1 response per connection on a local port and counts requests.
-    /// The last response repeats if more connections arrive than were scripted.
-    async fn mock_r2(responses: Vec<(u16, &'static str)>) -> (String, Arc<AtomicUsize>) {
+    /// The last response repeats if more connections arrive than were scripted. Bodies are
+    /// anything `Into<Vec<u8>>` so failure tests pass `&str` and the happy-path test raw bytes.
+    async fn mock_r2(responses: Vec<(u16, impl Into<Vec<u8>>)>) -> (String, Arc<AtomicUsize>) {
+        let responses: Vec<(u16, Vec<u8>)> =
+            responses.into_iter().map(|(status, body)| (status, body.into())).collect();
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let endpoint = format!("http://{}", listener.local_addr().unwrap());
         let hits = Arc::new(AtomicUsize::new(0));
@@ -293,19 +323,20 @@ mod tests {
             loop {
                 let Ok((mut sock, _)) = listener.accept().await else { return };
                 let n = counter.fetch_add(1, Ordering::SeqCst);
-                let (status, body) = responses[n.min(responses.len() - 1)];
+                let (status, body) = &responses[n.min(responses.len() - 1)];
                 // Drain the request head before replying.
                 let mut buf = [0u8; 4096];
                 let _ = sock.read(&mut buf).await;
                 // The reason phrase is never interpreted, and `location` is load-bearing only for
                 // the 3xx (redirects-not-followed) test — harmless noise on other statuses.
-                let response = format!(
+                let head = format!(
                     "HTTP/1.1 {status} X\r\nconnection: close\r\n\
                      location: http://example.invalid/elsewhere\r\n\
-                     content-length: {}\r\n\r\n{body}",
+                     content-length: {}\r\n\r\n",
                     body.len(),
                 );
-                let _ = sock.write_all(response.as_bytes()).await;
+                let _ = sock.write_all(head.as_bytes()).await;
+                let _ = sock.write_all(body).await;
             }
         });
         (endpoint, hits)
@@ -363,6 +394,30 @@ mod tests {
         let err = fetch(&endpoint).await.unwrap_err();
         assert!(matches!(err, R2WitnessError::Throttled { status: 503, .. }), "{err}");
         assert_eq!(hits.load(Ordering::SeqCst), MAX_RETRIES + 1, "initial attempt + MAX_RETRIES");
+    }
+
+    /// End-to-end happy path: a real fixture witness encoded exactly as the uploader writes it
+    /// (`encode_witness_payload`) and served with a 200 must decode back to the original tuple in
+    /// a single GET. This is the only test that exercises the success path of
+    /// `get_object` → `spawn_blocking` decode; the failure tests can't prove it.
+    #[tokio::test]
+    async fn valid_object_decodes_end_to_end() {
+        use stateless_test_utils::fixtures::TestFixtures;
+
+        let fixtures = TestFixtures::mainnet_shared();
+        let (_, hash) =
+            fixtures.paired_blocks().into_iter().next().expect("mainnet fixtures have a witness");
+        let salt_witness = fixtures.salt_witnesses[&hash].clone();
+        let mpt_witness: MptWitness = fixtures.mpt_witness(&hash);
+        let (_, payload) = stateless_common::encode_witness_payload(&salt_witness, &mpt_witness)
+            .expect("fixture witness must encode");
+
+        let (endpoint, hits) = mock_r2(vec![(200, payload)]).await;
+        let (decoded_salt, decoded_mpt) =
+            fetch(&endpoint).await.expect("valid object must fetch and decode");
+        assert_eq!(decoded_salt, salt_witness);
+        assert_eq!(decoded_mpt, mpt_witness);
+        assert_eq!(hits.load(Ordering::SeqCst), 1, "a successful fetch must take exactly one GET");
     }
 
     #[tokio::test]

--- a/bin/stateless-validator/src/r2_witness.rs
+++ b/bin/stateless-validator/src/r2_witness.rs
@@ -27,7 +27,7 @@ use reqwest::Client;
 use salt::SaltWitness;
 use stateless_common::decode_witness_payload;
 use stateless_core::withdrawals::MptWitness;
-use tracing::{trace, warn};
+use tracing::{debug, trace, warn};
 
 /// Failure outcome of an R2 witness fetch.
 #[derive(Debug, thiserror::Error)]
@@ -225,11 +225,38 @@ impl R2WitnessClient {
 
         let status = response.status();
         if status.is_success() {
+            // Snapshot the response headers before `bytes()` consumes `response`. These prove the
+            // witness came from R2: `cf-ray` / `x-amz-request-id` are Cloudflare/S3 request ids,
+            // and the `x-amz-meta-*` set is the custom metadata the migration/uploader wrote onto
+            // the object — the RPC/KV witness path carries none of it. Cheap: header maps are tiny.
+            let headers = response.headers().clone();
+            let hdr = |name: &str| {
+                headers.get(name).and_then(|v| v.to_str().ok()).unwrap_or("").to_owned()
+            };
             let bytes = response.bytes().await.map_err(|source| R2WitnessError::Transport {
                 number,
                 key: key.to_string(),
                 source,
             })?;
+            debug!(
+                block_number = number,
+                bucket = %self.bucket,
+                key,
+                http_status = status.as_u16(),
+                bytes = bytes.len(),
+                content_type = %hdr("content-type"),
+                etag = %hdr("etag"),
+                last_modified = %hdr("last-modified"),
+                cf_ray = %hdr("cf-ray"),
+                x_amz_request_id = %hdr("x-amz-request-id"),
+                x_amz_meta_compression = %hdr("x-amz-meta-compression"),
+                x_amz_meta_original_size = %hdr("x-amz-meta-original-size"),
+                x_amz_meta_compressed_size = %hdr("x-amz-meta-compressed-size"),
+                x_amz_meta_sha256 = %hdr("x-amz-meta-sha256"),
+                x_amz_meta_parent_hash = %hdr("x-amz-meta-parent-hash"),
+                x_amz_meta_attr_hash = %hdr("x-amz-meta-attr-hash"),
+                "witness fetched from R2 (S3 GET)",
+            );
             return Ok(Attempt::Found(bytes.to_vec()));
         }
         let code = status.as_u16();

--- a/bin/stateless-validator/src/r2_witness.rs
+++ b/bin/stateless-validator/src/r2_witness.rs
@@ -1,35 +1,31 @@
-//! Direct-from-R2 witness source for end-to-end validation of the migrated archive.
+//! Direct-from-R2 witness source.
 //!
-//! The production validator fetches witnesses over `mega_getBlockWitness`, which transparently
-//! falls back to KV — so a block validating successfully does **not** prove its witness actually
-//! came from R2. This client bypasses the RPC entirely: it fetches the primary witness object
-//! straight from the R2 bucket over the S3 API (a SigV4-signed `GET`), decompresses it, and
-//! returns the same `(SaltWitness, MptWitness)` tuple the RPC path yields. Pointing the validator
-//! at this source and replaying a block range therefore proves every witness is present and
-//! correct in R2 alone.
+//! Fetches the primary witness object straight from the R2 bucket over the S3 API (a SigV4-signed
+//! `GET`), decompresses it, and returns the same `(SaltWitness, MptWitness)` tuple the RPC path
+//! yields.
 //!
-//! The object-key layout, SigV4 signer, and endpoint parsing are reused from `megaeth-witness-r2`
-//! — the very crate the witness generator and the replayer uploader write with — so the read path
-//! here cannot drift from the write path. The primary object body is
-//! `zstd(bincode-legacy((SaltWitness, MptWitness)))` (see the uploader's `encode_witness_payload`),
-//! which [`stateless_common::decode_witness_payload`] inverts exactly.
+//! The object-key layout, SigV4 signer, and endpoint parsing come from `stateless-r2` — the same
+//! crate the witness uploaders write with — so the read path here cannot drift from the write
+//! path. The primary object body is `zstd(bincode-legacy((SaltWitness, MptWitness)))` (the
+//! uploader's `encode_witness_payload`), which [`stateless_common::decode_witness_payload`]
+//! inverts exactly.
 
 use std::time::Duration;
 
 use alloy_primitives::B256;
 use bytes::Bytes;
 use chrono::Utc;
-use megaeth_witness_r2::{
-    endpoint::parse_endpoint,
-    keys,
-    sigv4::{SigV4Signer, encode_uri_path},
-};
 use reqwest::Client;
 use salt::SaltWitness;
 use stateless_common::{decode_witness_payload, witness_encoding::WitnessDecodingError};
 use stateless_core::withdrawals::MptWitness;
+use stateless_r2::{
+    endpoint::parse_endpoint,
+    keys,
+    sigv4::{SigV4Signer, encode_uri_path},
+};
 use tokio::task::JoinError;
-use tracing::{Level, debug, enabled, trace, warn};
+use tracing::{trace, warn};
 
 /// Max retry rounds for retryable (transport/429/5xx) failures before surfacing an error.
 const MAX_RETRIES: usize = 8;
@@ -44,9 +40,8 @@ const MISSING_THROTTLE: Duration = Duration::from_secs(2);
 /// Failure outcome of an R2 witness fetch.
 #[derive(Debug, thiserror::Error)]
 pub enum R2WitnessError {
-    /// The primary object is absent from the bucket (HTTP 404). For blocks known to have a
-    /// witness this is a genuine completeness gap in R2 — the whole point of the validation run
-    /// is to prove this never happens.
+    /// The primary object is absent from the bucket (HTTP 404) — a completeness gap in R2 for
+    /// blocks known to have a witness.
     #[error(
         "R2 witness MISSING for block {number} (key {key}): object not found (404) — R2 completeness gap"
     )]
@@ -64,11 +59,11 @@ pub enum R2WitnessError {
     #[error("R2 unexpected status {status} for block {number} (key {key}): {body}")]
     Status { number: u64, key: String, status: u16, body: String },
     /// The object was fetched but its bytes did not decode to a `(SaltWitness, MptWitness)` tuple
-    /// — a corrupt witness in R2. Deterministic; a finding, not retried.
+    /// — a corrupt witness in R2. Deterministic; not retried.
     #[error("R2 witness for block {number} (key {key}) failed to decode: {source}")]
     Decode { number: u64, key: String, source: WitnessDecodingError },
-    /// The decode task panicked. This is a bug in our own decoder, not evidence about the archive,
-    /// so it is kept out of [`Self::Decode`] — a panic must never masquerade as an R2 finding.
+    /// The decode task panicked. This is a bug in our own decoder, not a problem with the data in
+    /// R2, so it is kept out of [`Self::Decode`].
     #[error("R2 witness decode task for block {number} (key {key}) panicked: {source}")]
     DecodePanicked { number: u64, key: String, source: JoinError },
 }
@@ -137,28 +132,16 @@ impl R2WitnessClient {
         })
     }
 
-    /// The primary witness object key for `(number, hash)`: `block/{range}/{number}.{hash}`.
-    ///
-    /// Built from the same `megaeth-witness-r2` bucketing constants the uploader uses, so it is
-    /// byte-identical to the key that was written. `hash` renders via `B256`'s `Display`
-    /// (lowercase `0x` + 64 hex); the pinned test below guards that against drift.
-    fn block_key(number: u64, hash: B256) -> String {
-        let range_start = keys::block_range_prefix(number);
-        let range_end = range_start + keys::BLOCK_RANGE_SIZE - 1;
-        format!("{}/{range_start}_{range_end}/{number}.{hash}", keys::BLOCK_PREFIX)
-    }
-
     /// Fetches and decodes the witness for `(number, hash)` from R2.
     ///
-    /// Retryable failures (transport/429/5xx) are retried with exponential backoff up to
-    /// [`MAX_RETRIES`] times. `Missing` (404) and `Decode` failures are deterministic and surface
-    /// immediately as findings.
+    /// Transport/429/5xx failures are retried with backoff up to [`MAX_RETRIES`] times;
+    /// `Missing` (404) and `Decode` failures are deterministic and surface immediately.
     pub async fn get_witness(
         &self,
         number: u64,
         hash: B256,
     ) -> Result<(SaltWitness, MptWitness), R2WitnessError> {
-        let key = Self::block_key(number, hash);
+        let key = keys::block_object_key(number, hash);
         let mut backoff = INITIAL_BACKOFF;
         let mut attempt = 0usize;
 
@@ -210,36 +193,7 @@ impl R2WitnessClient {
 
         let status = response.status();
         if status.is_success() {
-            // Snapshot the response headers before `bytes()` consumes `response` — but only when
-            // the log will actually emit, since this sits on the per-block hot path. These prove
-            // the witness came from R2: `cf-ray` / `x-amz-request-id` are Cloudflare/S3 request
-            // ids, and the `x-amz-meta-*` set is the custom metadata the migration/uploader wrote
-            // onto the object — the RPC/KV witness path carries none of it.
-            let headers = enabled!(Level::DEBUG).then(|| response.headers().clone());
             let bytes = response.bytes().await.map_err(transport)?;
-            if let Some(headers) = headers {
-                let hdr =
-                    |name: &str| headers.get(name).and_then(|v| v.to_str().ok()).unwrap_or("");
-                debug!(
-                    block_number = number,
-                    bucket = %self.bucket,
-                    key,
-                    http_status = status.as_u16(),
-                    bytes = bytes.len(),
-                    content_type = hdr("content-type"),
-                    etag = hdr("etag"),
-                    last_modified = hdr("last-modified"),
-                    cf_ray = hdr("cf-ray"),
-                    x_amz_request_id = hdr("x-amz-request-id"),
-                    x_amz_meta_compression = hdr("x-amz-meta-compression"),
-                    x_amz_meta_original_size = hdr("x-amz-meta-original-size"),
-                    x_amz_meta_compressed_size = hdr("x-amz-meta-compressed-size"),
-                    x_amz_meta_sha256 = hdr("x-amz-meta-sha256"),
-                    x_amz_meta_parent_hash = hdr("x-amz-meta-parent-hash"),
-                    x_amz_meta_attr_hash = hdr("x-amz-meta-attr-hash"),
-                    "witness fetched from R2 (S3 GET)",
-                );
-            }
             return Ok(Attempt::Found(bytes));
         }
         let code = status.as_u16();
@@ -262,27 +216,18 @@ mod tests {
 
     use super::*;
 
-    /// Pins the object-key format to a real migrated mainnet key. If `B256`'s `Display` ever
-    /// stopped rendering full lowercase `0x` hex, every GET would 404 — this catches that at
-    /// build time rather than as a silent wall of "missing" in production.
+    /// Guards the one layer `stateless-r2` cannot pin itself: that [`B256`]'s `Display` renders
+    /// full lowercase `0x` hex. If that changed, every GET would 404.
     #[test]
-    fn block_key_matches_migrated_layout() {
+    fn block_object_key_renders_b256_as_lowercase_hex() {
         let hash =
             B256::from_str("0x05dd41e545b25db0ce04f628e6e1705232240c70a0435c8233ac4479176fe6b0")
                 .unwrap();
         assert_eq!(
-            R2WitnessClient::block_key(6_632_136, hash),
+            keys::block_object_key(6_632_136, hash),
             "block/6632000_6632999/6632136.\
              0x05dd41e545b25db0ce04f628e6e1705232240c70a0435c8233ac4479176fe6b0",
         );
-    }
-
-    #[test]
-    fn block_key_buckets_on_thousands() {
-        let h = B256::ZERO;
-        assert!(R2WitnessClient::block_key(0, h).starts_with("block/0_999/0."));
-        assert!(R2WitnessClient::block_key(999, h).starts_with("block/0_999/999."));
-        assert!(R2WitnessClient::block_key(1000, h).starts_with("block/1000_1999/1000."));
     }
 
     #[test]

--- a/bin/stateless-validator/src/r2_witness.rs
+++ b/bin/stateless-validator/src/r2_witness.rs
@@ -35,10 +35,11 @@ use tracing::{trace, warn};
 
 use crate::metrics;
 
-/// Max retry rounds for retryable (transport/429/5xx) failures before surfacing an error.
-/// Stays a local constant while the backoff pacing is injected (see [`R2WitnessClient::new`]):
-/// the RPC path retries unboundedly, so there is no operator flag to mirror.
-const MAX_RETRIES: usize = 8;
+/// Total GET attempts (first try + retries) per fetch for retryable (transport/429/5xx)
+/// failures before the error surfaces. Stays a local constant while the backoff pacing is
+/// injected (see [`R2WitnessClient::new`]): the RPC path retries unboundedly, so there is no
+/// operator flag to mirror.
+const MAX_ATTEMPTS: usize = 9;
 /// Throttle applied before surfacing any deterministic (non-retryable) failure: the pipeline
 /// fetcher (`stateless-core/src/pipeline/fetcher.rs`) re-enqueues failed fetches with no delay,
 /// so returning instantly would hot-loop signed GETs against R2. Delete this once the fetcher
@@ -52,8 +53,16 @@ const MAX_ERROR_BODY_BYTES: usize = 1024;
 /// Failure outcome of an R2 witness fetch.
 #[derive(Debug, thiserror::Error)]
 pub enum R2WitnessError {
-    /// The primary object is absent from the bucket (HTTP 404): a completeness gap in R2, or a
-    /// transient miss near the tip / right after a reorg, before the uploader has PUT the object.
+    /// The primary object is absent from the bucket (HTTP 404 `NoSuchKey`): a transient miss
+    /// near the tip / right after a reorg (the uploader has not PUT the object yet), or a
+    /// permanent completeness gap in R2.
+    ///
+    /// Operator note: the pipeline retries a missing witness indefinitely (each attempt
+    /// throttled by [`DETERMINISTIC_FAILURE_THROTTLE`]). Near the tip that is exactly right —
+    /// the object appears once the uploader wins the race. But on a fixed `--end-block` slice
+    /// over history, a permanently absent object means the run never completes and never
+    /// fails: alert on `r2_witness_errors_total{kind="missing"}` staying hot for the same
+    /// block, and use the object key from this error's log line to check/backfill the bucket.
     #[error("R2 witness MISSING for block {number} (key {key}): object not found (404)")]
     Missing { number: u64, key: String },
     /// Transport-level failure (connection reset/timeout) — the endpoint is effectively
@@ -176,9 +185,13 @@ impl R2WitnessClient {
 
     /// Fetches and decodes the witness for `(number, hash)` from R2.
     ///
-    /// Transport/429/5xx failures are retried up to `MAX_RETRIES` times, paced by the
-    /// `retry_backoff` policy given at construction. Every other failure is deterministic and
-    /// surfaces after a short `DETERMINISTIC_FAILURE_THROTTLE` sleep (see its docs for why).
+    /// Transport/429/5xx failures are retried up to [`MAX_ATTEMPTS`] total attempts, paced by
+    /// the `retry_backoff` policy given at construction. Every surfaced failure pauses before
+    /// returning (the pipeline fetcher re-enqueues failed fetches with zero delay, so returning
+    /// instantly would hot-loop GETs against R2): deterministic failures wait the fixed
+    /// [`DETERMINISTIC_FAILURE_THROTTLE`], and exhausted retryable failures wait the policy's
+    /// `max` backoff — without that, the next fetch cycle would restart its ramp at `initial`,
+    /// re-bursting GETs into the same brownout the exhausted ramp just backed away from.
     pub async fn get_witness(
         &self,
         number: u64,
@@ -187,14 +200,17 @@ impl R2WitnessClient {
         let result = self.get_witness_inner(number, hash).await;
         if let Err(e) = &result {
             metrics::on_r2_witness_error(e.kind());
-            if !e.is_retryable() {
-                tokio::time::sleep(DETERMINISTIC_FAILURE_THROTTLE).await;
-            }
+            let pause = if e.is_retryable() {
+                self.retry_backoff.max
+            } else {
+                DETERMINISTIC_FAILURE_THROTTLE
+            };
+            tokio::time::sleep(pause).await;
         }
         result
     }
 
-    /// [`Self::get_witness`] without the deterministic-failure throttle.
+    /// [`Self::get_witness`] without the surfaced-failure pause.
     async fn get_witness_inner(
         &self,
         number: u64,
@@ -222,7 +238,7 @@ impl R2WitnessClient {
             match outcome {
                 Ok(bytes) => break bytes,
                 Err(e) => {
-                    if !e.is_retryable() || attempt > MAX_RETRIES {
+                    if !e.is_retryable() || attempt >= MAX_ATTEMPTS {
                         return Err(e);
                     }
                     metrics::on_r2_witness_retry();
@@ -290,8 +306,12 @@ impl R2WitnessClient {
             body.truncate(end);
         }
         // A 404 usually means the object is absent (`NoSuchKey`) — but S3 also 404s a missing
-        // *bucket*, which is operator misconfiguration, not a data gap; keep those apart.
-        if code == 404 && !body.contains("NoSuchBucket") {
+        // *bucket*, which is operator misconfiguration, not a data gap; keep those apart by
+        // parsing the S3 XML error code. A 404 with no parseable code (a proxy's bare 404, a
+        // truncated body) still counts as Missing: for a correctly configured endpoint that is
+        // by far the likeliest cause, and misreading a config error as Missing only changes
+        // the metric kind, not the retry behavior.
+        if code == 404 && s3_error_code(&body).is_none_or(|c| c == "NoSuchKey") {
             return Err(R2WitnessError::Missing { number, key: key.to_string() });
         }
         let key = key.to_string();
@@ -301,6 +321,15 @@ impl R2WitnessClient {
             Err(R2WitnessError::Status { number, key, status: code, body })
         }
     }
+}
+
+/// Extracts the value of the first `<Code>…</Code>` element from an S3 XML error body, e.g.
+/// `NoSuchKey` / `NoSuchBucket`. `None` when the body carries no such element (non-XML proxy
+/// response, truncation that ate the element).
+fn s3_error_code(body: &str) -> Option<&str> {
+    let start = body.find("<Code>")? + "<Code>".len();
+    let len = body[start..].find("</Code>")?;
+    Some(&body[start..start + len])
 }
 
 #[cfg(test)]
@@ -438,6 +467,31 @@ mod tests {
         assert!(matches!(err, R2WitnessError::Status { status: 404, .. }), "{err}");
     }
 
+    /// Any parseable S3 code other than `NoSuchKey` on a 404 is not a data gap; a 404 with no
+    /// parseable code (bare proxy 404, truncated body) still counts as Missing.
+    #[tokio::test]
+    async fn only_no_such_key_and_bare_404s_are_missing() {
+        let (endpoint, _) = mock_r2(vec![(404, "<Code>AccessDenied</Code>")]).await;
+        let err = fetch(&endpoint).await.unwrap_err();
+        assert!(matches!(err, R2WitnessError::Status { status: 404, .. }), "{err}");
+
+        let (endpoint, _) = mock_r2(vec![(404, "<html>not found</html>")]).await;
+        let err = fetch(&endpoint).await.unwrap_err();
+        assert!(matches!(err, R2WitnessError::Missing { .. }), "{err}");
+    }
+
+    #[test]
+    fn s3_error_code_parses_real_and_degenerate_bodies() {
+        let real = r#"<?xml version="1.0" encoding="UTF-8"?>
+            <Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message></Error>"#;
+        assert_eq!(s3_error_code(real), Some("NoSuchKey"));
+        assert_eq!(s3_error_code("<Code>NoSuchBucket</Code>"), Some("NoSuchBucket"));
+        assert_eq!(s3_error_code(""), None);
+        assert_eq!(s3_error_code("<html>gateway error</html>"), None);
+        // Truncation that ate the closing tag must not panic or misparse.
+        assert_eq!(s3_error_code("<Error><Code>NoSuchBu"), None);
+    }
+
     #[tokio::test]
     async fn throttled_5xx_retries_until_a_deterministic_answer() {
         let (endpoint, hits) = mock_r2(vec![(503, "SlowDown"), (503, "SlowDown"), (403, "")]).await;
@@ -471,7 +525,29 @@ mod tests {
         let (endpoint, hits) = mock_r2(vec![(503, "overloaded")]).await;
         let err = fetch(&endpoint).await.unwrap_err();
         assert!(matches!(err, R2WitnessError::Throttled { status: 503, .. }), "{err}");
-        assert_eq!(hits.load(Ordering::SeqCst), MAX_RETRIES + 1, "initial attempt + MAX_RETRIES");
+        assert_eq!(hits.load(Ordering::SeqCst), MAX_ATTEMPTS, "exactly MAX_ATTEMPTS GETs");
+    }
+
+    /// Exhausted retryable failures must pause the policy's `max` backoff before surfacing:
+    /// the pipeline fetcher re-enqueues with zero delay, so without the pause the next fetch
+    /// cycle would re-burst a fresh ramp (starting at `initial`) into the same brownout.
+    #[tokio::test]
+    async fn exhausted_retries_pause_max_backoff_before_surfacing() {
+        let (endpoint, hits) = mock_r2(vec![(503, "overloaded")]).await;
+        // The ramp's 8 in-loop sleeps double from 1ms and never reach the 400ms cap
+        // (1+2+…+128 = 255ms before jitter, ≤382ms with the ≤50% jitter), so of the asserted
+        // lower bound, ≥400ms is attributable to the exhaustion pause alone.
+        let (initial, max) = (Duration::from_millis(1), Duration::from_millis(400));
+        let client = client_with_backoff(&endpoint, None, BackoffPolicy::new(initial, max));
+        let started = std::time::Instant::now();
+        let err = client.get_witness(1, B256::ZERO).await.unwrap_err();
+        assert!(matches!(err, R2WitnessError::Throttled { status: 503, .. }), "{err}");
+        assert_eq!(hits.load(Ordering::SeqCst), MAX_ATTEMPTS);
+        assert!(
+            started.elapsed() >= Duration::from_millis(255) + max,
+            "exhausted retries surfaced without the max-backoff pause ({:?})",
+            started.elapsed(),
+        );
     }
 
     /// The only test of the success path (`get_object` → `spawn_blocking` decode): a fixture

--- a/bin/stateless-validator/src/r2_witness.rs
+++ b/bin/stateless-validator/src/r2_witness.rs
@@ -17,9 +17,10 @@ use bytes::Bytes;
 use chrono::Utc;
 use reqwest::Client;
 use salt::SaltWitness;
-use stateless_common::{decode_witness_payload, witness_encoding::WitnessDecodingError};
+use stateless_common::{WitnessDecodingError, decode_witness_payload};
 use stateless_core::withdrawals::MptWitness;
 use stateless_r2::{
+    client::is_throttle_status,
     endpoint::parse_endpoint,
     keys,
     sigv4::{SigV4Signer, encode_uri_path},
@@ -29,25 +30,23 @@ use tracing::{trace, warn};
 
 /// Max retry rounds for retryable (transport/429/5xx) failures before surfacing an error.
 const MAX_RETRIES: usize = 8;
-/// First retry sleep; doubles each round up to [`MAX_BACKOFF`]. (Test builds shrink the sleeps so
-/// the retry-path tests run in milliseconds; the loop logic is identical.)
-#[cfg(not(test))]
-const INITIAL_BACKOFF: Duration = Duration::from_millis(500);
-#[cfg(test)]
-const INITIAL_BACKOFF: Duration = Duration::from_millis(5);
+/// First retry sleep; doubles each round up to [`MAX_BACKOFF`]. Test builds shrink all three
+/// durations so the retry-path tests run in milliseconds; the loop logic is identical.
+const INITIAL_BACKOFF: Duration =
+    if cfg!(test) { Duration::from_millis(5) } else { Duration::from_millis(500) };
 /// Upper bound on any single retry sleep.
-#[cfg(not(test))]
-const MAX_BACKOFF: Duration = Duration::from_secs(30);
-#[cfg(test)]
-const MAX_BACKOFF: Duration = Duration::from_millis(20);
+const MAX_BACKOFF: Duration =
+    if cfg!(test) { Duration::from_millis(20) } else { Duration::from_secs(30) };
 /// Throttle applied before surfacing any deterministic failure (`Missing`, `Status`, `Decode`,
-/// `DecodePanicked`), so the pipeline's immediate re-enqueue of a failed fetch does not hot-loop
-/// signed GETs (and full block re-downloads) against R2 on a wrong credential, a corrupt object,
-/// or a genuine gap.
-#[cfg(not(test))]
-const DETERMINISTIC_FAILURE_THROTTLE: Duration = Duration::from_secs(2);
-#[cfg(test)]
-const DETERMINISTIC_FAILURE_THROTTLE: Duration = Duration::from_millis(5);
+/// `DecodePanicked`): the pipeline fetcher re-enqueues a failed fetch immediately with no delay
+/// (`stateless-core/src/pipeline/fetcher.rs`), so returning instantly would hot-loop signed GETs
+/// (and full block re-downloads) against R2 on a wrong credential, a corrupt object, or a genuine
+/// gap. If the fetcher ever grows per-block re-enqueue backoff, this throttle is the piece to
+/// delete.
+const DETERMINISTIC_FAILURE_THROTTLE: Duration =
+    if cfg!(test) { Duration::from_millis(5) } else { Duration::from_secs(2) };
+/// Cap on the response body carried inside `Throttled`/`Status` errors.
+const MAX_ERROR_BODY_BYTES: usize = 1024;
 
 /// Failure outcome of an R2 witness fetch.
 #[derive(Debug, thiserror::Error)]
@@ -87,15 +86,6 @@ impl R2WitnessError {
     const fn is_retryable(&self) -> bool {
         matches!(self, Self::Transport { .. } | Self::Throttled { .. })
     }
-}
-
-/// Outcome of a single (non-retrying) GET attempt.
-enum Attempt {
-    /// 2xx with the object body. Held as [`Bytes`] (refcounted) so the multi-MB witness is never
-    /// copied between the HTTP response and the decoder.
-    Found(Bytes),
-    /// 404 — object absent.
-    Missing,
 }
 
 /// Fetches witness objects straight from an R2 bucket over the S3 API with SigV4-signed GETs.
@@ -152,10 +142,8 @@ impl R2WitnessClient {
     /// Fetches and decodes the witness for `(number, hash)` from R2.
     ///
     /// Transport/429/5xx failures are retried with backoff up to [`MAX_RETRIES`] times. Every
-    /// other failure is deterministic; it surfaces after a short
-    /// [`DETERMINISTIC_FAILURE_THROTTLE`] sleep, because the pipeline re-enqueues a failed fetch
-    /// immediately and would otherwise hot-loop signed GETs (plus full block re-downloads) against
-    /// R2 on a wrong credential, a corrupt object, or a genuine gap.
+    /// other failure is deterministic and surfaces after a short
+    /// [`DETERMINISTIC_FAILURE_THROTTLE`] sleep (see its docs for why).
     pub async fn get_witness(
         &self,
         number: u64,
@@ -183,8 +171,7 @@ impl R2WitnessClient {
         let bytes = loop {
             attempt += 1;
             match self.get_object(number, &key).await {
-                Ok(Attempt::Found(bytes)) => break bytes,
-                Ok(Attempt::Missing) => return Err(R2WitnessError::Missing { number, key }),
+                Ok(bytes) => break bytes,
                 Err(e) => {
                     if !e.is_retryable() || attempt > MAX_RETRIES {
                         return Err(e);
@@ -207,8 +194,10 @@ impl R2WitnessClient {
         }
     }
 
-    /// Performs one SigV4-signed GET and classifies the response. No retry.
-    async fn get_object(&self, number: u64, key: &str) -> Result<Attempt, R2WitnessError> {
+    /// Performs one SigV4-signed GET and classifies the response. No retry. The body comes back
+    /// as [`Bytes`] (refcounted), so the multi-MB witness is never copied between the HTTP
+    /// response and the decoder.
+    async fn get_object(&self, number: u64, key: &str) -> Result<Bytes, R2WitnessError> {
         let canonical_uri = encode_uri_path(&self.bucket, key);
         let url = format!("{}{}", self.endpoint, canonical_uri);
         // Signed-payload mode with an empty body: x-amz-content-sha256 = sha256("").
@@ -223,18 +212,27 @@ impl R2WitnessClient {
 
         let status = response.status();
         if status.is_success() {
-            let bytes = response.bytes().await.map_err(transport)?;
-            return Ok(Attempt::Found(bytes));
+            return response.bytes().await.map_err(transport);
         }
         let code = status.as_u16();
-        let body = response.text().await.unwrap_or_default();
+        let mut body = response.text().await.unwrap_or_default();
+        // Cap the body carried in the error (and re-printed by the retry `warn!`): real R2 error
+        // bodies are a few hundred bytes of XML, but a misconfigured endpoint fronted by a
+        // verbose proxy can return arbitrarily large HTML.
+        if body.len() > MAX_ERROR_BODY_BYTES {
+            let mut end = MAX_ERROR_BODY_BYTES;
+            while !body.is_char_boundary(end) {
+                end -= 1;
+            }
+            body.truncate(end);
+        }
         // A 404 usually means the object is absent (`NoSuchKey`) — but S3 also 404s a missing
         // *bucket*, which is operator misconfiguration, not a data gap; keep those apart.
         if code == 404 && !body.contains("NoSuchBucket") {
-            return Ok(Attempt::Missing);
+            return Err(R2WitnessError::Missing { number, key: key.to_string() });
         }
         let key = key.to_string();
-        if code == 429 || code >= 500 {
+        if is_throttle_status(code) {
             Err(R2WitnessError::Throttled { number, key, status: code, body })
         } else {
             Err(R2WitnessError::Status { number, key, status: code, body })
@@ -299,13 +297,10 @@ mod tests {
                 // Drain the request head before replying.
                 let mut buf = [0u8; 4096];
                 let _ = sock.read(&mut buf).await;
-                let reason = match status {
-                    200 => "OK",
-                    301 => "Moved Permanently",
-                    _ => "X",
-                };
+                // The reason phrase is never interpreted, and `location` is load-bearing only for
+                // the 3xx (redirects-not-followed) test — harmless noise on other statuses.
                 let response = format!(
-                    "HTTP/1.1 {status} {reason}\r\nconnection: close\r\n\
+                    "HTTP/1.1 {status} X\r\nconnection: close\r\n\
                      location: http://example.invalid/elsewhere\r\n\
                      content-length: {}\r\n\r\n{body}",
                     body.len(),

--- a/bin/stateless-validator/src/r2_witness.rs
+++ b/bin/stateless-validator/src/r2_witness.rs
@@ -29,22 +29,34 @@ use tracing::{trace, warn};
 
 /// Max retry rounds for retryable (transport/429/5xx) failures before surfacing an error.
 const MAX_RETRIES: usize = 8;
-/// First retry sleep; doubles each round up to [`MAX_BACKOFF`].
+/// First retry sleep; doubles each round up to [`MAX_BACKOFF`]. (Test builds shrink the sleeps so
+/// the retry-path tests run in milliseconds; the loop logic is identical.)
+#[cfg(not(test))]
 const INITIAL_BACKOFF: Duration = Duration::from_millis(500);
+#[cfg(test)]
+const INITIAL_BACKOFF: Duration = Duration::from_millis(5);
 /// Upper bound on any single retry sleep.
+#[cfg(not(test))]
 const MAX_BACKOFF: Duration = Duration::from_secs(30);
-/// Throttle applied before surfacing a `Missing` (404), so the pipeline's immediate re-enqueue of
-/// a failed fetch does not hot-spin GETs against R2 on a genuine gap.
-const MISSING_THROTTLE: Duration = Duration::from_secs(2);
+#[cfg(test)]
+const MAX_BACKOFF: Duration = Duration::from_millis(20);
+/// Throttle applied before surfacing any deterministic failure (`Missing`, `Status`, `Decode`,
+/// `DecodePanicked`), so the pipeline's immediate re-enqueue of a failed fetch does not hot-loop
+/// signed GETs (and full block re-downloads) against R2 on a wrong credential, a corrupt object,
+/// or a genuine gap.
+#[cfg(not(test))]
+const DETERMINISTIC_FAILURE_THROTTLE: Duration = Duration::from_secs(2);
+#[cfg(test)]
+const DETERMINISTIC_FAILURE_THROTTLE: Duration = Duration::from_millis(5);
 
 /// Failure outcome of an R2 witness fetch.
 #[derive(Debug, thiserror::Error)]
 pub enum R2WitnessError {
-    /// The primary object is absent from the bucket (HTTP 404) — a completeness gap in R2 for
-    /// blocks known to have a witness.
-    #[error(
-        "R2 witness MISSING for block {number} (key {key}): object not found (404) — R2 completeness gap"
-    )]
+    /// The primary object is absent from the bucket (HTTP 404). For a block known to have a
+    /// witness this is a completeness gap in R2, but near the tip (or right after a reorg) it can
+    /// also fire transiently before the uploader has PUT the object — the retry that follows the
+    /// pipeline's re-enqueue resolves those.
+    #[error("R2 witness MISSING for block {number} (key {key}): object not found (404)")]
     Missing { number: u64, key: String },
     /// Transport-level failure (connection reset/timeout) — the endpoint is effectively
     /// unreachable. Retried internally with backoff before surfacing.
@@ -54,8 +66,9 @@ pub enum R2WitnessError {
     /// overload / SlowDown). Retried internally with backoff before surfacing.
     #[error("R2 throttled/server error {status} for block {number} (key {key}): {body}")]
     Throttled { number: u64, key: String, status: u16, body: String },
-    /// A non-success status unlikely to clear on retry (typically 4xx other than 429 — e.g. 403
-    /// SignatureDoesNotMatch from bad credentials or a malformed endpoint).
+    /// A non-success status unlikely to clear on retry: 4xx other than 429 (e.g. 403
+    /// SignatureDoesNotMatch from bad credentials, 404 NoSuchBucket from a wrong bucket name) or a
+    /// 3xx (redirects are never followed — a signed GET cannot survive one).
     #[error("R2 unexpected status {status} for block {number} (key {key}): {body}")]
     Status { number: u64, key: String, status: u16, body: String },
     /// The object was fetched but its bytes did not decode to a `(SaltWitness, MptWitness)` tuple
@@ -121,6 +134,10 @@ impl R2WitnessClient {
         }
         let http = Client::builder()
             .timeout(per_attempt_timeout)
+            // A SigV4-signed GET can never survive a redirect (reqwest strips `authorization` on
+            // cross-host hops, and a same-host hop invalidates the signed URI), so following one
+            // just turns the real cause into a baffling 403. Surface the 3xx as a `Status` error.
+            .redirect(reqwest::redirect::Policy::none())
             .build()
             .map_err(|e| eyre::eyre!("Failed to build R2 HTTP client: {e}"))?;
         Ok(Self {
@@ -134,9 +151,27 @@ impl R2WitnessClient {
 
     /// Fetches and decodes the witness for `(number, hash)` from R2.
     ///
-    /// Transport/429/5xx failures are retried with backoff up to [`MAX_RETRIES`] times;
-    /// `Missing` (404) and `Decode` failures are deterministic and surface immediately.
+    /// Transport/429/5xx failures are retried with backoff up to [`MAX_RETRIES`] times. Every
+    /// other failure is deterministic; it surfaces after a short
+    /// [`DETERMINISTIC_FAILURE_THROTTLE`] sleep, because the pipeline re-enqueues a failed fetch
+    /// immediately and would otherwise hot-loop signed GETs (plus full block re-downloads) against
+    /// R2 on a wrong credential, a corrupt object, or a genuine gap.
     pub async fn get_witness(
+        &self,
+        number: u64,
+        hash: B256,
+    ) -> Result<(SaltWitness, MptWitness), R2WitnessError> {
+        let result = self.get_witness_inner(number, hash).await;
+        if let Err(e) = &result &&
+            !e.is_retryable()
+        {
+            tokio::time::sleep(DETERMINISTIC_FAILURE_THROTTLE).await;
+        }
+        result
+    }
+
+    /// [`Self::get_witness`] without the deterministic-failure throttle.
+    async fn get_witness_inner(
         &self,
         number: u64,
         hash: B256,
@@ -149,12 +184,7 @@ impl R2WitnessClient {
             attempt += 1;
             match self.get_object(number, &key).await {
                 Ok(Attempt::Found(bytes)) => break bytes,
-                Ok(Attempt::Missing) => {
-                    // Deterministic gap. Sleep briefly first: the fetcher re-enqueues a failed
-                    // fetch immediately, so returning instantly would hot-loop 404s against R2.
-                    tokio::time::sleep(MISSING_THROTTLE).await;
-                    return Err(R2WitnessError::Missing { number, key });
-                }
+                Ok(Attempt::Missing) => return Err(R2WitnessError::Missing { number, key }),
                 Err(e) => {
                     if !e.is_retryable() || attempt > MAX_RETRIES {
                         return Err(e);
@@ -197,10 +227,12 @@ impl R2WitnessClient {
             return Ok(Attempt::Found(bytes));
         }
         let code = status.as_u16();
-        if code == 404 {
+        let body = response.text().await.unwrap_or_default();
+        // A 404 usually means the object is absent (`NoSuchKey`) — but S3 also 404s a missing
+        // *bucket*, which is operator misconfiguration, not a data gap; keep those apart.
+        if code == 404 && !body.contains("NoSuchBucket") {
             return Ok(Attempt::Missing);
         }
-        let body = response.text().await.unwrap_or_default();
         let key = key.to_string();
         if code == 429 || code >= 500 {
             Err(R2WitnessError::Throttled { number, key, status: code, body })
@@ -212,7 +244,15 @@ impl R2WitnessClient {
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
+    use std::{
+        str::FromStr,
+        sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        },
+    };
+
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
     use super::*;
 
@@ -242,5 +282,124 @@ mod tests {
         )
         .unwrap_err();
         assert!(err.to_string().contains("Invalid R2 endpoint"));
+    }
+
+    /// Serves one scripted HTTP/1.1 response per connection on a local port and counts requests.
+    /// The last response repeats if more connections arrive than were scripted.
+    async fn mock_r2(responses: Vec<(u16, &'static str)>) -> (String, Arc<AtomicUsize>) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let endpoint = format!("http://{}", listener.local_addr().unwrap());
+        let hits = Arc::new(AtomicUsize::new(0));
+        let counter = hits.clone();
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut sock, _)) = listener.accept().await else { return };
+                let n = counter.fetch_add(1, Ordering::SeqCst);
+                let (status, body) = responses[n.min(responses.len() - 1)];
+                // Drain the request head before replying.
+                let mut buf = [0u8; 4096];
+                let _ = sock.read(&mut buf).await;
+                let reason = match status {
+                    200 => "OK",
+                    301 => "Moved Permanently",
+                    _ => "X",
+                };
+                let response = format!(
+                    "HTTP/1.1 {status} {reason}\r\nconnection: close\r\n\
+                     location: http://example.invalid/elsewhere\r\n\
+                     content-length: {}\r\n\r\n{body}",
+                    body.len(),
+                );
+                let _ = sock.write_all(response.as_bytes()).await;
+            }
+        });
+        (endpoint, hits)
+    }
+
+    fn client(endpoint: &str) -> R2WitnessClient {
+        R2WitnessClient::new(
+            endpoint,
+            "witness-test".to_string(),
+            "ak".to_string(),
+            "sk".to_string(),
+            Duration::from_secs(5),
+        )
+        .unwrap()
+    }
+
+    async fn fetch(endpoint: &str) -> Result<(SaltWitness, MptWitness), R2WitnessError> {
+        client(endpoint).get_witness(1, B256::ZERO).await
+    }
+
+    #[tokio::test]
+    async fn status_4xx_surfaces_without_retry() {
+        let (endpoint, hits) = mock_r2(vec![(403, "SignatureDoesNotMatch")]).await;
+        let err = fetch(&endpoint).await.unwrap_err();
+        assert!(matches!(err, R2WitnessError::Status { status: 403, .. }), "{err}");
+        assert_eq!(hits.load(Ordering::SeqCst), 1, "4xx must not be retried");
+    }
+
+    #[tokio::test]
+    async fn missing_404_surfaces_without_retry() {
+        let (endpoint, hits) = mock_r2(vec![(404, "<Code>NoSuchKey</Code>")]).await;
+        let err = fetch(&endpoint).await.unwrap_err();
+        assert!(matches!(err, R2WitnessError::Missing { number: 1, .. }), "{err}");
+        assert_eq!(hits.load(Ordering::SeqCst), 1, "404 must not be retried");
+    }
+
+    #[tokio::test]
+    async fn missing_bucket_404_is_a_config_error_not_a_gap() {
+        let (endpoint, _) = mock_r2(vec![(404, "<Code>NoSuchBucket</Code>")]).await;
+        let err = fetch(&endpoint).await.unwrap_err();
+        assert!(matches!(err, R2WitnessError::Status { status: 404, .. }), "{err}");
+    }
+
+    #[tokio::test]
+    async fn throttled_5xx_retries_until_a_deterministic_answer() {
+        let (endpoint, hits) = mock_r2(vec![(503, "SlowDown"), (503, "SlowDown"), (403, "")]).await;
+        let err = fetch(&endpoint).await.unwrap_err();
+        assert!(matches!(err, R2WitnessError::Status { status: 403, .. }), "{err}");
+        assert_eq!(hits.load(Ordering::SeqCst), 3, "5xx must be retried, 4xx must stop the loop");
+    }
+
+    #[tokio::test]
+    async fn persistent_5xx_exhausts_retries_and_surfaces_throttled() {
+        let (endpoint, hits) = mock_r2(vec![(503, "overloaded")]).await;
+        let err = fetch(&endpoint).await.unwrap_err();
+        assert!(matches!(err, R2WitnessError::Throttled { status: 503, .. }), "{err}");
+        assert_eq!(hits.load(Ordering::SeqCst), MAX_RETRIES + 1, "initial attempt + MAX_RETRIES");
+    }
+
+    #[tokio::test]
+    async fn undecodable_body_surfaces_decode_without_retry() {
+        let (endpoint, hits) = mock_r2(vec![(200, "not a zstd witness")]).await;
+        let err = fetch(&endpoint).await.unwrap_err();
+        assert!(matches!(err, R2WitnessError::Decode { .. }), "{err}");
+        assert_eq!(hits.load(Ordering::SeqCst), 1, "a corrupt object must not be re-downloaded");
+    }
+
+    #[tokio::test]
+    async fn redirects_are_not_followed() {
+        // A signed GET cannot survive a redirect; the 3xx must surface instead of a spurious 403
+        // from the redirect target (which would also leak the request outside the endpoint).
+        let (endpoint, hits) = mock_r2(vec![(301, "moved")]).await;
+        let err = fetch(&endpoint).await.unwrap_err();
+        assert!(matches!(err, R2WitnessError::Status { status: 301, .. }), "{err}");
+        assert_eq!(hits.load(Ordering::SeqCst), 1);
+    }
+
+    /// Every deterministic failure must be throttled before surfacing — the pipeline re-enqueues
+    /// failed fetches immediately, so an unthrottled return hot-loops GETs against R2.
+    #[tokio::test]
+    async fn deterministic_failures_are_throttled_before_surfacing() {
+        for (status, body) in [(403, ""), (404, ""), (200, "garbage")] {
+            let (endpoint, _) = mock_r2(vec![(status, body)]).await;
+            let started = std::time::Instant::now();
+            fetch(&endpoint).await.unwrap_err();
+            assert!(
+                started.elapsed() >= DETERMINISTIC_FAILURE_THROTTLE,
+                "status {status} surfaced without the deterministic-failure throttle",
+            );
+        }
     }
 }

--- a/bin/stateless-validator/src/r2_witness.rs
+++ b/bin/stateless-validator/src/r2_witness.rs
@@ -36,18 +36,16 @@ use crate::metrics;
 /// Max retry rounds for retryable (transport/429/5xx) failures before surfacing an error.
 const MAX_RETRIES: usize = 8;
 /// First retry sleep; doubles each round up to [`MAX_BACKOFF`]. Test builds shrink all three
-/// durations so the retry-path tests run in milliseconds; the loop logic is identical.
+/// durations so the retry-path tests run in milliseconds.
 const INITIAL_BACKOFF: Duration =
     if cfg!(test) { Duration::from_millis(5) } else { Duration::from_millis(500) };
 /// Upper bound on any single retry sleep.
 const MAX_BACKOFF: Duration =
     if cfg!(test) { Duration::from_millis(20) } else { Duration::from_secs(30) };
-/// Throttle applied before surfacing any deterministic failure (`Missing`, `Status`, `Decode`,
-/// `DecodePanicked`): the pipeline fetcher re-enqueues a failed fetch immediately with no delay
-/// (`stateless-core/src/pipeline/fetcher.rs`), so returning instantly would hot-loop signed GETs
-/// (and full block re-downloads) against R2 on a wrong credential, a corrupt object, or a genuine
-/// gap. If the fetcher ever grows per-block re-enqueue backoff, this throttle is the piece to
-/// delete.
+/// Throttle applied before surfacing any deterministic (non-retryable) failure: the pipeline
+/// fetcher (`stateless-core/src/pipeline/fetcher.rs`) re-enqueues failed fetches with no delay,
+/// so returning instantly would hot-loop signed GETs against R2. Delete this once the fetcher
+/// grows per-block re-enqueue backoff.
 const DETERMINISTIC_FAILURE_THROTTLE: Duration =
     if cfg!(test) { Duration::from_millis(5) } else { Duration::from_secs(2) };
 /// Cap on the response body carried inside `Throttled`/`Status` errors.
@@ -56,10 +54,8 @@ const MAX_ERROR_BODY_BYTES: usize = 1024;
 /// Failure outcome of an R2 witness fetch.
 #[derive(Debug, thiserror::Error)]
 pub enum R2WitnessError {
-    /// The primary object is absent from the bucket (HTTP 404). For a block known to have a
-    /// witness this is a completeness gap in R2, but near the tip (or right after a reorg) it can
-    /// also fire transiently before the uploader has PUT the object — the retry that follows the
-    /// pipeline's re-enqueue resolves those.
+    /// The primary object is absent from the bucket (HTTP 404): a completeness gap in R2, or a
+    /// transient miss near the tip / right after a reorg, before the uploader has PUT the object.
     #[error("R2 witness MISSING for block {number} (key {key}): object not found (404)")]
     Missing { number: u64, key: String },
     /// Transport-level failure (connection reset/timeout) — the endpoint is effectively
@@ -70,9 +66,9 @@ pub enum R2WitnessError {
     /// overload / SlowDown). Retried internally with backoff before surfacing.
     #[error("R2 throttled/server error {status} for block {number} (key {key}): {body}")]
     Throttled { number: u64, key: String, status: u16, body: String },
-    /// A non-success status unlikely to clear on retry: 4xx other than 429 (e.g. 403
-    /// SignatureDoesNotMatch from bad credentials, 404 NoSuchBucket from a wrong bucket name) or a
-    /// 3xx (redirects are never followed — a signed GET cannot survive one).
+    /// A non-success status unlikely to clear on retry: a 4xx other than 429 (e.g. 403 bad
+    /// credentials, 404 NoSuchBucket) or a 3xx (redirects are never followed — see
+    /// [`R2WitnessClient::new`]).
     #[error("R2 unexpected status {status} for block {number} (key {key}): {body}")]
     Status { number: u64, key: String, status: u16, body: String },
     /// The object was fetched but its bytes did not decode to a `(SaltWitness, MptWitness)` tuple
@@ -124,9 +120,8 @@ pub struct R2WitnessClient {
     /// SigV4 canonical host (`host[:port]`).
     host: String,
     bucket: String,
-    /// Caps concurrent GETs, honoring `--witness-max-concurrent-requests` — the documented
-    /// knob for bounding witness I/O (the RPC witness path enforces it with its own semaphore
-    /// inside `RpcClient`, which this client bypasses).
+    /// Caps concurrent GETs, honoring `--witness-max-concurrent-requests` (the RPC witness path
+    /// enforces it inside `RpcClient`, which R2 mode bypasses).
     concurrency: Arc<Semaphore>,
 }
 
@@ -199,10 +194,8 @@ impl R2WitnessClient {
         hash: B256,
     ) -> Result<(SaltWitness, MptWitness), R2WitnessError> {
         let started = Instant::now();
-        // Time queued on the concurrency cap, subtracted from the fetch-duration metric below:
-        // queue wait is self-imposed by `--witness-max-concurrent-requests`, and folding it in
-        // would make the histogram indistinguishable from genuine R2 slowness. (The RPC witness
-        // path likewise starts its attempt timer only after acquiring its permit.)
+        // Subtracted from the fetch-duration metric below: queue wait on the concurrency cap is
+        // self-imposed, and folded in it would masquerade as R2 slowness.
         let mut queue_wait = Duration::ZERO;
         let key = keys::block_object_key(number, hash);
         let mut backoff = INITIAL_BACKOFF;
@@ -210,9 +203,8 @@ impl R2WitnessClient {
 
         let bytes = loop {
             attempt += 1;
-            // The permit is scoped to the request itself — holding it across the backoff sleep
-            // or the decode below would waste capacity other fetches could use. Mirrors the RPC
-            // path, which acquires its witness permit per attempt inside the retry loop.
+            // Permit scoped to the GET itself — holding it across the backoff sleep or the
+            // decode below would waste capacity other fetches could use.
             let outcome = {
                 let queued = Instant::now();
                 let _permit = self.concurrency.acquire().await.expect("semaphore is never closed");
@@ -355,8 +347,8 @@ mod tests {
                 // Drain the request head before replying.
                 let mut buf = [0u8; 4096];
                 let _ = sock.read(&mut buf).await;
-                // The reason phrase is never interpreted, and `location` is load-bearing only for
-                // the 3xx (redirects-not-followed) test — harmless noise on other statuses.
+                // The reason phrase is never interpreted; `location` matters only to the
+                // redirects-not-followed test.
                 let head = format!(
                     "HTTP/1.1 {status} X\r\nconnection: close\r\n\
                      location: http://example.invalid/elsewhere\r\n\
@@ -429,10 +421,9 @@ mod tests {
         assert_eq!(hits.load(Ordering::SeqCst), MAX_RETRIES + 1, "initial attempt + MAX_RETRIES");
     }
 
-    /// End-to-end happy path: a real fixture witness encoded exactly as the uploader writes it
-    /// (`encode_witness_payload`) and served with a 200 must decode back to the original tuple in
-    /// a single GET. This is the only test that exercises the success path of
-    /// `get_object` → `spawn_blocking` decode; the failure tests can't prove it.
+    /// The only test of the success path (`get_object` → `spawn_blocking` decode): a fixture
+    /// witness encoded with the uploader's `encode_witness_payload` must round-trip to the
+    /// original tuple.
     #[tokio::test]
     async fn valid_object_decodes_end_to_end() {
         use stateless_test_utils::fixtures::TestFixtures;
@@ -463,27 +454,22 @@ mod tests {
 
     #[tokio::test]
     async fn redirects_are_not_followed() {
-        // A signed GET cannot survive a redirect; the 3xx must surface instead of a spurious 403
-        // from the redirect target (which would also leak the request outside the endpoint).
         let (endpoint, hits) = mock_r2(vec![(301, "moved")]).await;
         let err = fetch(&endpoint).await.unwrap_err();
         assert!(matches!(err, R2WitnessError::Status { status: 301, .. }), "{err}");
         assert_eq!(hits.load(Ordering::SeqCst), 1);
     }
 
-    /// `--witness-max-concurrent-requests` is the documented knob for bounding witness I/O, and
-    /// in R2 mode this client is the only thing enforcing it (the `RpcClient` witness semaphore
-    /// is bypassed). Six concurrent fetches against a limit of 2 must never have more than two
-    /// GETs in flight at once.
+    /// In R2 mode this client is the only enforcement of `--witness-max-concurrent-requests`:
+    /// six concurrent fetches against a limit of 2 must never exceed two in-flight GETs.
     #[tokio::test]
     async fn concurrency_limit_bounds_in_flight_gets() {
         const LIMIT: usize = 2;
         const FETCHES: u64 = 6;
 
-        // Handles each connection in its own task (unlike `mock_r2`, which serves one at a
-        // time and so cannot observe concurrency), tracking the in-flight high-water mark.
-        // Responses are held open long enough for the other fetches to pile up behind the
-        // semaphore, then answered 404 (a deterministic error → exactly one GET per fetch).
+        // Per-connection tasks (unlike `mock_r2`, which serves serially) track the in-flight
+        // high-water mark; each response is held 50ms so fetches pile up behind the semaphore,
+        // then answered 404 (deterministic → exactly one GET per fetch).
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let endpoint = format!("http://{}", listener.local_addr().unwrap());
         let in_flight = Arc::new(AtomicUsize::new(0));
@@ -527,8 +513,8 @@ mod tests {
         assert_eq!(peak, LIMIT, "expected the fetches to saturate the concurrency limit");
     }
 
-    /// Every deterministic failure must be throttled before surfacing — the pipeline re-enqueues
-    /// failed fetches immediately, so an unthrottled return hot-loops GETs against R2.
+    /// Every deterministic failure must be throttled before surfacing (see
+    /// [`DETERMINISTIC_FAILURE_THROTTLE`] for why).
     #[tokio::test]
     async fn deterministic_failures_are_throttled_before_surfacing() {
         for (status, body) in [(403, ""), (404, ""), (200, "garbage")] {

--- a/bin/stateless-validator/src/r2_witness.rs
+++ b/bin/stateless-validator/src/r2_witness.rs
@@ -10,7 +10,10 @@
 //! uploader's `encode_witness_payload`), which [`stateless_common::decode_witness_payload`]
 //! inverts exactly.
 
-use std::time::{Duration, Instant};
+use std::{
+    sync::Arc,
+    time::{Duration, Instant},
+};
 
 use alloy_primitives::B256;
 use bytes::Bytes;
@@ -25,7 +28,7 @@ use stateless_r2::{
     keys,
     sigv4::{SigV4Signer, encode_uri_path},
 };
-use tokio::task::JoinError;
+use tokio::{sync::Semaphore, task::JoinError};
 use tracing::{trace, warn};
 
 use crate::metrics;
@@ -121,12 +124,18 @@ pub struct R2WitnessClient {
     /// SigV4 canonical host (`host[:port]`).
     host: String,
     bucket: String,
+    /// Caps concurrent GETs, honoring `--witness-max-concurrent-requests` — the documented
+    /// knob for bounding witness I/O (the RPC witness path enforces it with its own semaphore
+    /// inside `RpcClient`, which this client bypasses).
+    concurrency: Arc<Semaphore>,
 }
 
 impl R2WitnessClient {
     /// Builds a client from an R2 endpoint origin, bucket, and bucket-scoped S3 credentials.
     ///
-    /// `per_attempt_timeout` bounds each individual GET. Fails if the endpoint is not a bare
+    /// `per_attempt_timeout` bounds each individual GET. `max_concurrent_requests` caps the
+    /// number of GETs in flight at once (`None` = unlimited, `Some(0)` clamps to 1 — same
+    /// semantics as the RPC witness semaphore). Fails if the endpoint is not a bare
     /// `scheme://host[:port]` origin (see [`parse_endpoint`]) or the HTTP client cannot be built.
     pub fn new(
         endpoint: &str,
@@ -134,6 +143,7 @@ impl R2WitnessClient {
         access_key_id: String,
         secret_access_key: String,
         per_attempt_timeout: Duration,
+        max_concurrent_requests: Option<usize>,
     ) -> eyre::Result<Self> {
         let (origin, host) = parse_endpoint(endpoint);
         if host.is_empty() {
@@ -156,6 +166,9 @@ impl R2WitnessClient {
             endpoint: origin,
             host,
             bucket,
+            concurrency: Arc::new(Semaphore::new(
+                max_concurrent_requests.unwrap_or(Semaphore::MAX_PERMITS).max(1),
+            )),
         })
     }
 
@@ -186,13 +199,27 @@ impl R2WitnessClient {
         hash: B256,
     ) -> Result<(SaltWitness, MptWitness), R2WitnessError> {
         let started = Instant::now();
+        // Time queued on the concurrency cap, subtracted from the fetch-duration metric below:
+        // queue wait is self-imposed by `--witness-max-concurrent-requests`, and folding it in
+        // would make the histogram indistinguishable from genuine R2 slowness. (The RPC witness
+        // path likewise starts its attempt timer only after acquiring its permit.)
+        let mut queue_wait = Duration::ZERO;
         let key = keys::block_object_key(number, hash);
         let mut backoff = INITIAL_BACKOFF;
         let mut attempt = 0usize;
 
         let bytes = loop {
             attempt += 1;
-            match self.get_object(number, &key).await {
+            // The permit is scoped to the request itself — holding it across the backoff sleep
+            // or the decode below would waste capacity other fetches could use. Mirrors the RPC
+            // path, which acquires its witness permit per attempt inside the retry loop.
+            let outcome = {
+                let queued = Instant::now();
+                let _permit = self.concurrency.acquire().await.expect("semaphore is never closed");
+                queue_wait += queued.elapsed();
+                self.get_object(number, &key).await
+            };
+            match outcome {
                 Ok(bytes) => break bytes,
                 Err(e) => {
                     if !e.is_retryable() || attempt > MAX_RETRIES {
@@ -211,7 +238,7 @@ impl R2WitnessClient {
             Ok(Ok(witness)) => {
                 trace!(number, "R2 witness fetched and decoded");
                 metrics::on_r2_witness_fetch_success(
-                    started.elapsed().as_secs_f64(),
+                    started.elapsed().saturating_sub(queue_wait).as_secs_f64(),
                     WitnessSizeBreakdown::new(&witness.0, &witness.1),
                 );
                 Ok(witness)
@@ -304,6 +331,7 @@ mod tests {
             "ak".to_string(),
             "sk".to_string(),
             Duration::from_secs(20),
+            None,
         )
         .unwrap_err();
         assert!(err.to_string().contains("Invalid R2 endpoint"));
@@ -343,12 +371,17 @@ mod tests {
     }
 
     fn client(endpoint: &str) -> R2WitnessClient {
+        client_with_limit(endpoint, None)
+    }
+
+    fn client_with_limit(endpoint: &str, limit: Option<usize>) -> R2WitnessClient {
         R2WitnessClient::new(
             endpoint,
             "witness-test".to_string(),
             "ak".to_string(),
             "sk".to_string(),
             Duration::from_secs(5),
+            limit,
         )
         .unwrap()
     }
@@ -436,6 +469,62 @@ mod tests {
         let err = fetch(&endpoint).await.unwrap_err();
         assert!(matches!(err, R2WitnessError::Status { status: 301, .. }), "{err}");
         assert_eq!(hits.load(Ordering::SeqCst), 1);
+    }
+
+    /// `--witness-max-concurrent-requests` is the documented knob for bounding witness I/O, and
+    /// in R2 mode this client is the only thing enforcing it (the `RpcClient` witness semaphore
+    /// is bypassed). Six concurrent fetches against a limit of 2 must never have more than two
+    /// GETs in flight at once.
+    #[tokio::test]
+    async fn concurrency_limit_bounds_in_flight_gets() {
+        const LIMIT: usize = 2;
+        const FETCHES: u64 = 6;
+
+        // Handles each connection in its own task (unlike `mock_r2`, which serves one at a
+        // time and so cannot observe concurrency), tracking the in-flight high-water mark.
+        // Responses are held open long enough for the other fetches to pile up behind the
+        // semaphore, then answered 404 (a deterministic error → exactly one GET per fetch).
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let endpoint = format!("http://{}", listener.local_addr().unwrap());
+        let in_flight = Arc::new(AtomicUsize::new(0));
+        let peak = Arc::new(AtomicUsize::new(0));
+        {
+            let (in_flight, peak) = (in_flight.clone(), peak.clone());
+            tokio::spawn(async move {
+                loop {
+                    let Ok((mut sock, _)) = listener.accept().await else { return };
+                    let (in_flight, peak) = (in_flight.clone(), peak.clone());
+                    tokio::spawn(async move {
+                        let now = in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+                        peak.fetch_max(now, Ordering::SeqCst);
+                        let mut buf = [0u8; 4096];
+                        let _ = sock.read(&mut buf).await;
+                        tokio::time::sleep(Duration::from_millis(50)).await;
+                        let response =
+                            "HTTP/1.1 404 X\r\nconnection: close\r\ncontent-length: 0\r\n\r\n";
+                        let _ = sock.write_all(response.as_bytes()).await;
+                        in_flight.fetch_sub(1, Ordering::SeqCst);
+                    });
+                }
+            });
+        }
+
+        let client = client_with_limit(&endpoint, Some(LIMIT));
+        let mut fetches = tokio::task::JoinSet::new();
+        for number in 0..FETCHES {
+            let client = client.clone();
+            fetches.spawn(async move { client.get_witness(number, B256::ZERO).await });
+        }
+        while let Some(result) = fetches.join_next().await {
+            let err = result.unwrap().unwrap_err();
+            assert!(matches!(err, R2WitnessError::Missing { .. }), "{err}");
+        }
+
+        let peak = peak.load(Ordering::SeqCst);
+        assert!(peak <= LIMIT, "peak in-flight GETs {peak} exceeded the limit {LIMIT}");
+        // Liveness guard: with six fetches, a 2-permit semaphore, and 50ms-held responses,
+        // the limit must actually be reached — otherwise this test can't have observed it.
+        assert_eq!(peak, LIMIT, "expected the fetches to saturate the concurrency limit");
     }
 
     /// Every deterministic failure must be throttled before surfacing — the pipeline re-enqueues

--- a/bin/stateless-validator/src/r2_witness.rs
+++ b/bin/stateless-validator/src/r2_witness.rs
@@ -1,0 +1,291 @@
+//! Direct-from-R2 witness source for end-to-end validation of the migrated archive.
+//!
+//! The production validator fetches witnesses over `mega_getBlockWitness`, which transparently
+//! falls back to KV — so a block validating successfully does **not** prove its witness actually
+//! came from R2. This client bypasses the RPC entirely: it fetches the primary witness object
+//! straight from the R2 bucket over the S3 API (a SigV4-signed `GET`), decompresses it, and
+//! returns the same `(SaltWitness, MptWitness)` tuple the RPC path yields. Pointing the validator
+//! at this source and replaying a block range therefore proves every witness is present and
+//! correct in R2 alone.
+//!
+//! The object-key layout, SigV4 signer, and endpoint parsing are reused from `megaeth-witness-r2`
+//! — the very crate the witness generator and the replayer uploader write with — so the read path
+//! here cannot drift from the write path. The primary object body is
+//! `zstd(bincode-legacy((SaltWitness, MptWitness)))` (see the uploader's `encode_witness_payload`),
+//! which [`stateless_common::decode_witness_payload`] inverts exactly.
+
+use std::time::{Duration, Instant};
+
+use alloy_primitives::B256;
+use chrono::Utc;
+use megaeth_witness_r2::{
+    endpoint::parse_endpoint,
+    keys,
+    sigv4::{encode_uri_path, SigV4Signer},
+};
+use reqwest::Client;
+use salt::SaltWitness;
+use stateless_common::decode_witness_payload;
+use stateless_core::withdrawals::MptWitness;
+use tracing::{trace, warn};
+
+/// Failure outcome of an R2 witness fetch.
+#[derive(Debug, thiserror::Error)]
+pub enum R2WitnessError {
+    /// The primary object is absent from the bucket (HTTP 404). For blocks known to have a
+    /// witness this is a genuine completeness gap in R2 — the whole point of the validation run
+    /// is to prove this never happens.
+    #[error("R2 witness MISSING for block {number} (key {key}): object not found (404) — R2 completeness gap")]
+    Missing { number: u64, key: String },
+    /// Transport-level failure (connection reset/timeout) — the endpoint is effectively
+    /// unreachable. Retried internally with backoff before surfacing.
+    #[error("R2 transport failure for block {number} (key {key}): {source}")]
+    Transport { number: u64, key: String, source: reqwest::Error },
+    /// R2 asked us to slow down (429) or returned a server-side error (5xx, including R2's 503
+    /// overload / SlowDown). Retried internally with backoff before surfacing.
+    #[error("R2 throttled/server error {status} for block {number} (key {key}): {body}")]
+    Throttled { number: u64, key: String, status: u16, body: String },
+    /// A non-success status unlikely to clear on retry (typically 4xx other than 429 — e.g. 403
+    /// SignatureDoesNotMatch from bad credentials or a malformed endpoint).
+    #[error("R2 unexpected status {status} for block {number} (key {key}): {body}")]
+    Status { number: u64, key: String, status: u16, body: String },
+    /// The object was fetched but its bytes did not decode to a `(SaltWitness, MptWitness)` tuple
+    /// — a corrupt witness in R2. Deterministic; a finding, not retried.
+    #[error("R2 witness for block {number} (key {key}) failed to decode: {source}")]
+    Decode {
+        number: u64,
+        key: String,
+        source: stateless_common::witness_encoding::WitnessDecodingError,
+    },
+}
+
+impl R2WitnessError {
+    /// Whether an immediate retry against the same endpoint could plausibly succeed (transport
+    /// blips, 429, 5xx). `Missing`/`Status`/`Decode` are deterministic and not retried.
+    const fn is_retryable(&self) -> bool {
+        matches!(self, Self::Transport { .. } | Self::Throttled { .. })
+    }
+}
+
+/// Outcome of a single (non-retrying) GET attempt.
+enum Attempt {
+    /// 2xx with the object body.
+    Found(Vec<u8>),
+    /// 404 — object absent.
+    Missing,
+}
+
+/// Fetches witness objects straight from an R2 bucket over the S3 API with SigV4-signed GETs.
+///
+/// Cloning is cheap — the `reqwest::Client` and signer are internally reference-counted / small.
+/// `Debug` is safe to derive: [`SigV4Signer`]'s own `Debug` redacts the credentials.
+#[derive(Clone, Debug)]
+pub struct R2WitnessClient {
+    http: Client,
+    signer: SigV4Signer,
+    /// Endpoint origin (`scheme://host`, no trailing slash).
+    endpoint: String,
+    /// SigV4 canonical host (`host[:port]`).
+    host: String,
+    bucket: String,
+    /// Max retry rounds for retryable (transport/429/5xx) failures before surfacing an error.
+    max_retries: usize,
+    initial_backoff: Duration,
+    max_backoff: Duration,
+    /// Throttle applied before surfacing a `Missing` (404), so the pipeline's immediate
+    /// re-enqueue of a failed fetch does not hot-spin GETs against R2 on a genuine gap.
+    missing_throttle: Duration,
+}
+
+impl R2WitnessClient {
+    /// Builds a client from an R2 endpoint origin, bucket, and bucket-scoped S3 credentials.
+    ///
+    /// `per_attempt_timeout` bounds each individual GET. Fails if the endpoint is not a bare
+    /// `scheme://host[:port]` origin (see [`parse_endpoint`]) or the HTTP client cannot be built.
+    pub fn new(
+        endpoint: &str,
+        bucket: String,
+        access_key_id: String,
+        secret_access_key: String,
+        per_attempt_timeout: Duration,
+    ) -> eyre::Result<Self> {
+        let (origin, host) = parse_endpoint(endpoint);
+        if host.is_empty() {
+            return Err(eyre::eyre!(
+                "Invalid R2 endpoint {endpoint:?}: expected a bare scheme://host origin \
+                 (no path/query), e.g. https://<account>.r2.cloudflarestorage.com"
+            ));
+        }
+        let http = Client::builder()
+            .timeout(per_attempt_timeout)
+            .build()
+            .map_err(|e| eyre::eyre!("Failed to build R2 HTTP client: {e}"))?;
+        Ok(Self {
+            http,
+            signer: SigV4Signer::new(access_key_id, secret_access_key),
+            endpoint: origin,
+            host,
+            bucket,
+            max_retries: 8,
+            initial_backoff: Duration::from_millis(500),
+            max_backoff: Duration::from_secs(30),
+            missing_throttle: Duration::from_secs(2),
+        })
+    }
+
+    /// The primary witness object key for `(number, hash)`: `block/{range}/{number}.{hash}`.
+    ///
+    /// Built from the same `megaeth-witness-r2` bucketing constants the uploader uses, so it is
+    /// byte-identical to the key that was written. `hash` renders via `B256`'s `Display`
+    /// (lowercase `0x` + 64 hex); the pinned test below guards that against drift.
+    fn block_key(number: u64, hash: B256) -> String {
+        let range_start = keys::block_range_prefix(number);
+        let range_end = range_start + keys::BLOCK_RANGE_SIZE - 1;
+        format!("{}/{range_start}_{range_end}/{number}.{hash}", keys::BLOCK_PREFIX)
+    }
+
+    /// Fetches and decodes the witness for `(number, hash)` from R2.
+    ///
+    /// Retryable failures (transport/429/5xx) are retried with exponential backoff up to
+    /// `max_retries` (respecting `deadline` when given). `Missing` (404) and `Decode` failures are
+    /// deterministic and surface immediately as findings.
+    pub async fn get_witness(
+        &self,
+        number: u64,
+        hash: B256,
+        deadline: Option<Instant>,
+    ) -> Result<(SaltWitness, MptWitness), R2WitnessError> {
+        let key = Self::block_key(number, hash);
+        let mut backoff = self.initial_backoff;
+        let mut attempt = 0usize;
+
+        let bytes = loop {
+            attempt += 1;
+            match self.get_object(number, &key).await {
+                Ok(Attempt::Found(bytes)) => break bytes,
+                Ok(Attempt::Missing) => {
+                    // Deterministic gap. Sleep briefly first: the fetcher re-enqueues a failed
+                    // fetch immediately, so returning instantly would hot-loop 404s against R2.
+                    tokio::time::sleep(self.missing_throttle).await;
+                    return Err(R2WitnessError::Missing { number, key });
+                }
+                Err(e) => {
+                    let out_of_retries = attempt > self.max_retries
+                        || deadline.is_some_and(|d| Instant::now() >= d);
+                    if !e.is_retryable() || out_of_retries {
+                        return Err(e);
+                    }
+                    let sleep = match deadline {
+                        Some(d) => backoff.min(d.saturating_duration_since(Instant::now())),
+                        None => backoff,
+                    };
+                    warn!(number, %key, attempt, error = %e, "R2 witness GET failed, backing off");
+                    tokio::time::sleep(sleep).await;
+                    backoff = (backoff * 2).min(self.max_backoff);
+                }
+            }
+        };
+
+        let decode_key = key.clone();
+        let (salt_witness, mpt_witness) = tokio::task::spawn_blocking(move || {
+            decode_witness_payload(&bytes)
+        })
+        .await
+        .map_err(|e| R2WitnessError::Decode {
+            number,
+            key: decode_key.clone(),
+            // A panic in decode is not a `WitnessDecodingError`; fold it into the same finding
+            // channel with a synthetic message rather than unwrapping and killing the worker.
+            source: stateless_common::witness_encoding::WitnessDecodingError::Decompress(
+                std::io::Error::other(format!("decode task panicked: {e}")),
+            ),
+        })?
+        .map_err(|source| R2WitnessError::Decode { number, key, source })?;
+
+        trace!(number, "R2 witness fetched and decoded");
+        Ok((salt_witness, mpt_witness))
+    }
+
+    /// Performs one SigV4-signed GET and classifies the response. No retry.
+    async fn get_object(&self, number: u64, key: &str) -> Result<Attempt, R2WitnessError> {
+        let canonical_uri = encode_uri_path(&self.bucket, key);
+        let url = format!("{}{}", self.endpoint, canonical_uri);
+        // Signed-payload mode with an empty body: x-amz-content-sha256 = sha256("").
+        let signed = self.signer.sign("GET", &self.host, &canonical_uri, "", &[], b"", Utc::now());
+
+        let mut request = self.http.get(&url);
+        for (name, value) in signed {
+            request = request.header(name, value);
+        }
+        let response = request.send().await.map_err(|source| R2WitnessError::Transport {
+            number,
+            key: key.to_string(),
+            source,
+        })?;
+
+        let status = response.status();
+        if status.is_success() {
+            let bytes = response.bytes().await.map_err(|source| R2WitnessError::Transport {
+                number,
+                key: key.to_string(),
+                source,
+            })?;
+            return Ok(Attempt::Found(bytes.to_vec()));
+        }
+        let code = status.as_u16();
+        if code == 404 {
+            return Ok(Attempt::Missing);
+        }
+        let body = response.text().await.unwrap_or_default();
+        if code == 429 || code >= 500 {
+            Err(R2WitnessError::Throttled { number, key: key.to_string(), status: code, body })
+        } else {
+            Err(R2WitnessError::Status { number, key: key.to_string(), status: code, body })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use super::*;
+
+    /// Pins the object-key format to a real migrated mainnet key. If `B256`'s `Display` ever
+    /// stopped rendering full lowercase `0x` hex, every GET would 404 — this catches that at
+    /// build time rather than as a silent wall of "missing" in production.
+    #[test]
+    fn block_key_matches_migrated_layout() {
+        let hash = B256::from_str(
+            "0x05dd41e545b25db0ce04f628e6e1705232240c70a0435c8233ac4479176fe6b0",
+        )
+        .unwrap();
+        assert_eq!(
+            R2WitnessClient::block_key(6_632_136, hash),
+            "block/6632000_6632999/6632136.\
+             0x05dd41e545b25db0ce04f628e6e1705232240c70a0435c8233ac4479176fe6b0",
+        );
+    }
+
+    #[test]
+    fn block_key_buckets_on_thousands() {
+        let h = B256::ZERO;
+        assert!(R2WitnessClient::block_key(0, h).starts_with("block/0_999/0."));
+        assert!(R2WitnessClient::block_key(999, h).starts_with("block/0_999/999."));
+        assert!(R2WitnessClient::block_key(1000, h).starts_with("block/1000_1999/1000."));
+    }
+
+    #[test]
+    fn rejects_endpoint_with_path() {
+        // A bucket-in-path URL is the classic misconfiguration; construction must fail fast.
+        let err = R2WitnessClient::new(
+            "https://acc.r2.cloudflarestorage.com/witness-mainnet",
+            "witness-mainnet".to_string(),
+            "ak".to_string(),
+            "sk".to_string(),
+            Duration::from_secs(20),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("Invalid R2 endpoint"));
+    }
+}

--- a/bin/stateless-validator/src/workers.rs
+++ b/bin/stateless-validator/src/workers.rs
@@ -16,6 +16,7 @@ use tracing::{debug, error, info, warn};
 use crate::{
     chain_sync::{ValidatorFetcher, ValidatorHooks, ValidatorProcessor},
     metrics,
+    r2_witness::R2WitnessClient,
     validator_db::ValidatorDB,
 };
 
@@ -25,6 +26,7 @@ use crate::{
 /// on signal.
 pub async fn run_with_signals(
     client: Arc<RpcClient>,
+    r2_witness: Option<Arc<R2WitnessClient>>,
     validator_db: Arc<ValidatorDB>,
     contract_cache: Arc<ContractCache>,
     chain_spec: Arc<ChainSpec>,
@@ -47,6 +49,7 @@ pub async fn run_with_signals(
 
     let fetcher = Arc::new(ValidatorFetcher {
         rpc_client: client.clone(),
+        r2_witness,
         on_remote_height: metrics::set_remote_chain_height,
     });
     let processor =

--- a/bin/stateless-validator/src/workers.rs
+++ b/bin/stateless-validator/src/workers.rs
@@ -58,7 +58,7 @@ pub async fn run_with_signals(
 
     let reporter = if report_validation {
         Some(task::spawn(validation_reporter(
-            client,
+            Arc::clone(&client),
             Arc::clone(&validator_db),
             Duration::from_secs(1),
             shutdown.clone(),
@@ -112,6 +112,20 @@ pub async fn run_with_signals(
         let _ = tokio::time::timeout(Duration::from_secs(3), reporter).await;
     }
 
+    // Final authoritative report, sent after the pipeline (and any drain) has fully stopped
+    // and the periodic reporter has been cancelled and joined (best-effort: a reporter wedged
+    // in a slow report past the 3s join above keeps running detached, but upstream applies
+    // reports through a forward-only cursor, so a stale late report cannot regress it). The
+    // reporter is cancelled the instant the pipeline stops, so anything validated since its
+    // last 1s tick — or during the drain — would otherwise go unreported. In tip-following
+    // mode the next restart re-reports the range on its first tick, but an `--end-block` slice
+    // run has no next restart, so this is its only chance to report the tail. Re-reporting an
+    // already-reported tip is harmless: that is exactly what every fresh start does. Bounded
+    // by the client's single-attempt `per_attempt_timeout`.
+    if report_validation && let Err(e) = report_range_once(&client, &validator_db, &mut 0).await {
+        warn!(error = %e, "Final validation report failed");
+    }
+
     // Canonical chain advances strictly +1 (advancer enforces parent-hash continuity and
     // rolls back on reorg), so the final tip bounds the validated range exactly.
     match (initial_tip, validator_db.get_canonical_tip()?.map(|t| t.block_number)) {
@@ -132,7 +146,9 @@ pub async fn run_with_signals(
 /// Reports validated blocks to the dedicated report endpoint.
 ///
 /// Periodically reads the canonical tip from ValidatorDB and reports the
-/// validated range to the upstream node.
+/// validated range to the upstream node. Exits as soon as `shutdown` fires;
+/// the final tip is reported by `run_with_signals` after the pipeline has
+/// fully stopped, so nothing validated after this task's last tick is lost.
 async fn validation_reporter(
     client: Arc<RpcClient>,
     validator_db: Arc<ValidatorDB>,
@@ -151,53 +167,67 @@ async fn validation_reporter(
             }
         }
 
-        let (anchor, tip) = match (validator_db.get_anchor(), validator_db.get_canonical_tip()) {
-            (Ok(Some(a)), Ok(Some(t))) => (a, t),
-            (Ok(None), _) | (_, Ok(None)) => continue,
-            (Err(e), _) | (_, Err(e)) => {
-                warn!(error = %e, "Failed to read anchor/tip, retrying");
-                continue;
-            }
-        };
+        report_range_once(&client, &validator_db, &mut last_reported_block).await?;
+    }
+}
 
-        if tip.block_number == last_reported_block {
-            continue;
+/// One reporter round: read anchor + tip and report the validated range upstream if the tip
+/// differs from `last_reported_block` (updated on an accepted report). A tip that regressed
+/// below it after a reorg rollback is deliberately re-reported — upstream must learn the new
+/// range. Read failures and rejected/failed reports are logged and skipped — the next round
+/// retries. The only `Err` is a detected validation gap, which is fatal to the reporter.
+async fn report_range_once(
+    client: &RpcClient,
+    validator_db: &ValidatorDB,
+    last_reported_block: &mut u64,
+) -> Result<()> {
+    let (anchor, tip) = match (validator_db.get_anchor(), validator_db.get_canonical_tip()) {
+        (Ok(Some(a)), Ok(Some(t))) => (a, t),
+        (Ok(None), _) | (_, Ok(None)) => return Ok(()),
+        (Err(e), _) | (_, Err(e)) => {
+            warn!(error = %e, "Failed to read anchor/tip, retrying");
+            return Ok(());
         }
+    };
 
-        let result = client
-            .set_validated_blocks(
-                (anchor.block_number, B256::from(anchor.block_hash.0)),
-                (tip.block_number, B256::from(tip.block_hash.0)),
-            )
-            .await;
+    if tip.block_number == *last_reported_block {
+        return Ok(());
+    }
 
-        match result {
-            Ok(response) if response.accepted => {
-                debug!(
-                    anchor = anchor.block_number,
-                    anchor_hash = %anchor.block_hash,
-                    tip = tip.block_number,
-                    tip_hash = %tip.block_hash,
-                    "Reported blocks"
-                );
-                last_reported_block = tip.block_number;
+    let result = client
+        .set_validated_blocks(
+            (anchor.block_number, B256::from(anchor.block_hash.0)),
+            (tip.block_number, B256::from(tip.block_hash.0)),
+        )
+        .await;
+
+    match result {
+        Ok(response) if response.accepted => {
+            debug!(
+                anchor = anchor.block_number,
+                anchor_hash = %anchor.block_hash,
+                tip = tip.block_number,
+                tip_hash = %tip.block_hash,
+                "Reported blocks"
+            );
+            *last_reported_block = tip.block_number;
+        }
+        Ok(response) => {
+            if response.last_validated_block.0 < anchor.block_number {
+                return Err(eyre::eyre!(
+                    "Validation gap detected: upstream at block {}, but local chain starts at {}",
+                    response.last_validated_block.0,
+                    anchor.block_number
+                ));
             }
-            Ok(response) => {
-                if response.last_validated_block.0 < anchor.block_number {
-                    return Err(eyre::eyre!(
-                        "Validation gap detected: upstream at block {}, but local chain starts at {}",
-                        response.last_validated_block.0,
-                        anchor.block_number
-                    ));
-                }
-                error!(
-                    upstream_block = ?response.last_validated_block,
-                    "Report rejected"
-                );
-            }
-            Err(e) => {
-                error!(error = %e, "Failed to report blocks");
-            }
+            error!(
+                upstream_block = ?response.last_validated_block,
+                "Report rejected"
+            );
+        }
+        Err(e) => {
+            error!(error = %e, "Failed to report blocks");
         }
     }
+    Ok(())
 }

--- a/bin/stateless-validator/src/workers.rs
+++ b/bin/stateless-validator/src/workers.rs
@@ -20,6 +20,13 @@ use crate::{
     validator_db::ValidatorDB,
 };
 
+/// Attempts for the final shutdown report (first try + retries). An `--end-block` slice run
+/// has no reporter tick after this to publish its tail, so a transient endpoint blip at
+/// exactly shutdown must not silently drop the report.
+const FINAL_REPORT_ATTEMPTS: usize = 3;
+/// Sleep between final-report attempts.
+const FINAL_REPORT_RETRY_DELAY: Duration = Duration::from_secs(1);
+
 /// Starts the validator pipeline, optional reporter, and signal handlers.
 ///
 /// Cleanly drains on SIGINT/SIGTERM and returns either the pipeline result or `Ok(())`
@@ -119,11 +126,33 @@ pub async fn run_with_signals(
     // reporter is cancelled the instant the pipeline stops, so anything validated since its
     // last 1s tick — or during the drain — would otherwise go unreported. In tip-following
     // mode the next restart re-reports the range on its first tick, but an `--end-block` slice
-    // run has no next restart, so this is its only chance to report the tail. Re-reporting an
-    // already-reported tip is harmless: that is exactly what every fresh start does. Bounded
-    // by the client's single-attempt `per_attempt_timeout`.
-    if report_validation && let Err(e) = report_range_once(&client, &validator_db, &mut 0).await {
-        warn!(error = %e, "Final validation report failed");
+    // run has no next restart, so this is its only chance to report the tail — hence, unlike
+    // the periodic loop (whose next tick is its retry), a failed attempt here is retried up to
+    // FINAL_REPORT_ATTEMPTS times before giving up with an ERROR log. Re-reporting an
+    // already-reported tip is harmless: that is exactly what every fresh start does. Worst
+    // case this delays shutdown by FINAL_REPORT_ATTEMPTS single-attempt reports (each bounded
+    // by `per_attempt_timeout`) plus the sleeps between them.
+    if report_validation {
+        let mut last_reported = 0u64;
+        for attempt in 1..=FINAL_REPORT_ATTEMPTS {
+            match report_range_once(&client, &validator_db, &mut last_reported).await {
+                Ok(true) => break,
+                Ok(false) if attempt < FINAL_REPORT_ATTEMPTS => {
+                    warn!(attempt, "Final validation report failed, retrying");
+                    tokio::time::sleep(FINAL_REPORT_RETRY_DELAY).await;
+                }
+                Ok(false) => error!(
+                    attempts = FINAL_REPORT_ATTEMPTS,
+                    "Final validation report failed; the validated tail may be unreported \
+                     upstream"
+                ),
+                // A detected validation gap is deterministic — retrying cannot resolve it.
+                Err(e) => {
+                    warn!(error = %e, "Final validation report failed");
+                    break;
+                }
+            }
+        }
     }
 
     // Canonical chain advances strictly +1 (advancer enforces parent-hash continuity and
@@ -174,24 +203,30 @@ async fn validation_reporter(
 /// One reporter round: read anchor + tip and report the validated range upstream if the tip
 /// differs from `last_reported_block` (updated on an accepted report). A tip that regressed
 /// below it after a reorg rollback is deliberately re-reported — upstream must learn the new
-/// range. Read failures and rejected/failed reports are logged and skipped — the next round
-/// retries. The only `Err` is a detected validation gap, which is fatal to the reporter.
+/// range.
+///
+/// Returns `Ok(true)` when this round is settled — the report was accepted, or there is
+/// nothing to report (no anchor/tip yet, or the tip is already reported). Returns `Ok(false)`
+/// when the attempt failed in a way a retry could resolve (read failure, transport failure, or
+/// a rejection without a gap) — the failure is logged here; the periodic loop just waits for
+/// its next tick, while the final shutdown flush retries a bounded number of times. The only
+/// `Err` is a detected validation gap, which is fatal to the reporter.
 async fn report_range_once(
     client: &RpcClient,
     validator_db: &ValidatorDB,
     last_reported_block: &mut u64,
-) -> Result<()> {
+) -> Result<bool> {
     let (anchor, tip) = match (validator_db.get_anchor(), validator_db.get_canonical_tip()) {
         (Ok(Some(a)), Ok(Some(t))) => (a, t),
-        (Ok(None), _) | (_, Ok(None)) => return Ok(()),
+        (Ok(None), _) | (_, Ok(None)) => return Ok(true),
         (Err(e), _) | (_, Err(e)) => {
             warn!(error = %e, "Failed to read anchor/tip, retrying");
-            return Ok(());
+            return Ok(false);
         }
     };
 
     if tip.block_number == *last_reported_block {
-        return Ok(());
+        return Ok(true);
     }
 
     let result = client
@@ -211,6 +246,7 @@ async fn report_range_once(
                 "Reported blocks"
             );
             *last_reported_block = tip.block_number;
+            Ok(true)
         }
         Ok(response) => {
             if response.last_validated_block.0 < anchor.block_number {
@@ -224,10 +260,11 @@ async fn report_range_once(
                 upstream_block = ?response.last_validated_block,
                 "Report rejected"
             );
+            Ok(false)
         }
         Err(e) => {
             error!(error = %e, "Failed to report blocks");
+            Ok(false)
         }
     }
-    Ok(())
 }

--- a/bin/stateless-validator/src/workers.rs
+++ b/bin/stateless-validator/src/workers.rs
@@ -1,6 +1,12 @@
 //! Pipeline + signal handling + optional validation reporter.
 
-use std::{sync::Arc, time::Duration};
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
+    time::Duration,
+};
 
 use alloy_primitives::B256;
 use eyre::Result;
@@ -28,7 +34,10 @@ const FINAL_REPORT_RETRY_DELAY: Duration = Duration::from_secs(1);
 /// Starts the validator pipeline, optional reporter, and signal handlers.
 ///
 /// Cleanly drains on SIGINT/SIGTERM and returns either the pipeline result or `Ok(())`
-/// on signal.
+/// on signal. Exception: on a fixed-range run (`--end-block`), a final validation report
+/// that cannot land (or a detected validation gap) fails the run — a slice has no later
+/// restart to re-report, so exiting 0 would let an orchestrator record the slice as
+/// complete while upstream never saw the tip.
 pub async fn run_with_signals(
     client: Arc<RpcClient>,
     r2_witness: Option<Arc<R2WitnessClient>>,
@@ -40,6 +49,7 @@ pub async fn run_with_signals(
 ) -> Result<()> {
     let report_validation = report_validation_endpoint.is_some();
     let config = Arc::new(pipeline_config);
+    let is_slice_run = config.sync_target.is_some();
     info!(
         concurrent_workers = config.concurrent_workers,
         poll_interval = ?config.poll_interval,
@@ -61,12 +71,17 @@ pub async fn run_with_signals(
         Arc::new(ValidatorProcessor { chain_spec, contract_cache, rpc_client: client.clone() });
     let hooks = Arc::new(ValidatorHooks);
 
+    // Last tip accepted upstream, shared between the periodic reporter and the final flush so
+    // the flush only covers the still-unreported tail instead of re-sending anchor→tip.
+    let last_reported = Arc::new(AtomicU64::new(0));
+
     let reporter = if report_validation {
         Some(task::spawn(validation_reporter(
             Arc::clone(&client),
             Arc::clone(&validator_db),
             Duration::from_secs(1),
             shutdown.clone(),
+            Arc::clone(&last_reported),
         )))
     } else {
         info!("Validation reporter disabled");
@@ -88,7 +103,7 @@ pub async fn run_with_signals(
     ));
 
     // Signal wins → drain; pipeline wins → already done.
-    let (result, needs_drain): (Result<()>, bool) = tokio::select! {
+    let (mut result, needs_drain): (Result<()>, bool) = tokio::select! {
         res = &mut pipeline_handle => {
             let r = res.unwrap_or_else(|e| Err(eyre::eyre!("Pipeline task panicked: {e}")));
             (r, false)
@@ -119,31 +134,47 @@ pub async fn run_with_signals(
 
     // Final report of the validated tail, sent after the pipeline (and any drain) has stopped
     // and the periodic reporter was joined. The reporter exits the moment the pipeline does, so
-    // blocks validated since its last tick would otherwise go unreported — and an `--end-block`
-    // slice run has no later restart to re-report them, hence the bounded retries (the periodic
-    // loop's next tick is its retry). Re-reporting an already-reported tip is harmless (every
-    // fresh start does it), and a reporter wedged past the 3s join above cannot regress
-    // upstream: reports apply through a forward-only cursor.
+    // blocks validated since its last accepted report would otherwise go unreported — and an
+    // `--end-block` slice run has no later restart to re-report them, hence the bounded retries
+    // (the periodic loop's next tick is its retry). The shared `last_reported` makes this a
+    // no-op when the reporter already landed the tip; a reporter wedged past the 3s join above
+    // cannot regress upstream either way: reports apply through a forward-only cursor.
     if report_validation {
-        let mut last_reported = 0u64;
+        let mut flush_failure: Option<eyre::Report> = None;
         for attempt in 1..=FINAL_REPORT_ATTEMPTS {
-            match report_range_once(&client, &validator_db, &mut last_reported).await {
+            match report_range_once(&client, &validator_db, &last_reported).await {
                 Ok(true) => break,
                 Ok(false) if attempt < FINAL_REPORT_ATTEMPTS => {
                     warn!(attempt, "Final validation report failed, retrying");
                     tokio::time::sleep(FINAL_REPORT_RETRY_DELAY).await;
                 }
-                Ok(false) => error!(
-                    attempts = FINAL_REPORT_ATTEMPTS,
-                    "Final validation report failed; the validated tail may be unreported \
-                     upstream"
-                ),
+                Ok(false) => {
+                    error!(
+                        attempts = FINAL_REPORT_ATTEMPTS,
+                        "Final validation report failed; the validated tail may be unreported \
+                         upstream"
+                    );
+                    flush_failure = Some(eyre::eyre!(
+                        "final validation report failed after {FINAL_REPORT_ATTEMPTS} attempts; \
+                         the validated tail may be unreported upstream"
+                    ));
+                }
                 // A detected validation gap is deterministic — retrying cannot resolve it.
                 Err(e) => {
-                    warn!(error = %e, "Final validation report failed");
+                    error!(error = %e, "Final validation report failed with a non-retryable error");
+                    flush_failure = Some(e);
                     break;
                 }
             }
+        }
+        // A chain-following run re-reports anchor→tip on its next start, so an unreported tail
+        // heals itself. An `--end-block` slice run has no later restart: fail the run so the
+        // orchestrator cannot record the slice as complete. A pipeline error, if any, takes
+        // precedence (the flush failure was already logged above).
+        if let Some(e) = flush_failure &&
+            is_slice_run
+        {
+            result = result.and(Err(e));
         }
     }
 
@@ -168,15 +199,16 @@ pub async fn run_with_signals(
 ///
 /// Periodically reads the canonical tip from ValidatorDB and reports the
 /// validated range to the upstream node. Exits as soon as `shutdown` fires;
-/// `run_with_signals` flushes the final tail afterwards.
+/// `run_with_signals` flushes the final tail afterwards, seeded by the shared
+/// `last_reported_block` so the flush skips what already landed here.
 async fn validation_reporter(
     client: Arc<RpcClient>,
     validator_db: Arc<ValidatorDB>,
     report_interval: Duration,
     shutdown: CancellationToken,
+    last_reported_block: Arc<AtomicU64>,
 ) -> Result<()> {
     info!("Starting validation reporter");
-    let mut last_reported_block = 0u64;
 
     loop {
         tokio::select! {
@@ -187,7 +219,7 @@ async fn validation_reporter(
             }
         }
 
-        report_range_once(&client, &validator_db, &mut last_reported_block).await?;
+        report_range_once(&client, &validator_db, &last_reported_block).await?;
     }
 }
 
@@ -201,7 +233,7 @@ async fn validation_reporter(
 async fn report_range_once(
     client: &RpcClient,
     validator_db: &ValidatorDB,
-    last_reported_block: &mut u64,
+    last_reported_block: &AtomicU64,
 ) -> Result<bool> {
     let (anchor, tip) = match (validator_db.get_anchor(), validator_db.get_canonical_tip()) {
         (Ok(Some(a)), Ok(Some(t))) => (a, t),
@@ -212,7 +244,10 @@ async fn report_range_once(
         }
     };
 
-    if tip.block_number == *last_reported_block {
+    // Relaxed suffices: this is a single monotonic hint, and both users are already ordered —
+    // the reporter is the only writer while it runs, and the final flush reads it only after
+    // joining the reporter task.
+    if tip.block_number == last_reported_block.load(Ordering::Relaxed) {
         return Ok(true);
     }
 
@@ -232,7 +267,7 @@ async fn report_range_once(
                 tip_hash = %tip.block_hash,
                 "Reported blocks"
             );
-            *last_reported_block = tip.block_number;
+            last_reported_block.store(tip.block_number, Ordering::Relaxed);
             Ok(true)
         }
         Ok(response) => {

--- a/bin/stateless-validator/src/workers.rs
+++ b/bin/stateless-validator/src/workers.rs
@@ -20,9 +20,7 @@ use crate::{
     validator_db::ValidatorDB,
 };
 
-/// Attempts for the final shutdown report (first try + retries). An `--end-block` slice run
-/// has no reporter tick after this to publish its tail, so a transient endpoint blip at
-/// exactly shutdown must not silently drop the report.
+/// Attempts for the final shutdown report (first try + retries).
 const FINAL_REPORT_ATTEMPTS: usize = 3;
 /// Sleep between final-report attempts.
 const FINAL_REPORT_RETRY_DELAY: Duration = Duration::from_secs(1);
@@ -119,19 +117,13 @@ pub async fn run_with_signals(
         let _ = tokio::time::timeout(Duration::from_secs(3), reporter).await;
     }
 
-    // Final authoritative report, sent after the pipeline (and any drain) has fully stopped
-    // and the periodic reporter has been cancelled and joined (best-effort: a reporter wedged
-    // in a slow report past the 3s join above keeps running detached, but upstream applies
-    // reports through a forward-only cursor, so a stale late report cannot regress it). The
-    // reporter is cancelled the instant the pipeline stops, so anything validated since its
-    // last 1s tick — or during the drain — would otherwise go unreported. In tip-following
-    // mode the next restart re-reports the range on its first tick, but an `--end-block` slice
-    // run has no next restart, so this is its only chance to report the tail — hence, unlike
-    // the periodic loop (whose next tick is its retry), a failed attempt here is retried up to
-    // FINAL_REPORT_ATTEMPTS times before giving up with an ERROR log. Re-reporting an
-    // already-reported tip is harmless: that is exactly what every fresh start does. Worst
-    // case this delays shutdown by FINAL_REPORT_ATTEMPTS single-attempt reports (each bounded
-    // by `per_attempt_timeout`) plus the sleeps between them.
+    // Final report of the validated tail, sent after the pipeline (and any drain) has stopped
+    // and the periodic reporter was joined. The reporter exits the moment the pipeline does, so
+    // blocks validated since its last tick would otherwise go unreported — and an `--end-block`
+    // slice run has no later restart to re-report them, hence the bounded retries (the periodic
+    // loop's next tick is its retry). Re-reporting an already-reported tip is harmless (every
+    // fresh start does it), and a reporter wedged past the 3s join above cannot regress
+    // upstream: reports apply through a forward-only cursor.
     if report_validation {
         let mut last_reported = 0u64;
         for attempt in 1..=FINAL_REPORT_ATTEMPTS {
@@ -176,8 +168,7 @@ pub async fn run_with_signals(
 ///
 /// Periodically reads the canonical tip from ValidatorDB and reports the
 /// validated range to the upstream node. Exits as soon as `shutdown` fires;
-/// the final tip is reported by `run_with_signals` after the pipeline has
-/// fully stopped, so nothing validated after this task's last tick is lost.
+/// `run_with_signals` flushes the final tail afterwards.
 async fn validation_reporter(
     client: Arc<RpcClient>,
     validator_db: Arc<ValidatorDB>,
@@ -201,15 +192,11 @@ async fn validation_reporter(
 }
 
 /// One reporter round: read anchor + tip and report the validated range upstream if the tip
-/// differs from `last_reported_block` (updated on an accepted report). A tip that regressed
-/// below it after a reorg rollback is deliberately re-reported — upstream must learn the new
-/// range.
+/// differs from `last_reported_block` (updated on an accepted report; a tip that regressed
+/// after a reorg rollback is deliberately re-reported).
 ///
-/// Returns `Ok(true)` when this round is settled — the report was accepted, or there is
-/// nothing to report (no anchor/tip yet, or the tip is already reported). Returns `Ok(false)`
-/// when the attempt failed in a way a retry could resolve (read failure, transport failure, or
-/// a rejection without a gap) — the failure is logged here; the periodic loop just waits for
-/// its next tick, while the final shutdown flush retries a bounded number of times. The only
+/// Returns `Ok(true)` when the round settled (report accepted, or nothing to report) and
+/// `Ok(false)` when the attempt failed in a way a retry could resolve (logged here). The only
 /// `Err` is a detected validation gap, which is fatal to the reporter.
 async fn report_range_once(
     client: &RpcClient,

--- a/bin/stateless-validator/tests/integration.rs
+++ b/bin/stateless-validator/tests/integration.rs
@@ -3,7 +3,10 @@
 //! Covers CLI argument parsing and end-to-end pipeline validation against a mock RPC server.
 //! Mainnet single-block validation is covered in `crates/stateless-core/src/executor.rs::tests`.
 
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
 
 use alloy_primitives::{B256, BlockHash};
 use alloy_rpc_types_eth::Block;
@@ -15,7 +18,7 @@ use jsonrpsee::{
 use jsonrpsee_types::error::{
     CALL_EXECUTION_FAILED_CODE, ErrorObject, ErrorObjectOwned, INVALID_PARAMS_CODE,
 };
-use stateless_common::{RpcClient, WitnessRequestKeys, encode_witness_response};
+use stateless_common::{RpcClient, RpcClientConfig, WitnessRequestKeys, encode_witness_response};
 use stateless_core::{
     BisectResolver, ChainStore, ContractStore, PipelineConfig, db::BlockMeta,
     pipeline::run_pipeline, withdrawals::MptWitness,
@@ -24,7 +27,7 @@ use stateless_db::ContractCache;
 use stateless_test_utils::{fixtures::TestFixtures, logging::init_test_logging};
 use stateless_validator::{
     CommandLineArgs, VALIDATOR_DB_FILENAME, ValidatorDB, ValidatorFetcher, ValidatorHooks,
-    ValidatorProcessor, load_or_create_chain_spec,
+    ValidatorProcessor, load_or_create_chain_spec, run_with_signals,
 };
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info};
@@ -210,6 +213,9 @@ const MAX_RESPONSE_BODY_SIZE: u32 = 1024 * 1024 * 100;
 struct MockServerState {
     fixtures: TestFixtures,
     mpt_witnesses: HashMap<BlockHash, MptWitness>,
+    /// Every `mega_setValidatedBlocks` call received, as `(first_block, last_block)` numbers.
+    /// Clone the `Arc` before handing the state to the server to assert on reports.
+    validated_reports: Arc<Mutex<Vec<(u64, u64)>>>,
 }
 
 impl MockServerState {
@@ -219,7 +225,7 @@ impl MockServerState {
             .keys()
             .map(|hash| (*hash, fixtures.mpt_witness(hash)))
             .collect();
-        Self { fixtures, mpt_witnesses }
+        Self { fixtures, mpt_witnesses, validated_reports: Arc::default() }
     }
 }
 
@@ -393,9 +399,9 @@ async fn setup_mock_rpc_server(
         .unwrap();
 
     module
-        .register_method("mega_setValidatedBlocks", |params, _ctx, _| {
-            let (_first_block, last_block): ((u64, String), (u64, String)) =
-                params.parse().unwrap();
+        .register_method("mega_setValidatedBlocks", |params, ctx, _| {
+            let (first_block, last_block): ((u64, String), (u64, String)) = params.parse().unwrap();
+            ctx.validated_reports.lock().unwrap().push((first_block.0, last_block.0));
             let last_hash: BlockHash = last_block.1.parse().unwrap();
             Ok::<serde_json::Value, ErrorObjectOwned>(serde_json::json!({
                 "accepted": true,
@@ -468,4 +474,64 @@ async fn integration_test() {
 
     handle.stop().unwrap();
     info!("Mock RPC server has been shut down");
+}
+
+/// A fixed-range run (`--end-block` → `sync_target`) must report its final validated tip
+/// upstream before exiting. The periodic reporter is cancelled the instant the pipeline
+/// completes and its 1s tick usually never fires on a short run, so without the final flush in
+/// `run_with_signals` the whole slice would finish unreported — and a slice run has no later
+/// restart whose first tick would re-report it.
+#[tokio::test]
+async fn end_block_run_reports_final_tip() {
+    let _logging = init_test_logging("stateless_validator");
+    let fx = TestFixtures::synthetic();
+    let genesis_file = fx.data_dir.join("genesis.json");
+
+    let max_block_number = fx.max_block().0;
+    let (validator_db, _tmp) = setup_test_db(&fx).unwrap();
+    let contract_cache =
+        Arc::new(ContractCache::new(Arc::clone(&validator_db) as Arc<dyn ContractStore>));
+    let state = MockServerState::new(fx);
+    let reports = Arc::clone(&state.validated_reports);
+    let (handle, url) = setup_mock_rpc_server(state).await;
+    // Unlike `integration_test`, the report endpoint is wired up (fourth argument), pointing at
+    // the same mock server.
+    let client = Arc::new(
+        RpcClient::new_with_config(
+            &[url.as_str()],
+            &[url.as_str()],
+            RpcClientConfig::validator(),
+            Some(url.as_str()),
+        )
+        .unwrap(),
+    );
+    let chain_spec = Arc::new(
+        load_or_create_chain_spec(&validator_db, Some(genesis_file.to_str().unwrap())).unwrap(),
+    );
+
+    let mut cfg = PipelineConfig::default();
+    cfg.concurrent_workers = 1;
+    cfg.sync_target = Some(max_block_number);
+
+    run_with_signals(
+        client,
+        None,
+        Arc::clone(&validator_db),
+        contract_cache,
+        chain_spec,
+        Some(url.clone()),
+        cfg,
+    )
+    .await
+    .unwrap();
+
+    let reports = reports.lock().unwrap();
+    let &(_, last_reported) =
+        reports.last().expect("the run must report validated blocks before exiting");
+    assert_eq!(
+        last_reported, max_block_number,
+        "the final report must cover the end block (got reports: {reports:?})",
+    );
+
+    handle.stop().unwrap();
 }

--- a/bin/stateless-validator/tests/integration.rs
+++ b/bin/stateless-validator/tests/integration.rs
@@ -214,10 +214,8 @@ struct MockServerState {
     fixtures: TestFixtures,
     mpt_witnesses: HashMap<BlockHash, MptWitness>,
     /// Every *accepted* `mega_setValidatedBlocks` call, as `(first_block, last_block)` numbers.
-    /// Clone the `Arc` before handing the state to the server to assert on reports.
     validated_reports: Arc<Mutex<Vec<(u64, u64)>>>,
-    /// Number of upcoming `mega_setValidatedBlocks` calls to fail with an RPC error (simulating
-    /// a transient endpoint blip); decremented per rejected call.
+    /// Number of upcoming `mega_setValidatedBlocks` calls to reject with an RPC error.
     reject_reports: Arc<std::sync::atomic::AtomicUsize>,
 }
 
@@ -495,10 +493,9 @@ async fn integration_test() {
     info!("Mock RPC server has been shut down");
 }
 
-/// Runs `run_with_signals` over the synthetic fixtures to their max block (`--end-block` →
-/// `sync_target`) with the report endpoint wired to the mock server, failing the first
-/// `reject_first_reports` report calls, and asserts the last accepted report covers the end
-/// block. Returns every accepted report for further assertions.
+/// Runs `run_with_signals` to the fixtures' max block (`--end-block` → `sync_target`) with
+/// reports wired to the mock, failing the first `reject_first_reports` calls; asserts the last
+/// accepted report covers the end block and returns all accepted reports.
 async fn run_end_block_slice_and_assert_tip_reported(
     reject_first_reports: usize,
 ) -> Vec<(u64, u64)> {
@@ -514,8 +511,6 @@ async fn run_end_block_slice_and_assert_tip_reported(
     let reports = Arc::clone(&state.validated_reports);
     state.reject_reports.store(reject_first_reports, std::sync::atomic::Ordering::SeqCst);
     let (handle, url) = setup_mock_rpc_server(state).await;
-    // Unlike `integration_test`, the report endpoint is wired up (fourth argument), pointing at
-    // the same mock server.
     let client = Arc::new(
         RpcClient::new_with_config(
             &[url.as_str()],
@@ -557,19 +552,17 @@ async fn run_end_block_slice_and_assert_tip_reported(
     reports.clone()
 }
 
-/// A fixed-range run (`--end-block` → `sync_target`) must report its final validated tip
-/// upstream before exiting. The periodic reporter is cancelled the instant the pipeline
-/// completes and its 1s tick usually never fires on a short run, so without the final flush in
-/// `run_with_signals` the whole slice would finish unreported — and a slice run has no later
-/// restart whose first tick would re-report it.
+/// A fixed-range run must flush its final validated tip before exiting: the periodic reporter
+/// is cancelled when the pipeline completes (its 1s tick rarely fires on a short slice) and a
+/// slice run has no restart to re-report, so the final flush in `run_with_signals` is the only
+/// path.
 #[tokio::test]
 async fn end_block_run_reports_final_tip() {
     run_end_block_slice_and_assert_tip_reported(0).await;
 }
 
-/// The final report must survive a transient endpoint failure: the run has no reporter tick
-/// after it, so a single blip at exactly shutdown would otherwise permanently lose the tail.
-/// The mock fails the first report call; the final flush's bounded retry must land the second.
+/// Like [`end_block_run_reports_final_tip`], but the mock rejects the first report call: the
+/// final flush's bounded retry must still land the tip.
 #[tokio::test]
 async fn end_block_final_report_retries_after_transient_failure() {
     run_end_block_slice_and_assert_tip_reported(1).await;

--- a/bin/stateless-validator/tests/integration.rs
+++ b/bin/stateless-validator/tests/integration.rs
@@ -494,11 +494,11 @@ async fn integration_test() {
 }
 
 /// Runs `run_with_signals` to the fixtures' max block (`--end-block` → `sync_target`) with
-/// reports wired to the mock, failing the first `reject_first_reports` calls; asserts the last
-/// accepted report covers the end block and returns all accepted reports.
-async fn run_end_block_slice_and_assert_tip_reported(
+/// reports wired to the mock, failing the first `reject_first_reports` calls. Returns the run
+/// result, the accepted reports, and the slice's end block.
+async fn run_end_block_slice(
     reject_first_reports: usize,
-) -> Vec<(u64, u64)> {
+) -> (eyre::Result<()>, Vec<(u64, u64)>, u64) {
     let _logging = init_test_logging("stateless_validator");
     let fx = TestFixtures::synthetic();
     let genesis_file = fx.data_dir.join("genesis.json");
@@ -528,7 +528,7 @@ async fn run_end_block_slice_and_assert_tip_reported(
     cfg.concurrent_workers = 1;
     cfg.sync_target = Some(max_block_number);
 
-    run_with_signals(
+    let result = run_with_signals(
         client,
         None,
         Arc::clone(&validator_db),
@@ -537,19 +537,29 @@ async fn run_end_block_slice_and_assert_tip_reported(
         Some(url.clone()),
         cfg,
     )
-    .await
-    .unwrap();
+    .await;
 
     handle.stop().unwrap();
 
-    let reports = reports.lock().unwrap();
+    let reports = reports.lock().unwrap().clone();
+    (result, reports, max_block_number)
+}
+
+/// [`run_end_block_slice`] + asserts the run succeeded and the last accepted report covers the
+/// end block; returns all accepted reports.
+async fn run_end_block_slice_and_assert_tip_reported(
+    reject_first_reports: usize,
+) -> Vec<(u64, u64)> {
+    let (result, reports, max_block_number) = run_end_block_slice(reject_first_reports).await;
+    result.unwrap();
+
     let &(_, last_reported) =
         reports.last().expect("the run must report validated blocks before exiting");
     assert_eq!(
         last_reported, max_block_number,
         "the final report must cover the end block (got reports: {reports:?})",
     );
-    reports.clone()
+    reports
 }
 
 /// A fixed-range run must flush its final validated tip before exiting: the periodic reporter
@@ -566,4 +576,15 @@ async fn end_block_run_reports_final_tip() {
 #[tokio::test]
 async fn end_block_final_report_retries_after_transient_failure() {
     run_end_block_slice_and_assert_tip_reported(1).await;
+}
+
+/// If the final flush cannot land within its bounded retries, an `--end-block` slice run must
+/// fail rather than exit 0: the slice has no later restart to re-report, so a clean exit would
+/// let an orchestrator record the slice as complete while upstream never saw the tip.
+#[tokio::test]
+async fn end_block_run_fails_when_final_report_never_lands() {
+    let (result, reports, _) = run_end_block_slice(usize::MAX).await;
+    let err = result.expect_err("run must fail when the validated tail cannot be reported");
+    assert!(err.to_string().contains("final validation report failed"), "{err}");
+    assert!(reports.is_empty(), "mock rejected every report, yet some landed: {reports:?}");
 }

--- a/bin/stateless-validator/tests/integration.rs
+++ b/bin/stateless-validator/tests/integration.rs
@@ -213,9 +213,12 @@ const MAX_RESPONSE_BODY_SIZE: u32 = 1024 * 1024 * 100;
 struct MockServerState {
     fixtures: TestFixtures,
     mpt_witnesses: HashMap<BlockHash, MptWitness>,
-    /// Every `mega_setValidatedBlocks` call received, as `(first_block, last_block)` numbers.
+    /// Every *accepted* `mega_setValidatedBlocks` call, as `(first_block, last_block)` numbers.
     /// Clone the `Arc` before handing the state to the server to assert on reports.
     validated_reports: Arc<Mutex<Vec<(u64, u64)>>>,
+    /// Number of upcoming `mega_setValidatedBlocks` calls to fail with an RPC error (simulating
+    /// a transient endpoint blip); decremented per rejected call.
+    reject_reports: Arc<std::sync::atomic::AtomicUsize>,
 }
 
 impl MockServerState {
@@ -225,7 +228,12 @@ impl MockServerState {
             .keys()
             .map(|hash| (*hash, fixtures.mpt_witness(hash)))
             .collect();
-        Self { fixtures, mpt_witnesses, validated_reports: Arc::default() }
+        Self {
+            fixtures,
+            mpt_witnesses,
+            validated_reports: Arc::default(),
+            reject_reports: Arc::default(),
+        }
     }
 }
 
@@ -400,7 +408,18 @@ async fn setup_mock_rpc_server(
 
     module
         .register_method("mega_setValidatedBlocks", |params, ctx, _| {
+            use std::sync::atomic::Ordering;
             let (first_block, last_block): ((u64, String), (u64, String)) = params.parse().unwrap();
+            if ctx
+                .reject_reports
+                .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |n| n.checked_sub(1))
+                .is_ok()
+            {
+                return Err(make_rpc_error(
+                    CALL_EXECUTION_FAILED_CODE,
+                    "transient report failure (scripted)".to_string(),
+                ));
+            }
             ctx.validated_reports.lock().unwrap().push((first_block.0, last_block.0));
             let last_hash: BlockHash = last_block.1.parse().unwrap();
             Ok::<serde_json::Value, ErrorObjectOwned>(serde_json::json!({
@@ -476,13 +495,13 @@ async fn integration_test() {
     info!("Mock RPC server has been shut down");
 }
 
-/// A fixed-range run (`--end-block` → `sync_target`) must report its final validated tip
-/// upstream before exiting. The periodic reporter is cancelled the instant the pipeline
-/// completes and its 1s tick usually never fires on a short run, so without the final flush in
-/// `run_with_signals` the whole slice would finish unreported — and a slice run has no later
-/// restart whose first tick would re-report it.
-#[tokio::test]
-async fn end_block_run_reports_final_tip() {
+/// Runs `run_with_signals` over the synthetic fixtures to their max block (`--end-block` →
+/// `sync_target`) with the report endpoint wired to the mock server, failing the first
+/// `reject_first_reports` report calls, and asserts the last accepted report covers the end
+/// block. Returns every accepted report for further assertions.
+async fn run_end_block_slice_and_assert_tip_reported(
+    reject_first_reports: usize,
+) -> Vec<(u64, u64)> {
     let _logging = init_test_logging("stateless_validator");
     let fx = TestFixtures::synthetic();
     let genesis_file = fx.data_dir.join("genesis.json");
@@ -493,6 +512,7 @@ async fn end_block_run_reports_final_tip() {
         Arc::new(ContractCache::new(Arc::clone(&validator_db) as Arc<dyn ContractStore>));
     let state = MockServerState::new(fx);
     let reports = Arc::clone(&state.validated_reports);
+    state.reject_reports.store(reject_first_reports, std::sync::atomic::Ordering::SeqCst);
     let (handle, url) = setup_mock_rpc_server(state).await;
     // Unlike `integration_test`, the report endpoint is wired up (fourth argument), pointing at
     // the same mock server.
@@ -525,6 +545,8 @@ async fn end_block_run_reports_final_tip() {
     .await
     .unwrap();
 
+    handle.stop().unwrap();
+
     let reports = reports.lock().unwrap();
     let &(_, last_reported) =
         reports.last().expect("the run must report validated blocks before exiting");
@@ -532,6 +554,23 @@ async fn end_block_run_reports_final_tip() {
         last_reported, max_block_number,
         "the final report must cover the end block (got reports: {reports:?})",
     );
+    reports.clone()
+}
 
-    handle.stop().unwrap();
+/// A fixed-range run (`--end-block` → `sync_target`) must report its final validated tip
+/// upstream before exiting. The periodic reporter is cancelled the instant the pipeline
+/// completes and its 1s tick usually never fires on a short run, so without the final flush in
+/// `run_with_signals` the whole slice would finish unreported — and a slice run has no later
+/// restart whose first tick would re-report it.
+#[tokio::test]
+async fn end_block_run_reports_final_tip() {
+    run_end_block_slice_and_assert_tip_reported(0).await;
+}
+
+/// The final report must survive a transient endpoint failure: the run has no reporter tick
+/// after it, so a single blip at exactly shutdown would otherwise permanently lose the tail.
+/// The mock fails the first report call; the final flush's bounded retry must land the second.
+#[tokio::test]
+async fn end_block_final_report_retries_after_transient_failure() {
+    run_end_block_slice_and_assert_tip_reported(1).await;
 }

--- a/bin/stateless-validator/tests/integration.rs
+++ b/bin/stateless-validator/tests/integration.rs
@@ -133,6 +133,47 @@ fn tip_buffer_flag_and_env() {
     });
 }
 
+#[test]
+fn end_block_flag_and_env() {
+    assert_optional_numeric_flag::<u64>("--end-block", "STATELESS_VALIDATOR_END_BLOCK", |a| {
+        a.end_block
+    });
+}
+
+/// `--witness-source` must default to `rpc`, parse both lowercase values (flag and env), and
+/// reject anything else at parse time.
+#[test]
+fn witness_source_flag_and_env() {
+    use stateless_validator::WitnessSource;
+
+    let guard = stateless_test_utils::env::env_lock();
+    let parse = |extra: &[&str]| CommandLineArgs::try_parse_from(BASE_ARGS.iter().chain(extra));
+
+    assert_eq!(parse(&[]).unwrap().witness_source, WitnessSource::Rpc);
+    assert_eq!(parse(&["--witness-source", "rpc"]).unwrap().witness_source, WitnessSource::Rpc);
+    assert_eq!(parse(&["--witness-source", "r2"]).unwrap().witness_source, WitnessSource::R2);
+    assert!(parse(&["--witness-source", "s3"]).is_err());
+
+    let from_env = stateless_test_utils::env::with_env_var(
+        &guard,
+        "STATELESS_VALIDATOR_WITNESS_SOURCE",
+        "r2",
+        || parse(&[]).unwrap().witness_source,
+    );
+    assert_eq!(from_env, WitnessSource::R2);
+}
+
+/// `--witness-endpoint` is enforced at runtime per witness source (required for `rpc`, ignored
+/// for `r2`), so the parse itself must accept its absence in both modes.
+#[test]
+fn witness_endpoint_is_optional_at_parse_time() {
+    let base = &["stateless-validator", "--data-dir", "/tmp/x", "--rpc-endpoint", "http://rpc"];
+    let parse = |extra: &[&str]| CommandLineArgs::try_parse_from(base.iter().chain(extra));
+
+    assert!(parse(&[]).unwrap().witness_endpoint.is_empty());
+    assert!(parse(&["--witness-source", "r2"]).unwrap().witness_endpoint.is_empty());
+}
+
 /// `canonical_chain_max_length` must reject 0 at parse time. A value of 0 would make
 /// `advance_chain` prune the entire canonical chain on every successful advance,
 /// rolling the pipeline back to the anchor each round and looping forever.

--- a/bin/stateless-validator/tests/integration.rs
+++ b/bin/stateless-validator/tests/integration.rs
@@ -392,8 +392,11 @@ async fn integration_test() {
     let config = Arc::new(cfg);
 
     let shutdown = CancellationToken::new();
-    let fetcher =
-        Arc::new(ValidatorFetcher { rpc_client: client.clone(), on_remote_height: |_| {} });
+    let fetcher = Arc::new(ValidatorFetcher {
+        rpc_client: client.clone(),
+        r2_witness: None,
+        on_remote_height: |_| {},
+    });
     let processor = Arc::new(ValidatorProcessor { chain_spec, contract_cache, rpc_client: client });
     let hooks = Arc::new(ValidatorHooks);
 

--- a/bin/stateless-validator/tests/integration.rs
+++ b/bin/stateless-validator/tests/integration.rs
@@ -41,6 +41,11 @@ const BASE_ARGS: &[&str] = &[
     "http://w",
 ];
 
+/// [`BASE_ARGS`] without `--witness-endpoint`, for tests that exercise that flag itself or its
+/// absence.
+const BASE_ARGS_NO_WITNESS: &[&str] =
+    &["stateless-validator", "--data-dir", "/tmp/x", "--rpc-endpoint", "http://rpc"];
+
 /// Verifies that an endpoint flag accepts repeated flags, CSV values, and env var —
 /// ensuring container deployments configured purely via env are not silently limited
 /// to one endpoint (clap's `value_delimiter` applies to env-var values too).
@@ -71,7 +76,7 @@ fn witness_endpoint_accepts_multiple_forms() {
     assert_endpoint_accepts_multiple_forms(
         "--witness-endpoint",
         "STATELESS_VALIDATOR_WITNESS_ENDPOINT",
-        &["stateless-validator", "--data-dir", "/tmp/x", "--rpc-endpoint", "http://rpc"],
+        BASE_ARGS_NO_WITNESS,
         |a| a.witness_endpoint,
     );
 }
@@ -167,8 +172,8 @@ fn witness_source_flag_and_env() {
 /// for `r2`), so the parse itself must accept its absence in both modes.
 #[test]
 fn witness_endpoint_is_optional_at_parse_time() {
-    let base = &["stateless-validator", "--data-dir", "/tmp/x", "--rpc-endpoint", "http://rpc"];
-    let parse = |extra: &[&str]| CommandLineArgs::try_parse_from(base.iter().chain(extra));
+    let parse =
+        |extra: &[&str]| CommandLineArgs::try_parse_from(BASE_ARGS_NO_WITNESS.iter().chain(extra));
 
     assert!(parse(&[]).unwrap().witness_endpoint.is_empty());
     assert!(parse(&["--witness-source", "r2"]).unwrap().witness_endpoint.is_empty());

--- a/crates/stateless-common/Cargo.toml
+++ b/crates/stateless-common/Cargo.toml
@@ -36,7 +36,7 @@ eyre.workspace = true
 fastrand = { workspace = true, features = ["std"] }
 futures.workspace = true
 # Enables gzip/brotli on alloy-provider's reqwest 0.12 (Cargo feature unification) for witness/data fetches; not referenced in code.
-reqwest = { version = "0.12", default-features = false, features = ["gzip", "brotli"] }
+reqwest = { workspace = true, features = ["gzip", "brotli"] }
 rolling-file.workspace = true
 serde.workspace = true
 thiserror.workspace = true

--- a/crates/stateless-core/src/pipeline/fetcher.rs
+++ b/crates/stateless-core/src/pipeline/fetcher.rs
@@ -30,6 +30,10 @@ struct FetcherState<F: BlockFetcher> {
     /// Blocks awaiting retry. The RPC client retries transient errors internally, so failures
     /// bubbling up here are rare (integrity-check failures from corrupt providers). Re-enqueue
     /// without delay — a retry that rotates round-robin to a different provider will succeed.
+    /// Single-endpoint fetch sources have no rotation to lean on, so any pacing of deterministic
+    /// failures is their own responsibility (e.g. the validator's R2 witness client throttles
+    /// before surfacing them); if per-block re-enqueue backoff ever lands here, those client-side
+    /// throttles should be removed.
     failed: HashSet<u64>,
 }
 

--- a/crates/stateless-core/src/pipeline/fetcher.rs
+++ b/crates/stateless-core/src/pipeline/fetcher.rs
@@ -30,10 +30,8 @@ struct FetcherState<F: BlockFetcher> {
     /// Blocks awaiting retry. The RPC client retries transient errors internally, so failures
     /// bubbling up here are rare (integrity-check failures from corrupt providers). Re-enqueue
     /// without delay — a retry that rotates round-robin to a different provider will succeed.
-    /// Single-endpoint fetch sources have no rotation to lean on, so any pacing of deterministic
-    /// failures is their own responsibility (e.g. the validator's R2 witness client throttles
-    /// before surfacing them); if per-block re-enqueue backoff ever lands here, those client-side
-    /// throttles should be removed.
+    /// Single-endpoint sources have no rotation, so they must pace their own deterministic
+    /// failures (e.g. the R2 witness client's throttle) — remove those if backoff lands here.
     failed: HashSet<u64>,
 }
 

--- a/crates/stateless-r2/Cargo.toml
+++ b/crates/stateless-r2/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "stateless-r2"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+exclude.workspace = true
+description = "Shared Cloudflare R2 (S3-compatible) witness primitives: minimal SigV4 signer, object-key layout, endpoint parsing, and signed PUT helper shared by the mega-reth witness uploaders (write path) and the stateless validator (read path)."
+
+[dependencies]
+# misc
+bytes.workspace = true
+chrono = { workspace = true, features = ["clock"] }
+hex = { workspace = true, features = ["alloc"] }
+hmac.workspace = true
+percent-encoding.workspace = true
+# Pinned explicitly (not workspace-inherited): `put_object` exposes `&reqwest::Client`, so the
+# reqwest major is part of this crate's API and must match mega-reth's workspace (0.12). Bumping
+# it is a coordinated two-repo change that a workspace-wide bump must not ride over.
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
+sha2.workspace = true

--- a/crates/stateless-r2/src/client.rs
+++ b/crates/stateless-r2/src/client.rs
@@ -39,12 +39,9 @@ pub enum R2Error {
 }
 
 impl R2Error {
-    /// Whether this failure means the endpoint itself is unhealthy/overloaded and the caller should
-    /// apply a backoff (transport failures, `429`, and any `5xx`) rather than retry immediately.
-    ///
-    /// This is the single source of truth for "should the upload pool back off?"; classifying
-    /// transport failures and `5xx` here — not just `429`/`503` — is what prevents a retry storm
-    /// against an overloaded R2 endpoint.
+    /// Whether this failure means the endpoint itself is unhealthy/overloaded and the caller
+    /// should apply a backoff (transport failures, `429`, and any `5xx`) rather than retry
+    /// immediately.
     pub const fn is_backoff_worthy(&self) -> bool {
         matches!(self, Self::Transport(_) | Self::Throttled { .. })
     }
@@ -101,12 +98,9 @@ pub async fn put_object(
     classify_response(response).await
 }
 
-/// Whether a non-success HTTP status means R2 is throttling or struggling (`429` and any `5xx`)
-/// and the caller should back off before retrying, as opposed to a status that will not clear on
-/// retry.
-///
-/// The single definition of the throttle set: both the write path ([`classify_response`]) and the
-/// stateless validator's R2 witness reader classify with this predicate, so the two cannot drift.
+/// Whether a non-success status (`429` or any `5xx`) is backoff-worthy throttling, as opposed to
+/// one that will not clear on retry. The single definition of the throttle set — the write path
+/// (`classify_response`) and the validator's R2 reader both classify with it.
 pub const fn is_throttle_status(status: u16) -> bool {
     status == 429 || status >= 500
 }

--- a/crates/stateless-r2/src/client.rs
+++ b/crates/stateless-r2/src/client.rs
@@ -101,8 +101,18 @@ pub async fn put_object(
     classify_response(response).await
 }
 
-/// Classifies an R2 (S3 API) response into [`R2Error`], treating `429` and any `5xx` as
-/// backoff-worthy throttling and every other non-success status as a plain failure.
+/// Whether a non-success HTTP status means R2 is throttling or struggling (`429` and any `5xx`)
+/// and the caller should back off before retrying, as opposed to a status that will not clear on
+/// retry.
+///
+/// The single definition of the throttle set: both the write path ([`classify_response`]) and the
+/// stateless validator's R2 witness reader classify with this predicate, so the two cannot drift.
+pub const fn is_throttle_status(status: u16) -> bool {
+    status == 429 || status >= 500
+}
+
+/// Classifies an R2 (S3 API) response into [`R2Error`], treating [`is_throttle_status`] statuses
+/// as backoff-worthy throttling and every other non-success status as a plain failure.
 async fn classify_response(response: reqwest::Response) -> Result<(), R2Error> {
     let status = response.status();
     if status.is_success() {
@@ -110,7 +120,7 @@ async fn classify_response(response: reqwest::Response) -> Result<(), R2Error> {
     }
     let code = status.as_u16();
     let body = response.text().await.unwrap_or_default();
-    if code == 429 || code >= 500 {
+    if is_throttle_status(code) {
         Err(R2Error::Throttled { status: code, body })
     } else {
         Err(R2Error::Status { status: code, body })

--- a/crates/stateless-r2/src/client.rs
+++ b/crates/stateless-r2/src/client.rs
@@ -1,0 +1,133 @@
+//! Signed `PUT` helper and response classification for R2 uploads.
+//!
+//! [`put_object`] signs a single object `PUT` with `SigV4` (signed-payload mode) and sends it,
+//! mapping the outcome to [`R2Error`]. Both uploaders share this so the set of statuses that should
+//! trigger a backoff stays identical between the two binaries.
+
+use bytes::Bytes;
+use chrono::Utc;
+use reqwest::Client;
+
+use crate::sigv4::{Header, SigV4Signer, encode_uri_path};
+
+/// Failure outcome of a signed R2 `PUT`.
+#[derive(Debug)]
+pub enum R2Error {
+    /// The endpoint host was empty (endpoint not configured or not a valid URL); nothing was sent.
+    InvalidEndpoint,
+    /// The request never produced an HTTP response — a transport-level failure such as a
+    /// connection timeout or reset. The endpoint is effectively unreachable, so the caller
+    /// should back off before retrying.
+    Transport(String),
+    /// The endpoint asked us to slow down (`429`) or returned a server-side error (`5xx`,
+    /// including R2's `503` overload / `SlowDown`). Retrying without a backoff would keep
+    /// hammering a struggling endpoint, so the caller should back off.
+    Throttled {
+        /// HTTP status code returned by R2.
+        status: u16,
+        /// Response body (best-effort), included for diagnostics.
+        body: String,
+    },
+    /// A non-success status that is unlikely to clear on an immediate retry (typically a `4xx`
+    /// other than `429`). The caller may requeue but a pool-wide backoff is not warranted.
+    Status {
+        /// HTTP status code returned by R2.
+        status: u16,
+        /// Response body (best-effort), included for diagnostics.
+        body: String,
+    },
+}
+
+impl R2Error {
+    /// Whether this failure means the endpoint itself is unhealthy/overloaded and the caller should
+    /// apply a backoff (transport failures, `429`, and any `5xx`) rather than retry immediately.
+    ///
+    /// This is the single source of truth for "should the upload pool back off?"; classifying
+    /// transport failures and `5xx` here — not just `429`/`503` — is what prevents a retry storm
+    /// against an overloaded R2 endpoint.
+    pub const fn is_backoff_worthy(&self) -> bool {
+        matches!(self, Self::Transport(_) | Self::Throttled { .. })
+    }
+}
+
+impl std::fmt::Display for R2Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidEndpoint => write!(f, "R2 endpoint is not a valid URL"),
+            Self::Transport(err) => write!(f, "R2 request transport failure: {err}"),
+            Self::Throttled { status, body } => {
+                write!(f, "R2 throttled or server error: {status} - {body}")
+            }
+            Self::Status { status, body } => write!(f, "R2 request failed: {status} - {body}"),
+        }
+    }
+}
+
+impl std::error::Error for R2Error {}
+
+/// Uploads a single object to R2 with a SigV4-signed `PUT` request.
+///
+/// `endpoint` is the origin (`scheme://host`, no trailing slash), `host` the `SigV4` canonical host
+/// (`host[:port]`), `bucket`/`key` the destination object, `body` the object bytes, and `meta` the
+/// `x-amz-meta-*` headers to store alongside the object (empty for pointer objects).
+///
+/// `body` is a [`Bytes`], so the caller can hand off a cheap clone of an already-buffered payload;
+/// `reqwest` consumes it without an extra copy.
+// The connection parameters (client/signer/endpoint/host/bucket) live on the caller's uploader
+// struct; passing them through keeps this helper stateless and avoids a second copy of that state.
+#[allow(clippy::too_many_arguments)]
+pub async fn put_object(
+    client: &Client,
+    signer: &SigV4Signer,
+    endpoint: &str,
+    host: &str,
+    bucket: &str,
+    key: &str,
+    body: Bytes,
+    meta: &[Header],
+) -> Result<(), R2Error> {
+    if host.is_empty() {
+        return Err(R2Error::InvalidEndpoint);
+    }
+    let canonical_uri = encode_uri_path(bucket, key);
+    let url = format!("{endpoint}{canonical_uri}");
+    let signed = signer.sign("PUT", host, &canonical_uri, "", meta, &body, Utc::now());
+
+    let mut request = client.put(&url).body(body);
+    for (name, value) in signed {
+        request = request.header(name, value);
+    }
+    let response = request.send().await.map_err(|err| R2Error::Transport(err.to_string()))?;
+    classify_response(response).await
+}
+
+/// Classifies an R2 (S3 API) response into [`R2Error`], treating `429` and any `5xx` as
+/// backoff-worthy throttling and every other non-success status as a plain failure.
+async fn classify_response(response: reqwest::Response) -> Result<(), R2Error> {
+    let status = response.status();
+    if status.is_success() {
+        return Ok(());
+    }
+    let code = status.as_u16();
+    let body = response.text().await.unwrap_or_default();
+    if code == 429 || code >= 500 {
+        Err(R2Error::Throttled { status: code, body })
+    } else {
+        Err(R2Error::Status { status: code, body })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn backoff_worthy_covers_transport_and_throttled_only() {
+        assert!(R2Error::Transport("timeout".to_string()).is_backoff_worthy());
+        assert!(R2Error::Throttled { status: 429, body: String::new() }.is_backoff_worthy());
+        assert!(R2Error::Throttled { status: 503, body: String::new() }.is_backoff_worthy());
+        assert!(R2Error::Throttled { status: 500, body: String::new() }.is_backoff_worthy());
+        assert!(!R2Error::Status { status: 403, body: String::new() }.is_backoff_worthy());
+        assert!(!R2Error::InvalidEndpoint.is_backoff_worthy());
+    }
+}

--- a/crates/stateless-r2/src/endpoint.rs
+++ b/crates/stateless-r2/src/endpoint.rs
@@ -1,0 +1,87 @@
+//! R2 endpoint parsing shared by both witness uploaders.
+
+use reqwest::Url;
+
+/// Parses an R2 endpoint into its origin (`scheme://host[:port]`, no trailing slash) and the
+/// request host (`host[:port]`) used for `SigV4` canonical headers.
+///
+/// Returns empty strings when the endpoint is unusable: not a valid URL, no host, or anything
+/// beyond a bare origin (path/query/fragment). A path would be sent on the wire but never signed
+/// (the signer builds `/{bucket}/{key}` itself), failing every request with 403
+/// `SignatureDoesNotMatch` — so e.g. a pasted R2 dashboard bucket URL is rejected at startup.
+pub fn parse_endpoint(endpoint: &str) -> (String, String) {
+    let empty = || (String::new(), String::new());
+    let trimmed = endpoint.trim_end_matches('/');
+    let Ok(url) = Url::parse(trimmed) else { return empty() };
+    let Some(host_str) = url.host_str() else { return empty() };
+
+    // Accept only a bare origin. `Url` normalizes a hostname-only URL to a "/" path, so treat "/"
+    // (and the empty path) as "no path"; anything else — plus any query or fragment — is a
+    // misconfigured endpoint we must not silently forward.
+    let has_path = !matches!(url.path(), "" | "/");
+    if has_path || url.query().is_some() || url.fragment().is_some() {
+        return empty();
+    }
+
+    let host = match url.port() {
+        Some(port) => format!("{host_str}:{port}"),
+        None => host_str.to_string(),
+    };
+    // Reconstruct the origin from the parsed components rather than echoing the input, so no path
+    // can leak into it even if the trimming above ever misses a shape.
+    let origin = format!("{}://{host}", url.scheme());
+    (origin, host)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_endpoint_strips_trailing_slash_and_extracts_host() {
+        let (endpoint, host) = parse_endpoint("https://acc.r2.cloudflarestorage.com/");
+        assert_eq!(endpoint, "https://acc.r2.cloudflarestorage.com");
+        assert_eq!(host, "acc.r2.cloudflarestorage.com");
+    }
+
+    #[test]
+    fn parse_endpoint_keeps_non_default_port() {
+        let (endpoint, host) = parse_endpoint("http://localhost:9000");
+        assert_eq!(endpoint, "http://localhost:9000");
+        assert_eq!(host, "localhost:9000");
+    }
+
+    #[test]
+    fn parse_endpoint_rejects_invalid_url() {
+        let (endpoint, host) = parse_endpoint("not a url");
+        assert!(endpoint.is_empty());
+        assert!(host.is_empty());
+    }
+
+    #[test]
+    fn parse_endpoint_rejects_endpoint_with_path() {
+        // A pasted dashboard bucket URL (bucket embedded as a path) must be rejected — the path
+        // would be sent on the wire but never signed, failing SigV4.
+        let (endpoint, host) =
+            parse_endpoint("https://acc.r2.cloudflarestorage.com/witness-testnet");
+        assert!(endpoint.is_empty(), "an endpoint with a path must be rejected");
+        assert!(host.is_empty(), "an endpoint with a path must be rejected");
+
+        // A trailing-slash-only path is still just the origin and must be accepted.
+        let (endpoint, host) = parse_endpoint("https://acc.r2.cloudflarestorage.com/");
+        assert_eq!(endpoint, "https://acc.r2.cloudflarestorage.com");
+        assert_eq!(host, "acc.r2.cloudflarestorage.com");
+    }
+
+    #[test]
+    fn parse_endpoint_rejects_query_and_fragment() {
+        assert_eq!(
+            parse_endpoint("https://acc.r2.cloudflarestorage.com/?x=1"),
+            (String::new(), String::new())
+        );
+        assert_eq!(
+            parse_endpoint("https://acc.r2.cloudflarestorage.com/#frag"),
+            (String::new(), String::new())
+        );
+    }
+}

--- a/crates/stateless-r2/src/endpoint.rs
+++ b/crates/stateless-r2/src/endpoint.rs
@@ -16,8 +16,7 @@ pub fn parse_endpoint(endpoint: &str) -> (String, String) {
     let Some(host_str) = url.host_str() else { return empty() };
 
     // Accept only a bare origin. `Url` normalizes a hostname-only URL to a "/" path, so treat "/"
-    // (and the empty path) as "no path"; anything else — plus any query or fragment — is a
-    // misconfigured endpoint we must not silently forward.
+    // (and the empty path) as "no path"; any other path, query, or fragment is rejected.
     let has_path = !matches!(url.path(), "" | "/");
     if has_path || url.query().is_some() || url.fragment().is_some() {
         return empty();
@@ -60,8 +59,6 @@ mod tests {
 
     #[test]
     fn parse_endpoint_rejects_endpoint_with_path() {
-        // A pasted dashboard bucket URL (bucket embedded as a path) must be rejected — the path
-        // would be sent on the wire but never signed, failing SigV4.
         let (endpoint, host) =
             parse_endpoint("https://acc.r2.cloudflarestorage.com/witness-testnet");
         assert!(endpoint.is_empty(), "an endpoint with a path must be rejected");

--- a/crates/stateless-r2/src/keys.rs
+++ b/crates/stateless-r2/src/keys.rs
@@ -1,0 +1,168 @@
+//! R2 object-key layout shared by the witness writers and the validator's reader.
+//!
+//! Every witness is archived as three objects under a `{range_start}_{range_end}` bucket:
+//! - the **primary** object `block/{range}/{number}.{hash}` carrying the compressed witness bytes;
+//! - an **attr** pointer `attr/{range}/{parent_hash}.{attr_hash}`;
+//! - a **num** pointer `num/{range}/{number}`.
+//!
+//! This module is the single home of that layout plus the shared [`pointer_body`] and the
+//! `x-amz-meta-*` [`witness_metadata`], so the producers and the reader cannot drift. Objects
+//! carry no per-object expiry; retention is a bucket lifecycle rule targeting these prefixes
+//! (see the crate-level docs).
+
+use std::fmt::Display;
+
+use crate::sigv4::Header;
+
+/// Object-key prefix for the primary witness object (the compressed witness body).
+pub const BLOCK_PREFIX: &str = "block";
+
+/// Object-key prefix for the `(parent_hash, attributes_hash)` reference pointer.
+pub const ATTR_PREFIX: &str = "attr";
+
+/// Object-key prefix for the by-block-number reference pointer.
+pub const NUM_PREFIX: &str = "num";
+
+/// Block range size for grouping keys (1000 blocks per group).
+///
+/// Blocks are grouped into ranges of 1000 so R2 list and lifecycle operations can target contiguous
+/// block ranges by prefix.
+pub const BLOCK_RANGE_SIZE: u64 = 1000;
+
+/// Calculate the range-bucket prefix for grouping blocks into ranges.
+///
+/// For example:
+/// - Block 0-999 → prefix 0
+/// - Block 1000-1999 → prefix 1000
+/// - Block 2500 → prefix 2000
+#[inline]
+pub const fn block_range_prefix(block_number: u64) -> u64 {
+    (block_number / BLOCK_RANGE_SIZE) * BLOCK_RANGE_SIZE
+}
+
+/// Builds just the primary witness object key: `block/{range}/{number}.{hash}`.
+///
+/// This is the single implementation of the primary-key template. [`object_keys`] (the write path)
+/// delegates here, and the stateless validator's R2 witness source (the read path) calls it
+/// directly, so the writers and the reader can never disagree on where a witness lives.
+pub fn block_object_key(block_number: u64, block_hash: impl Display) -> String {
+    let range_start = block_range_prefix(block_number);
+    let range_end = range_start + BLOCK_RANGE_SIZE - 1;
+    format!("{BLOCK_PREFIX}/{range_start}_{range_end}/{block_number}.{block_hash}")
+}
+
+/// Builds the three R2 object keys for a witness from its block number and identifying hashes.
+///
+/// Keys use a `{range_start}_{range_end}` bucket where `range_start = (number / 1000) * 1000`,
+/// decimal block numbers, and lowercase hex hashes (alloy `B256` formats lowercase via `Display`).
+///
+/// Returns `(block_key, attr_key, num_key)`.
+pub fn object_keys(
+    block_number: u64,
+    block_hash: impl Display,
+    parent_hash: impl Display,
+    op_attr_hash: impl Display,
+) -> (String, String, String) {
+    let range_start = block_range_prefix(block_number);
+    let range_end = range_start + BLOCK_RANGE_SIZE - 1;
+    let range = format!("{range_start}_{range_end}");
+    let block_key = block_object_key(block_number, block_hash);
+    let attr_key = format!("{ATTR_PREFIX}/{range}/{parent_hash}.{op_attr_hash}");
+    let num_key = format!("{NUM_PREFIX}/{range}/{block_number}");
+    (block_key, attr_key, num_key)
+}
+
+/// Builds the plaintext body shared by both pointer objects: `"{block_number}.{block_hash}"`.
+///
+/// Both pointer objects (`attr/...` and `num/...`) store this same reference to the primary object.
+/// The stateless validator parses it, so the generator and the replayer must produce it
+/// identically.
+pub fn pointer_body(block_number: u64, block_hash: impl Display) -> String {
+    format!("{block_number}.{block_hash}")
+}
+
+/// Builds the `x-amz-meta-*` custom-metadata headers stored alongside the primary witness object.
+///
+/// The generator and the replayer must emit the same header names, order, and values — hence a
+/// single shared builder rather than a copy per binary.
+pub fn witness_metadata(
+    original_size: usize,
+    compressed_size: usize,
+    parent_hash: impl Display,
+    op_attr_hash: impl Display,
+) -> Vec<Header> {
+    vec![
+        ("x-amz-meta-compression".to_string(), "zstd".to_string()),
+        ("x-amz-meta-original-size".to_string(), original_size.to_string()),
+        ("x-amz-meta-compressed-size".to_string(), compressed_size.to_string()),
+        ("x-amz-meta-parent-hash".to_string(), parent_hash.to_string()),
+        ("x-amz-meta-attr-hash".to_string(), op_attr_hash.to_string()),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn block_range_prefix_buckets_by_thousand() {
+        assert_eq!(block_range_prefix(0), 0);
+        assert_eq!(block_range_prefix(999), 0);
+        assert_eq!(block_range_prefix(1000), 1000);
+        assert_eq!(block_range_prefix(1001), 1000);
+        assert_eq!(block_range_prefix(2500), 2000);
+        assert_eq!(block_range_prefix(9999), 9000);
+        assert_eq!(block_range_prefix(10000), 10000);
+    }
+
+    #[test]
+    fn object_keys_use_expected_layout() {
+        let (block_key, attr_key, num_key) = object_keys(2500, "0xblock", "0xparent", "0xattr");
+        assert_eq!(block_key, "block/2000_2999/2500.0xblock");
+        assert_eq!(attr_key, "attr/2000_2999/0xparent.0xattr");
+        assert_eq!(num_key, "num/2000_2999/2500");
+    }
+
+    /// Golden wire vector: the key of a real migrated mainnet object, transcribed from the
+    /// production R2 bucket — not generated by this code — so the key template is certified
+    /// against the bytes actually in R2 rather than against itself.
+    #[test]
+    fn block_object_key_matches_migrated_mainnet_object() {
+        assert_eq!(
+            block_object_key(
+                6_632_136,
+                "0x05dd41e545b25db0ce04f628e6e1705232240c70a0435c8233ac4479176fe6b0",
+            ),
+            "block/6632000_6632999/6632136.\
+             0x05dd41e545b25db0ce04f628e6e1705232240c70a0435c8233ac4479176fe6b0",
+        );
+    }
+
+    /// The write path's block key must stay byte-identical to the read path's — both must go
+    /// through [`block_object_key`].
+    #[test]
+    fn object_keys_block_key_delegates_to_block_object_key() {
+        let (block_key, _, _) = object_keys(2500, "0xblock", "0xparent", "0xattr");
+        assert_eq!(block_key, block_object_key(2500, "0xblock"));
+    }
+
+    #[test]
+    fn pointer_body_is_number_dot_hash() {
+        assert_eq!(pointer_body(2500, "0xblock"), "2500.0xblock");
+    }
+
+    #[test]
+    fn witness_metadata_emits_expected_headers() {
+        let meta = witness_metadata(4096, 1024, "0xparent", "0xattr");
+        assert_eq!(
+            meta,
+            vec![
+                ("x-amz-meta-compression".to_string(), "zstd".to_string()),
+                ("x-amz-meta-original-size".to_string(), "4096".to_string()),
+                ("x-amz-meta-compressed-size".to_string(), "1024".to_string()),
+                ("x-amz-meta-parent-hash".to_string(), "0xparent".to_string()),
+                ("x-amz-meta-attr-hash".to_string(), "0xattr".to_string()),
+            ]
+        );
+    }
+}

--- a/crates/stateless-r2/src/keys.rs
+++ b/crates/stateless-r2/src/keys.rs
@@ -6,9 +6,8 @@
 //! - a **num** pointer `num/{range}/{number}`.
 //!
 //! This module is the single home of that layout plus the shared [`pointer_body`] and the
-//! `x-amz-meta-*` [`witness_metadata`], so the producers and the reader cannot drift. Objects
-//! carry no per-object expiry; retention is a bucket lifecycle rule targeting these prefixes
-//! (see the crate-level docs).
+//! `x-amz-meta-*` [`witness_metadata`], so the producers and the reader cannot drift. Retention
+//! is a bucket lifecycle rule targeting these prefixes (see the crate-level docs).
 
 use std::fmt::Display;
 
@@ -23,10 +22,8 @@ pub const ATTR_PREFIX: &str = "attr";
 /// Object-key prefix for the by-block-number reference pointer.
 pub const NUM_PREFIX: &str = "num";
 
-/// Block range size for grouping keys (1000 blocks per group).
-///
-/// Blocks are grouped into ranges of 1000 so R2 list and lifecycle operations can target contiguous
-/// block ranges by prefix.
+/// Block range size for grouping keys: ranges let R2 list and lifecycle operations target
+/// contiguous blocks by prefix.
 pub const BLOCK_RANGE_SIZE: u64 = 1000;
 
 /// Calculate the range-bucket prefix for grouping blocks into ranges.
@@ -42,9 +39,9 @@ pub const fn block_range_prefix(block_number: u64) -> u64 {
 
 /// Builds just the primary witness object key: `block/{range}/{number}.{hash}`.
 ///
-/// This is the single implementation of the primary-key template. [`object_keys`] (the write path)
-/// delegates here, and the stateless validator's R2 witness source (the read path) calls it
-/// directly, so the writers and the reader can never disagree on where a witness lives.
+/// The single implementation of the primary-key template: both the write path ([`object_keys`])
+/// and the validator's reader build the key here, so they can never disagree on where a witness
+/// lives.
 pub fn block_object_key(block_number: u64, block_hash: impl Display) -> String {
     let range_start = block_range_prefix(block_number);
     let range_end = range_start + BLOCK_RANGE_SIZE - 1;
@@ -83,8 +80,7 @@ pub fn pointer_body(block_number: u64, block_hash: impl Display) -> String {
 
 /// Builds the `x-amz-meta-*` custom-metadata headers stored alongside the primary witness object.
 ///
-/// The generator and the replayer must emit the same header names, order, and values — hence a
-/// single shared builder rather than a copy per binary.
+/// The generator and the replayer must emit identical header names, order, and values.
 pub fn witness_metadata(
     original_size: usize,
     compressed_size: usize,

--- a/crates/stateless-r2/src/lib.rs
+++ b/crates/stateless-r2/src/lib.rs
@@ -1,0 +1,30 @@
+//! Shared Cloudflare R2 (S3-compatible) witness primitives.
+//!
+//! Both witness producers — mega-reth's standalone witness generator (`bin/stateless/witness`) and
+//! its replayer uploader (`bin/replayer/src/uploader`) — archive block witnesses to the same
+//! Cloudflare R2 bucket using R2's S3-compatible API, and this repo's validator reads them back
+//! (`bin/stateless-validator/src/r2_witness.rs`). The request signing, object-key layout, and
+//! response handling must be byte-for-byte identical across all of them, or the validator can no
+//! longer locate or authenticate against the uploaded objects. This crate is the single home for
+//! those primitives so the writers and the reader cannot drift; it lives in this repo and mega-reth
+//! consumes it from the same git tags it already pulls `stateless-core` / `stateless-common` from:
+//!
+//! - [`sigv4`] — a minimal AWS Signature Version 4 signer for buffered `PUT`/`GET`/`DELETE`
+//!   requests;
+//! - [`keys`] — the `block/`, `attr/`, `num/` object-key scheme and its block-range bucketing;
+//! - [`endpoint`] — parsing an R2 endpoint into the origin and `SigV4` canonical host;
+//! - [`client`] — a signed `PUT` helper that classifies the response into a small retry-friendly
+//!   error set ([`client::R2Error`]).
+//!
+//! ## Object retention
+//!
+//! Objects are written with **no per-object expiry**, so retention must be enforced by an R2
+//! **bucket lifecycle rule**. The [`keys`] layout buckets objects under the `block/`, `attr/`, and
+//! `num/` prefixes (and `{range_start}_{range_end}` sub-folders) precisely so a lifecycle rule can
+//! target contiguous block ranges by prefix. If no lifecycle rule is configured, the bucket grows
+//! without bound.
+
+pub mod client;
+pub mod endpoint;
+pub mod keys;
+pub mod sigv4;

--- a/crates/stateless-r2/src/lib.rs
+++ b/crates/stateless-r2/src/lib.rs
@@ -6,8 +6,7 @@
 //! (`bin/stateless-validator/src/r2_witness.rs`). The request signing, object-key layout, and
 //! response handling must be byte-for-byte identical across all of them, or the validator can no
 //! longer locate or authenticate against the uploaded objects. This crate is the single home for
-//! those primitives so the writers and the reader cannot drift; it lives in this repo and mega-reth
-//! consumes it from the same git tags it already pulls `stateless-core` / `stateless-common` from:
+//! those primitives so the writers and the reader cannot drift:
 //!
 //! - [`sigv4`] — a minimal AWS Signature Version 4 signer for buffered `PUT`/`GET`/`DELETE`
 //!   requests;

--- a/crates/stateless-r2/src/sigv4.rs
+++ b/crates/stateless-r2/src/sigv4.rs
@@ -38,9 +38,8 @@ const URI_SEGMENT: &AsciiSet =
 pub type Header = (String, String);
 
 /// Region placed in the credential scope. R2 ignores the value but requires a non-empty scope;
-/// Cloudflare's documented convention is the literal string `"auto"`. Unlike the endpoint, bucket,
-/// and credentials, this never varies by deployment, so it is hardcoded rather than exposed as a
-/// CLI/env option.
+/// Cloudflare's documented convention is the literal string `"auto"`. Never varies by deployment,
+/// so hardcoded.
 const REGION: &str = "auto";
 
 /// Holds the long-lived credentials and scope used to sign R2 requests.
@@ -48,9 +47,9 @@ const REGION: &str = "auto";
 pub struct SigV4Signer {
     access_key_id: String,
     secret_access_key: String,
-    /// Region placed in the credential scope. Always [`REGION`].
+    /// Always [`REGION`].
     region: String,
-    /// AWS service name in the credential scope. Always `"s3"` for R2.
+    /// Always `"s3"` for R2.
     service: String,
 }
 
@@ -139,10 +138,9 @@ impl SigV4Signer {
             self.access_key_id
         );
 
-        // Return the headers the caller must send: exactly the set that was signed, minus `host`
-        // (the HTTP client sets that from the URL), plus the computed authorization. Reusing the
-        // signed `headers` here — instead of rebuilding the list — both avoids re-cloning the meta
-        // headers and makes it impossible for the sent set to disagree with the signed set.
+        // Return exactly the signed set minus `host` (the HTTP client sets it from the URL) plus
+        // the computed authorization — reusing the signed list makes sent == signed by
+        // construction.
         let mut out: Vec<Header> = headers.into_iter().filter(|(name, _)| name != "host").collect();
         out.push(("authorization".to_string(), authorization));
         out
@@ -238,7 +236,6 @@ mod tests {
             now,
         );
 
-        // The signed payload hash is hex(sha256("payload")).
         let content_sha = headers
             .iter()
             .find(|(k, _)| k == "x-amz-content-sha256")

--- a/crates/stateless-r2/src/sigv4.rs
+++ b/crates/stateless-r2/src/sigv4.rs
@@ -1,0 +1,313 @@
+//! Minimal AWS Signature Version 4 signer for S3-compatible object storage.
+//!
+//! The witness uploaders write to Cloudflare R2 through R2's S3 API. R2 authenticates requests with
+//! AWS `SigV4` (`service = "s3"`, `region = "auto"`), so this module implements just the slice of
+//! `SigV4` the uploaders need: signing a single `PUT` / `GET` / `DELETE` request whose payload is
+//! fully buffered in memory.
+//!
+//! Only the "signed payload" mode is implemented (`x-amz-content-sha256 = hex(sha256(body))`),
+//! which is appropriate because compressed witnesses are at most tens of MiB and are already held
+//! as buffered bytes on the upload path. Streaming / `UNSIGNED-PAYLOAD` is intentionally omitted.
+//!
+//! Reference: <https://docs.aws.amazon.com/IAM/latest/UserGuide/create-signed-request.html>.
+
+use chrono::{DateTime, Utc};
+use hmac::{Hmac, Mac};
+use percent_encoding::{AsciiSet, NON_ALPHANUMERIC};
+use sha2::{Digest, Sha256};
+
+type HmacSha256 = Hmac<Sha256>;
+
+/// `SigV4` signing algorithm identifier.
+const ALGORITHM: &str = "AWS4-HMAC-SHA256";
+
+/// The `aws4_request` terminator used by both the credential scope and the signing key.
+const REQUEST_TYPE: &str = "aws4_request";
+
+/// Characters that do **not** need percent-encoding in a `SigV4` canonical URI path segment.
+///
+/// AWS leaves the RFC 3986 *unreserved* set (`A-Z a-z 0-9 - _ . ~`) untouched and percent-encodes
+/// everything else. `NON_ALPHANUMERIC` encodes every non-alphanumeric byte, so we remove the four
+/// unreserved punctuation characters from it. The path separator `/` is handled by the caller,
+/// which encodes each segment independently and rejoins them with `/`.
+const URI_SEGMENT: &AsciiSet =
+    &NON_ALPHANUMERIC.remove(b'-').remove(b'_').remove(b'.').remove(b'~');
+
+/// A single HTTP header (lowercase name, value) that participates in signing and is sent on the
+/// request.
+pub type Header = (String, String);
+
+/// Region placed in the credential scope. R2 ignores the value but requires a non-empty scope;
+/// Cloudflare's documented convention is the literal string `"auto"`. Unlike the endpoint, bucket,
+/// and credentials, this never varies by deployment, so it is hardcoded rather than exposed as a
+/// CLI/env option.
+const REGION: &str = "auto";
+
+/// Holds the long-lived credentials and scope used to sign R2 requests.
+#[derive(Clone)]
+pub struct SigV4Signer {
+    access_key_id: String,
+    secret_access_key: String,
+    /// Region placed in the credential scope. Always [`REGION`].
+    region: String,
+    /// AWS service name in the credential scope. Always `"s3"` for R2.
+    service: String,
+}
+
+impl std::fmt::Debug for SigV4Signer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Never print the credentials.
+        f.debug_struct("SigV4Signer")
+            .field("access_key_id", &"[redacted]")
+            .field("secret_access_key", &"[redacted]")
+            .field("region", &self.region)
+            .field("service", &self.service)
+            .finish()
+    }
+}
+
+impl SigV4Signer {
+    /// Builds a signer from bucket-scoped R2 credentials.
+    pub fn new(access_key_id: String, secret_access_key: String) -> Self {
+        Self {
+            access_key_id,
+            secret_access_key,
+            region: REGION.to_string(),
+            service: "s3".to_string(),
+        }
+    }
+
+    /// Signs a request and returns the complete set of headers to attach to it.
+    ///
+    /// `host` is the request host with no scheme or trailing slash (e.g.
+    /// `<account>.r2.cloudflarestorage.com`). `canonical_uri` is the absolute, already
+    /// percent-encoded request path (see [`encode_uri_path`]). `extra_headers` are additional
+    /// lowercase headers that must be covered by the signature — typically the `x-amz-meta-*`
+    /// custom-metadata headers; their names must be lowercase and they must also be sent on the
+    /// wire exactly as signed.
+    ///
+    /// The returned vector contains `extra_headers` plus the three computed headers
+    /// (`x-amz-date`, `x-amz-content-sha256`, `authorization`); the caller attaches every entry to
+    /// the outgoing request.
+    // The parameters mirror the inputs to the SigV4 canonical request; bundling them into a struct
+    // would only add indirection at the single call site in `client::put_object`.
+    #[allow(clippy::too_many_arguments)]
+    pub fn sign(
+        &self,
+        method: &str,
+        host: &str,
+        canonical_uri: &str,
+        canonical_query: &str,
+        extra_headers: &[Header],
+        payload: &[u8],
+        now: DateTime<Utc>,
+    ) -> Vec<Header> {
+        let amz_date = now.format("%Y%m%dT%H%M%SZ").to_string();
+        let date_stamp = now.format("%Y%m%d").to_string();
+        let payload_hash = hex::encode(Sha256::digest(payload));
+
+        // Assemble the full signed-header set: host + the two amz headers + caller extras.
+        let mut headers: Vec<Header> = Vec::with_capacity(extra_headers.len() + 3);
+        headers.push(("host".to_string(), host.to_string()));
+        headers.push(("x-amz-content-sha256".to_string(), payload_hash.clone()));
+        headers.push(("x-amz-date".to_string(), amz_date.clone()));
+        headers.extend(extra_headers.iter().cloned());
+        // Canonical headers are sorted by lowercase name; values are trimmed.
+        headers.sort_by(|a, b| a.0.cmp(&b.0));
+
+        let canonical_headers: String =
+            headers.iter().map(|(k, v)| format!("{k}:{}\n", v.trim())).collect();
+        let signed_headers: String =
+            headers.iter().map(|(k, _)| k.as_str()).collect::<Vec<_>>().join(";");
+
+        let canonical_request = format!(
+            "{method}\n{canonical_uri}\n{canonical_query}\n{canonical_headers}\n{signed_headers}\n{payload_hash}"
+        );
+
+        let credential_scope =
+            format!("{date_stamp}/{}/{}/{REQUEST_TYPE}", self.region, self.service);
+        let string_to_sign = format!(
+            "{ALGORITHM}\n{amz_date}\n{credential_scope}\n{}",
+            hex::encode(Sha256::digest(canonical_request.as_bytes()))
+        );
+
+        let signing_key = self.signing_key(&date_stamp);
+        let signature = hex::encode(hmac(&signing_key, string_to_sign.as_bytes()));
+
+        let authorization = format!(
+            "{ALGORITHM} Credential={}/{credential_scope}, SignedHeaders={signed_headers}, Signature={signature}",
+            self.access_key_id
+        );
+
+        // Return the headers the caller must send: exactly the set that was signed, minus `host`
+        // (the HTTP client sets that from the URL), plus the computed authorization. Reusing the
+        // signed `headers` here — instead of rebuilding the list — both avoids re-cloning the meta
+        // headers and makes it impossible for the sent set to disagree with the signed set.
+        let mut out: Vec<Header> = headers.into_iter().filter(|(name, _)| name != "host").collect();
+        out.push(("authorization".to_string(), authorization));
+        out
+    }
+
+    /// Derives the `SigV4` signing key for the given date via the four-step HMAC chain.
+    fn signing_key(&self, date_stamp: &str) -> Vec<u8> {
+        let k_date =
+            hmac(format!("AWS4{}", self.secret_access_key).as_bytes(), date_stamp.as_bytes());
+        let k_region = hmac(&k_date, self.region.as_bytes());
+        let k_service = hmac(&k_region, self.service.as_bytes());
+        hmac(&k_service, REQUEST_TYPE.as_bytes())
+    }
+}
+
+/// Computes `HMAC-SHA256(key, data)`.
+fn hmac(key: &[u8], data: &[u8]) -> Vec<u8> {
+    let mut mac = HmacSha256::new_from_slice(key).expect("HMAC accepts keys of any size");
+    mac.update(data);
+    mac.finalize().into_bytes().to_vec()
+}
+
+/// Percent-encodes an object key into a `SigV4` canonical URI path.
+///
+/// Each `/`-delimited segment is encoded with the RFC 3986 unreserved set preserved, then the
+/// segments are rejoined with `/`. A leading `/` is always present. R2 object keys produced by the
+/// uploaders (`block/<range>/<n>.<hash>`, `attr/...`, `num/...`) are already within the unreserved
+/// set, but this keeps the signer correct for any key.
+pub fn encode_uri_path(bucket: &str, key: &str) -> String {
+    let mut path = String::from("/");
+    path.push_str(&encode_segment(bucket));
+    for segment in key.split('/') {
+        path.push('/');
+        path.push_str(&encode_segment(segment));
+    }
+    path
+}
+
+/// Percent-encodes a single path segment with the `SigV4` unreserved set.
+fn encode_segment(segment: &str) -> String {
+    percent_encoding::utf8_percent_encode(segment, URI_SEGMENT).to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// AWS-published test vector for the `SigV4` signing-key derivation.
+    ///
+    /// From <https://docs.aws.amazon.com/IAM/latest/UserGuide/create-signed-request.html>:
+    /// secret `wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY`, date `20150830`, region `us-east-1`,
+    /// service `iam` yields the documented signing key.
+    #[test]
+    fn signing_key_matches_aws_reference_vector() {
+        let signer = SigV4Signer {
+            access_key_id: "AKIDEXAMPLE".to_string(),
+            secret_access_key: "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY".to_string(), /* pragma: allowlist secret */
+            region: "us-east-1".to_string(),
+            service: "iam".to_string(),
+        };
+        let key = signer.signing_key("20150830");
+        assert_eq!(
+            hex::encode(key),
+            "c4afb1cc5771d871763a393e44b703571b55cc28424d1a5e86da6ed3c154a4b9"
+        );
+    }
+
+    #[test]
+    fn encode_uri_path_preserves_unreserved_and_separators() {
+        // Witness keys only contain unreserved characters plus `/`, so they pass through unchanged.
+        let path = encode_uri_path("witness-testnet", "block/2000_2999/2045.0x23758c4d28eed6");
+        assert_eq!(path, "/witness-testnet/block/2000_2999/2045.0x23758c4d28eed6");
+    }
+
+    #[test]
+    fn encode_uri_path_escapes_reserved_characters() {
+        // Defensive: a space and a colon must be percent-encoded, the `/` separators must not.
+        let path = encode_uri_path("b", "a b/c:d");
+        assert_eq!(path, "/b/a%20b/c%3Ad");
+    }
+
+    #[test]
+    fn sign_produces_authorization_and_amz_headers() {
+        let signer = SigV4Signer::new("access".to_string(), "secret".to_string());
+        let now = DateTime::parse_from_rfc3339("2026-06-13T12:00:00Z").unwrap().with_timezone(&Utc);
+        let headers = signer.sign(
+            "PUT",
+            "acc.r2.cloudflarestorage.com",
+            "/witness-testnet/block/2000_2999/2045.0xabc",
+            "",
+            &[("x-amz-meta-compression".to_string(), "zstd".to_string())],
+            b"payload",
+            now,
+        );
+
+        // The signed payload hash is hex(sha256("payload")).
+        let content_sha = headers
+            .iter()
+            .find(|(k, _)| k == "x-amz-content-sha256")
+            .map(|(_, v)| v.clone())
+            .expect("content sha header present");
+        assert_eq!(content_sha, hex::encode(Sha256::digest(b"payload")));
+
+        let auth = headers
+            .iter()
+            .find(|(k, _)| k == "authorization")
+            .map(|(_, v)| v.clone())
+            .expect("authorization header present");
+        // Credential scope, the signed-header list (sorted, includes the meta header), and a
+        // signature must all be present.
+        assert!(
+            auth.starts_with("AWS4-HMAC-SHA256 Credential=access/20260613/auto/s3/aws4_request")
+        );
+        assert!(
+            auth.contains(
+                "SignedHeaders=host;x-amz-content-sha256;x-amz-date;x-amz-meta-compression"
+            )
+        );
+        assert!(auth.contains("Signature="));
+        // The custom-metadata header is echoed back for the caller to send.
+        assert!(headers.iter().any(|(k, v)| k == "x-amz-meta-compression" && v == "zstd"));
+        // `host` is not returned (the HTTP client sets it from the URL).
+        assert!(!headers.iter().any(|(k, _)| k == "host"));
+    }
+
+    /// Golden wire vector: the byte-exact header set for a complete signed request, computed with
+    /// an independent SigV4 implementation (Python `hashlib`/`hmac` over the AWS-documented
+    /// algorithm) — not with this code — so the signer is certified against the algorithm rather
+    /// than against itself. Any change to canonicalization, header ordering, credential scope, or
+    /// the HMAC chain flips the pinned signature.
+    #[test]
+    fn sign_matches_independent_golden_vector() {
+        let signer = SigV4Signer::new("access".to_string(), "secret".to_string());
+        let now = DateTime::parse_from_rfc3339("2026-06-13T12:00:00Z").unwrap().with_timezone(&Utc);
+        let headers = signer.sign(
+            "PUT",
+            "acc.r2.cloudflarestorage.com",
+            "/witness-testnet/block/2000_2999/2045.0xabc",
+            "",
+            &[("x-amz-meta-compression".to_string(), "zstd".to_string())],
+            b"payload",
+            now,
+        );
+
+        let expected = [
+            (
+                "x-amz-content-sha256",
+                "239f59ed55e737c77147cf55ad0c1b030b6d7ee748a7426952f9b852d5a935e5",
+            ),
+            ("x-amz-date", "20260613T120000Z"),
+            ("x-amz-meta-compression", "zstd"),
+            (
+                "authorization",
+                "AWS4-HMAC-SHA256 Credential=access/20260613/auto/s3/aws4_request, \
+                 SignedHeaders=host;x-amz-content-sha256;x-amz-date;x-amz-meta-compression, \
+                 Signature=dbbe53136588499c6798a928641af52e8dedf930a8cdd20cf138d4f8281fb167",
+            ),
+        ];
+        assert_eq!(headers.len(), expected.len());
+        for (name, value) in expected {
+            assert_eq!(
+                headers.iter().find(|(k, _)| k == name).map(|(_, v)| v.as_str()),
+                Some(value),
+                "header {name} mismatch",
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds a second witness source to the validator: `--witness-source r2` fetches each block's witness straight from the R2 bucket over the S3 API (SigV4-signed GET) instead of the `mega_getBlockWitness` RPC, and `--end-block` lets a fixed block range be sliced across multiple servers. To keep the read path byte-compatible with the write path, the `megaeth-witness-r2` crate is ported from mega-reth into this repo as the dedicated leaf crate `crates/stateless-r2` (full functionality including the signed-PUT upload path); mega-reth will delete its copy and consume this one via git tag, making the cross-repo dependency one-way.

## R2 witness source

`R2WitnessClient` (`bin/stateless-validator/src/r2_witness.rs`) GETs the primary object, carries the body as refcounted `Bytes` end to end (no multi-MB copy per block), decodes on `spawn_blocking`, and retries transport/429/5xx with exponential backoff while 404 (`Missing`) and decode failures surface immediately as deterministic errors — each throttled 2s before surfacing so the pipeline's zero-delay re-enqueue cannot hot-loop signed GETs against R2; a decode-task panic gets its own `DecodePanicked` variant so a bug in our decoder can't masquerade as bad data in R2. `--witness-max-concurrent-requests` is honored in R2 mode too via a client-owned semaphore (permit scoped per GET attempt, mirroring the RPC path); time queued on the cap is excluded from the latency histogram so self-imposed queuing can't read as R2 slowness. `ValidatorFetcher` branches on an optional client (`chain_sync.rs`) — block and witness fetches stay concurrent in both modes. New CLI: `--witness-source rpc|r2` (`app.rs`), the four `--r2-*` connection flags (secret redacted from `Debug` output), and `--end-block` mapping onto the existing `pipeline_config.sync_target`. In R2 mode `--witness-endpoint` is no longer required (a startup warning flags it as ignored if set); the `RpcClient` gets the data endpoints as placeholder witness providers since its constructor rejects an empty list.

## Observability

R2 mode reports the same witness-size histograms as the RPC path plus three new metrics: `witness_fetch_r2_time_seconds` (GET incl. internal retries, plus decode; excl. concurrency-cap queue wait), `r2_witness_retry_attempts_total`, and `r2_witness_errors_total{kind=missing|transport|throttled|status|decode|decode_panicked}` — all pre-registered at startup like the RPC method counters.

## Reliable tail reporting for `--end-block` runs

The periodic validation reporter is cancelled the instant the pipeline completes, so a fixed-range run could previously exit without reporting blocks validated since the last 1s tick — and a slice run has no later restart to re-report them. `run_with_signals` now sends one final authoritative report after the pipeline (and any signal drain) fully stops, retrying up to 3 times on transient failure before giving up with an ERROR log (`workers.rs`); the reporting round is extracted into `report_range_once`, shared by the tick loop and the final flush.

## stateless-r2 crate

Ported byte-identical from mega-reth `c290c3e` (keys / sigv4 / endpoint / client) with two additions: `keys::block_object_key` becomes the single implementation of the primary-key template — the uploaders' `object_keys` delegates to it and the validator calls it directly, so reader and writers cannot disagree on where a witness lives — and golden wire-vector tests pin a real migrated mainnet object key plus a full SigV4 header set computed with an independent implementation (`sigv4.rs`). Manifest deltas vs mega-reth's copy: `[lints]`/`homepage` dropped (this workspace defines neither), `chrono` gains `clock` and `hex` gains `alloc` (our workspace deps are `default-features = false`).

## reqwest unification

The workspace moves from reqwest 0.13 to 0.12 (`Cargo.toml`): 0.13's only consumer was debug-trace-server's test-only blocking client, while every production path (stateless-common, the validator bin, alloy-provider, mega-reth) is on 0.12 — the lock now carries a single reqwest major. `stateless-r2` keeps an explicit 0.12 pin rather than workspace inheritance because `put_object` exposes `&reqwest::Client`, making the reqwest major part of its public API; a future workspace-wide bump must not silently ride into mega-reth.

## Testing

`cargo test --workspace` (246 tests) passes, including 17 in stateless-r2 (AWS reference vector, independent SigV4 golden vector, migrated-key pin, write/read key-delegation equality) and the R2 client's mock-server suite (happy-path decode of a real fixture witness, no-retry on 4xx/404/corrupt object, retry-until-deterministic on 5xx, redirects refused, deterministic-failure throttle, concurrency-cap high-water mark). Two end-to-end `run_with_signals` tests cover `--end-block` tail reporting, one with a scripted transient report failure; the reporting and concurrency regression tests were mutation-tested against their reverted fixes. `fmt` / `clippy --all-targets --all-features` / `cargo sort` / `cargo doc` clean.

## Notes

mega-reth follow-up (separate PR there): swap its dep to this repo's tag and delete `crates/megaeth/witness-r2`; its stateless-core/common pins must stay on v2.0.14 in that PR — a same-tag bump would drag the salt v1.0.4→v1.0.5 + zstd-level change along and break the build. README/AGENTS.md table diffs include mechanical column realignment from the Markdown formatter alongside the new crate row.
