### PR TITLE
docs: add stateless-validator review checks to REVIEW.md

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -17,6 +17,9 @@ These per-repo rules take precedence wherever they conflict with that baseline.
 
 - Changes to consensus-critical code — EVM execution, witness verification, state root computation, withdrawals — require extra scrutiny.
 - Watch for read-check-write without atomicity (lock, CAS, or database constraint), CPU-intensive work that should use `spawn_blocking` inside async contexts, and deadlocks from nested lock acquisition.
+- **Fail closed on the terminal publish.** The final step (e.g. `mega_setValidatedBlocks`) must not look like success when it permanently failed — surface a non-zero exit / `Err` so the orchestrator detects the miss and retries, instead of advancing while upstream never saw the tip.
+- **Validate config at the boundary.** Reject or clamp nonsensical config at load: a `*_timeout_ms` of `0` makes `tokio::time::timeout` fail every attempt immediately; an unbounded size/alloc hint invites upfront over-allocation. Require `> 0` (or a clamp) before the value reaches the retry loop.
+- **Classify remote errors precisely.** Match known error codes (e.g. a small set of S3 codes), not `body.contains(...)` on response text a proxy can reshape. Give an exhausted-retry cycle an inter-cycle throttle so it doesn't re-burst after a brownout.
 
 ## Observability
 

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -17,7 +17,7 @@ These per-repo rules take precedence wherever they conflict with that baseline.
 
 - Changes to consensus-critical code — EVM execution, witness verification, state root computation, withdrawals — require extra scrutiny.
 - Watch for read-check-write without atomicity (lock, CAS, or database constraint), CPU-intensive work that should use `spawn_blocking` inside async contexts, and deadlocks from nested lock acquisition.
-- **Fail closed on the terminal publish.** The final step (e.g. `mega_setValidatedBlocks`) must not look like success when it permanently failed — surface a non-zero exit / `Err` so the orchestrator detects the miss and retries, instead of advancing while upstream never saw the tip.
+- **Fail closed on the terminal publish.** The final step (e.g. `mega_setValidatedBlocks`) must not look like success when the run has no later opportunity to retry (e.g. an `--end-block` slice run) — surface a non-zero exit / `Err` so the orchestrator cannot record the slice as complete while upstream never saw the tip. A chain-following run is the deliberate exception: it re-reports anchor→tip on its next start, so a tolerated final-report miss heals itself.
 - **Validate config at the boundary.** Reject or clamp nonsensical config at load: a `*_timeout_ms` of `0` makes `tokio::time::timeout` fail every attempt immediately; an unbounded size/alloc hint invites upfront over-allocation. Require `> 0` (or a clamp) before the value reaches the retry loop.
 - **Classify remote errors precisely.** Match known error codes (e.g. a small set of S3 codes), not `body.contains(...)` on response text a proxy can reshape. Give an exhausted-retry cycle an inter-cycle throttle so it doesn't re-burst after a brownout.
 


### PR DESCRIPTION
Supplements the baseline rubric with stateless-validator-specific checks it doesn't cover:

- Fail closed on the terminal publish — a permanently failed final step surfaces a non-zero exit / `Err`, not silent success.
- Validate config at the boundary — reject/clamp a `0` timeout and unbounded alloc hints before they reach the retry loop.
- Classify remote errors precisely — match known error codes (not `body.contains`), with an inter-cycle retry throttle.

Additive only — no existing rules changed.
