### PR TITLE
feat(debug-trace-server): age-based witness routing, configurable old-block budget, tip buffer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,7 +107,7 @@ Two operating modes:
 - **Local cache mode** — With `data_dir`, enables chain sync to pre-fetch blocks into `ValidatorDB` for faster serving.
 
 The server includes an HTTP response cache (`quick_cache`) for pre-serialized JSON and a `DataProvider` with single-flight request coalescing.
-In local cache mode with two or more witness endpoints, request-serving witness fetches route by block age: blocks at least `--witness-local-window` blocks below the local tip skip the first witness endpoint (the internal generator, which prunes beyond its `BACKUP` window) and fetch from the remaining endpoints.
+In local cache mode with a `--witness-generator-endpoint` plus at least one fallback `--witness-endpoint` (or, deprecated, the first of two or more `--witness-endpoint` values acting as the generator), request-serving witness fetches route by block age: blocks at least `--witness-local-window` blocks below the local tip skip the generator (which prunes beyond its `BACKUP` window) and fetch from the fallbacks.
 The background chain-sync prefetch always uses the full endpoint chain — it fetches at the sync frontier, which stays within the generator's retention unless `--blocks-to-keep` exceeds that retention during deep catch-up.
 
 ### Key Source Files

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,7 +107,8 @@ Two operating modes:
 - **Local cache mode** — With `data_dir`, enables chain sync to pre-fetch blocks into `ValidatorDB` for faster serving.
 
 The server includes an HTTP response cache (`quick_cache`) for pre-serialized JSON and a `DataProvider` with single-flight request coalescing.
-In local cache mode with two or more witness endpoints, witness fetches route by block age: blocks at least `--witness-local-window` blocks below the local tip skip the first witness endpoint (the internal generator, which prunes beyond its `BACKUP` window) and fetch from the remaining endpoints.
+In local cache mode with two or more witness endpoints, request-serving witness fetches route by block age: blocks at least `--witness-local-window` blocks below the local tip skip the first witness endpoint (the internal generator, which prunes beyond its `BACKUP` window) and fetch from the remaining endpoints.
+The background chain-sync prefetch always uses the full endpoint chain — it fetches at the sync frontier, which stays within the generator's retention unless `--blocks-to-keep` exceeds that retention during deep catch-up.
 
 ### Key Source Files
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,6 +107,7 @@ Two operating modes:
 - **Local cache mode** — With `data_dir`, enables chain sync to pre-fetch blocks into `ValidatorDB` for faster serving.
 
 The server includes an HTTP response cache (`quick_cache`) for pre-serialized JSON and a `DataProvider` with single-flight request coalescing.
+In local cache mode with two or more witness endpoints, witness fetches route by block age: blocks at least `--witness-local-window` blocks below the local tip skip the first witness endpoint (the internal generator, which prunes beyond its `BACKUP` window) and fetch from the remaining endpoints.
 
 ### Key Source Files
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,7 +107,7 @@ Two operating modes:
 - **Local cache mode** — With `data_dir`, enables chain sync to pre-fetch blocks into `ValidatorDB` for faster serving.
 
 The server includes an HTTP response cache (`quick_cache`) for pre-serialized JSON and a `DataProvider` with single-flight request coalescing.
-In local cache mode with a `--witness-generator-endpoint` plus at least one fallback `--witness-endpoint` (or, deprecated, the first of two or more `--witness-endpoint` values acting as the generator), request-serving witness fetches route by block age: blocks at least `--witness-local-window` blocks below the local tip skip the generator (which prunes beyond its `BACKUP` window) and fetch from the fallbacks.
+In local cache mode with a `--witness-generator-endpoint` plus at least one fallback `--witness-endpoint`, request-serving witness fetches route by block age: blocks at least `--witness-local-window` blocks below the local tip skip the generator (which prunes beyond its `BACKUP` window) and fetch from the fallbacks; without the generator flag, witness endpoints are plain failover and routing is disabled.
 The background chain-sync prefetch always uses the full endpoint chain — it fetches at the sync frontier, which stays within the generator's retention unless `--blocks-to-keep` exceeds that retention during deep catch-up.
 
 ### Key Source Files

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Two operating modes:
 Declare the internal witness generator via `--witness-generator-endpoint`; `--witness-endpoint` lists the durable fallbacks (e.g. an R2-backed witness service), tried in order.
 In local cache mode with a generator plus at least one fallback, requests for blocks at least `--witness-local-window` blocks below the local tip skip the generator and fetch from the fallbacks, because the generator only retains a recent window (its `BACKUP`, deployed at 4096) and probing it for pruned blocks is a guaranteed miss.
 The background chain-sync prefetch always uses the full endpoint chain.
-Deprecated: without `--witness-generator-endpoint`, the first of two or more `--witness-endpoint` values is treated as the generator (in local cache mode a startup warning nudges migration).
+Without `--witness-generator-endpoint`, historical routing is disabled and the endpoints are plain failover.
 
 **Witness routing and sync knobs** (each also settable via its `DEBUG_TRACE_SERVER_*` env var):
 - `--witness-local-window`: Block-age threshold for the historical witness route (default: 4096; should match the generator's `BACKUP`).

--- a/README.md
+++ b/README.md
@@ -100,7 +100,8 @@ Two operating modes:
 
 **Witness endpoint ordering:**
 For the debug-trace-server, the first `--witness-endpoint` is positionally special: it is treated as the internal witness generator, so list the generator first and durable fallbacks (e.g. an R2-backed witness service) after it.
-In local cache mode with two or more witness endpoints, blocks at least `--witness-local-window` blocks below the local tip skip that first endpoint and fetch from the remaining endpoints, because the generator only retains a recent window (its `BACKUP`, deployed at 4096) and probing it for pruned blocks is a guaranteed miss.
+In local cache mode with two or more witness endpoints, requests for blocks at least `--witness-local-window` blocks below the local tip skip that first endpoint and fetch from the remaining endpoints, because the generator only retains a recent window (its `BACKUP`, deployed at 4096) and probing it for pruned blocks is a guaranteed miss.
+The background chain-sync prefetch always uses the full endpoint chain.
 
 **Witness routing and sync knobs** (each also settable via its `DEBUG_TRACE_SERVER_*` env var):
 - `--witness-local-window`: Block-age threshold for the historical witness route (default: 4096; should match the generator's `BACKUP`).

--- a/README.md
+++ b/README.md
@@ -98,6 +98,15 @@ Two operating modes:
 - **Stateless mode** (no `--data-dir`): All data fetched from remote RPC on demand.
 - **Local cache mode** (with `--data-dir`): Enables chain sync to pre-fetch blocks for faster serving.
 
+**Witness endpoint ordering:**
+For the debug-trace-server, the first `--witness-endpoint` is positionally special: it is treated as the internal witness generator, so list the generator first and durable fallbacks (e.g. an R2-backed witness service) after it.
+In local cache mode with two or more witness endpoints, blocks at least `--witness-local-window` blocks below the local tip skip that first endpoint and fetch from the remaining endpoints, because the generator only retains a recent window (its `BACKUP`, deployed at 4096) and probing it for pruned blocks is a guaranteed miss.
+
+**Witness routing and sync knobs** (each also settable via its `DEBUG_TRACE_SERVER_*` env var):
+- `--witness-local-window`: Block-age threshold for the historical witness route (default: 4096; should match the generator's `BACKUP`).
+- `--witness-old-block-timeout`: Witness-stage budget in seconds for blocks at or below the local tip (default: 8, the full witness budget; lower it to fail fast on pruned blocks).
+- `--tip-buffer`: Stay this many blocks behind the upstream head during chain sync so fetches don't race the witness generator (default: 2; must be smaller than `--blocks-to-keep`).
+
 ### Environment Variables
 
 Each command-line flag has an equivalent environment variable:

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ The background chain-sync prefetch always uses the full endpoint chain.
 
 **Witness routing and sync knobs** (each also settable via its `DEBUG_TRACE_SERVER_*` env var):
 - `--witness-local-window`: Block-age threshold for the historical witness route (default: 4096; should match the generator's `BACKUP`).
-- `--witness-old-block-timeout`: Witness-stage budget in seconds for blocks at or below the local tip (default: 8, the full witness budget; lower it to fail fast on pruned blocks).
+- `--witness-old-block-timeout`: Witness-stage budget in seconds for blocks at or below the local tip (defaults to the full `--witness-timeout` budget, tracking it when raised; lower it to fail fast on pruned blocks).
 - `--tip-buffer`: Stay this many blocks behind the upstream head during chain sync so fetches don't race the witness generator (default: 2; must be smaller than `--blocks-to-keep`).
 
 ### Environment Variables

--- a/README.md
+++ b/README.md
@@ -98,10 +98,11 @@ Two operating modes:
 - **Stateless mode** (no `--data-dir`): All data fetched from remote RPC on demand.
 - **Local cache mode** (with `--data-dir`): Enables chain sync to pre-fetch blocks for faster serving.
 
-**Witness endpoint ordering:**
-For the debug-trace-server, the first `--witness-endpoint` is positionally special: it is treated as the internal witness generator, so list the generator first and durable fallbacks (e.g. an R2-backed witness service) after it.
-In local cache mode with two or more witness endpoints, requests for blocks at least `--witness-local-window` blocks below the local tip skip that first endpoint and fetch from the remaining endpoints, because the generator only retains a recent window (its `BACKUP`, deployed at 4096) and probing it for pruned blocks is a guaranteed miss.
+**Witness endpoints:**
+Declare the internal witness generator via `--witness-generator-endpoint`; `--witness-endpoint` lists the durable fallbacks (e.g. an R2-backed witness service), tried in order.
+In local cache mode with a generator plus at least one fallback, requests for blocks at least `--witness-local-window` blocks below the local tip skip the generator and fetch from the fallbacks, because the generator only retains a recent window (its `BACKUP`, deployed at 4096) and probing it for pruned blocks is a guaranteed miss.
 The background chain-sync prefetch always uses the full endpoint chain.
+Deprecated: without `--witness-generator-endpoint`, the first of two or more `--witness-endpoint` values is treated as the generator (in local cache mode a startup warning nudges migration).
 
 **Witness routing and sync knobs** (each also settable via its `DEBUG_TRACE_SERVER_*` env var):
 - `--witness-local-window`: Block-age threshold for the historical witness route (default: 4096; should match the generator's `BACKUP`).

--- a/bin/debug-trace-server/src/chain_sync.rs
+++ b/bin/debug-trace-server/src/chain_sync.rs
@@ -24,6 +24,12 @@ use crate::{metrics, response_cache::ResponseCache, server_db::BlockStore};
 /// Witnesses go through the zero-validation light decode (`get_witness_light`):
 /// the server never verifies the proof, so the full decode's per-point
 /// elliptic-curve work bought nothing.
+///
+/// Witness fetches deliberately use the full endpoint chain (no age-based routing): the sync
+/// frontier trails the remote head by only `tip_buffer`, inside the generator's retention —
+/// except during deep catch-up with `--blocks-to-keep` beyond that retention, where each
+/// pruned block burns one generator probe before failover (accepted; routing here would need
+/// a remote-head anchor instead of the local tip).
 pub struct TraceFetcher {
     pub rpc_client: Arc<RpcClient>,
 }

--- a/bin/debug-trace-server/src/data_provider.rs
+++ b/bin/debug-trace-server/src/data_provider.rs
@@ -52,8 +52,8 @@ use crate::{
 };
 
 /// Witness-stage budget and routing-window configuration, shared by the single-flight fetch
-/// futures. Whether the historical route is actually taken is derived per fetch from the
-/// client's endpoint count and the local tip (see [`witness_route`]).
+/// futures. Whether the historical route is actually taken is derived per fetch from
+/// `generator_first`, the client's endpoint count, and the local tip (see [`witness_route`]).
 #[derive(Clone, Copy)]
 pub(crate) struct WitnessFetchConfig {
     /// Sub-deadline applied to the witness stage for blocks above the local tip.
@@ -63,17 +63,23 @@ pub(crate) struct WitnessFetchConfig {
     /// Blocks at least this far below the local tip are historical and skip the internal
     /// generator endpoint (see [`DEFAULT_WITNESS_LOCAL_WINDOW`] for the rationale).
     pub local_window: u64,
+    /// Whether the first witness endpoint is a declared internal generator
+    /// (`--witness-generator-endpoint`) — only then may historical blocks skip it. CLI
+    /// knowledge, not derivable from the client: every endpoint speaks the same witness RPC.
+    pub generator_first: bool,
 }
 
 impl WitnessFetchConfig {
-    /// Config with the default window and the default old-block budget (the full witness
-    /// budget, mirroring the unset `--witness-old-block-timeout` behavior).
+    /// Config with the default window, no declared generator, and the default old-block
+    /// budget (the full witness budget, mirroring the unset `--witness-old-block-timeout`
+    /// behavior).
     #[cfg(test)]
     pub fn with_defaults(witness_timeout_secs: u64) -> Self {
         Self {
             witness_timeout: Duration::from_secs(witness_timeout_secs),
             old_block_witness_timeout: Duration::from_secs(witness_timeout_secs),
             local_window: DEFAULT_WITNESS_LOCAL_WINDOW,
+            generator_first: false,
         }
     }
 }
@@ -776,15 +782,15 @@ fn is_historical(db_tip: Option<u64>, block_number: u64, local_window: u64) -> b
 
 /// Witness route for a block: how many leading witness endpoints to skip, plus the metrics
 /// source label. Historical blocks skip the internal generator at index 0 — but only with a
-/// fallback endpoint to skip to (`have_fallback`, derived from the client's endpoint count, so
-/// the skip-aware fetch never sees an empty rotation); everything else uses the full chain.
+/// fallback endpoint to skip to (`can_skip_generator`, so the skip-aware fetch never sees an
+/// empty rotation); everything else uses the full chain.
 fn witness_route(
-    have_fallback: bool,
+    can_skip_generator: bool,
     db_tip: Option<u64>,
     block_number: u64,
     local_window: u64,
 ) -> (usize, &'static str) {
-    if have_fallback && is_historical(db_tip, block_number, local_window) {
+    if can_skip_generator && is_historical(db_tip, block_number, local_window) {
         (1, "witness_historical")
     } else {
         (0, "witness_generator")
@@ -797,8 +803,9 @@ fn witness_route(
 /// - **Recent block** (fewer than `local_window` blocks below the local tip, or tip unknown): the
 ///   full RPC witness endpoint chain, tried in order — the internal generator first, so near-tip
 ///   witnesses stay on the fast internal path.
-/// - **Historical block** with a fallback endpoint configured: the same chain minus the first
-///   endpoint, the guaranteed-miss probe [`DEFAULT_WITNESS_LOCAL_WINDOW`] describes.
+/// - **Historical block** with a declared generator and a fallback endpoint configured: the same
+///   chain minus the generator, the guaranteed-miss probe [`DEFAULT_WITNESS_LOCAL_WINDOW`]
+///   describes.
 ///
 /// Uses the zero-validation light decode: the trace server never verifies the witness proof,
 /// so the full decode's per-point elliptic-curve work bought nothing. The recorded size is
@@ -811,11 +818,10 @@ async fn fetch_witness(
     block_hash: B256,
     deadline: Instant,
 ) -> DataProviderResult<(LightWitness, MptWitness)> {
-    let have_fallback = rpc_client.witness_provider_count() >= 2;
-    let (skip, source) = witness_route(have_fallback, db_tip, block_number, cfg.local_window);
+    let can_skip_generator = cfg.generator_first && rpc_client.witness_provider_count() >= 2;
+    let (skip, source) = witness_route(can_skip_generator, db_tip, block_number, cfg.local_window);
     let metrics = WitnessSourceMetrics::new_for_source(source);
     let start = Instant::now();
-    let budget = deadline.saturating_duration_since(start);
 
     match rpc_client
         .get_witness_light_with_deadline_from(skip, block_number, block_hash, Some(deadline))
@@ -829,6 +835,7 @@ async fn fetch_witness(
         }
         Err(e) => {
             metrics.record_request(false, start.elapsed().as_secs_f64());
+            let budget = deadline.saturating_duration_since(start);
             // Attribution-grade context for the next timeout incident: the effective stage
             // budget, the route taken, and whether the old-block clamp applied — the client
             // only ever sees the generic `-32001` message.
@@ -942,11 +949,12 @@ mod tests {
     }
 
     /// Route selection: the skip-generator chain and the `witness_historical` label apply
-    /// only with a fallback endpoint AND a historical block; everything else stays on the
-    /// full chain under the `witness_generator` label.
+    /// only when the generator may be skipped (declared generator + fallback) AND the block
+    /// is historical; everything else stays on the full chain under the `witness_generator`
+    /// label.
     #[test]
     fn witness_route_selection() {
-        // No fallback endpoint (single witness endpoint): always the full chain.
+        // No declared generator (or no fallback to skip to): always the full chain.
         assert_eq!(witness_route(false, Some(5000), 900, 100), (0, "witness_generator"));
         assert_eq!(witness_route(true, Some(5000), 900, 100), (1, "witness_historical"));
         assert_eq!(witness_route(true, Some(5000), 4999, 100), (0, "witness_generator"));
@@ -974,29 +982,33 @@ mod tests {
         (server.start(module), url, hits)
     }
 
+    /// Fast-retry client over `witness_urls` plus a routing config (1 s budgets, 100-block
+    /// window) for the `fetch_witness` dispatch tests below.
+    fn routing_fixture(
+        witness_urls: &[&str],
+        generator_first: bool,
+    ) -> (RpcClient, WitnessFetchConfig) {
+        let config = RpcClientConfig {
+            rpc_retry: BackoffPolicy::new(Duration::from_millis(1), Duration::from_millis(2)),
+            ..RpcClientConfig::trace_server()
+        };
+        let rpc_client =
+            RpcClient::new_with_config(&witness_urls[..1], witness_urls, config, None).unwrap();
+        let cfg = WitnessFetchConfig {
+            local_window: 100,
+            generator_first,
+            ..WitnessFetchConfig::with_defaults(1)
+        };
+        (rpc_client, cfg)
+    }
+
     /// End-to-end routing dispatch through `fetch_witness`: a historical block must never
     /// touch the first (generator) endpoint, while a recent block probes it first.
     #[tokio::test]
     async fn fetch_witness_routes_historical_blocks_past_the_generator() {
         let (ha, url_a, hits_a) = start_counting_witness_rpc().await;
         let (hb, url_b, hits_b) = start_counting_witness_rpc().await;
-
-        let config = RpcClientConfig {
-            rpc_retry: BackoffPolicy::new(Duration::from_millis(1), Duration::from_millis(2)),
-            ..RpcClientConfig::trace_server()
-        };
-        let rpc_client = RpcClient::new_with_config(
-            &[url_a.as_str()],
-            &[url_a.as_str(), url_b.as_str()],
-            config,
-            None,
-        )
-        .unwrap();
-        let cfg = WitnessFetchConfig {
-            witness_timeout: Duration::from_secs(1),
-            old_block_witness_timeout: Duration::from_secs(1),
-            local_window: 100,
-        };
+        let (rpc_client, cfg) = routing_fixture(&[url_a.as_str(), url_b.as_str()], true);
         let db_tip = Some(5000);
 
         // Historical block (900 + 100 <= 5000): the generator endpoint must stay untouched.
@@ -1015,25 +1027,14 @@ mod tests {
         hb.stop().unwrap();
     }
 
-    /// With a single witness endpoint there is nothing to skip to: a historical block must
-    /// still fetch through the sole (generator) endpoint without tripping the skip assert.
-    /// Pins the `>= 2` fallback derivation in `fetch_witness` — a `>= 1` regression would
-    /// pass every other test and panic in production on the first historical fetch.
+    /// A declared generator with no fallback has nothing to skip to: a historical block must
+    /// still fetch through the sole endpoint without tripping the skip assert. Pins the
+    /// `>= 2` fallback guard in `fetch_witness` — a `>= 1` regression would pass every other
+    /// test and panic in production on the first historical fetch.
     #[tokio::test]
     async fn fetch_witness_single_endpoint_serves_historical_from_generator() {
         let (ha, url_a, hits_a) = start_counting_witness_rpc().await;
-
-        let config = RpcClientConfig {
-            rpc_retry: BackoffPolicy::new(Duration::from_millis(1), Duration::from_millis(2)),
-            ..RpcClientConfig::trace_server()
-        };
-        let rpc_client =
-            RpcClient::new_with_config(&[url_a.as_str()], &[url_a.as_str()], config, None).unwrap();
-        let cfg = WitnessFetchConfig {
-            witness_timeout: Duration::from_secs(1),
-            old_block_witness_timeout: Duration::from_secs(1),
-            local_window: 100,
-        };
+        let (rpc_client, cfg) = routing_fixture(&[url_a.as_str()], true);
 
         // Historical block (900 + 100 <= 5000) with no fallback endpoint configured.
         let deadline = Instant::now() + Duration::from_millis(150);
@@ -1045,6 +1046,26 @@ mod tests {
         );
 
         ha.stop().unwrap();
+    }
+
+    /// Two durable endpoints without a declared generator must never skip: historical blocks
+    /// still probe the first endpoint. Pins routing as an explicit opt-in — a pure failover
+    /// pair keeps its pre-routing behavior, with no endpoint special by position.
+    #[tokio::test]
+    async fn fetch_witness_without_generator_never_skips() {
+        let (ha, url_a, hits_a) = start_counting_witness_rpc().await;
+        let (hb, url_b, _hits_b) = start_counting_witness_rpc().await;
+        let (rpc_client, cfg) = routing_fixture(&[url_a.as_str(), url_b.as_str()], false);
+
+        // Historical block (900 + 100 <= 5000): with no declared generator, the first
+        // endpoint stays in the rotation.
+        let deadline = Instant::now() + Duration::from_millis(150);
+        let result = fetch_witness(&rpc_client, &cfg, Some(5000), 900, B256::ZERO, deadline).await;
+        assert!(result.is_err(), "the mock only returns errors, so the deadline must fire");
+        assert!(hits_a.load(Ordering::Relaxed) >= 1, "first endpoint must not be skipped");
+
+        ha.stop().unwrap();
+        hb.stop().unwrap();
     }
 
     /// Old-block witness budget honors the configurable timeout and clamps to

--- a/bin/debug-trace-server/src/data_provider.rs
+++ b/bin/debug-trace-server/src/data_provider.rs
@@ -7,9 +7,10 @@
 //! 2. **Remote RPC** (slower) - Upstream RPC endpoints as fallback
 //!
 //! Within the RPC fallback, the witness stage routes by block age (see [`WitnessFetchConfig`]):
-//! blocks within `local_window` of the local tip use the full witness endpoint chain (internal
-//! generator first), while historical blocks — which the generator has long pruned — skip the
-//! generator and go straight to the remaining endpoints.
+//! blocks fewer than `local_window` blocks below the local tip use the full witness endpoint
+//! chain (internal generator first), while historical blocks — at least `local_window` below,
+//! which the generator has long pruned — skip the generator and go straight to the remaining
+//! endpoints.
 //!
 //! # Features
 //! - **Single-flight request coalescing**: concurrent callers for the same block hash share one
@@ -115,12 +116,12 @@ pub const DEFAULT_WITNESS_TIMEOUT_SECS: u64 = 8;
 /// blocks whose witness is likely gone everywhere can lower `--witness-old-block-timeout`.
 pub const DEFAULT_OLD_BLOCK_WITNESS_TIMEOUT_SECS: u64 = DEFAULT_WITNESS_TIMEOUT_SECS;
 
-/// Default local-tip window (in blocks) below which witnesses are considered historical and
-/// skip the internal generator endpoint (see [`witness_route`]).
+/// Default local-tip window (in blocks): witnesses at least this far below the local tip are
+/// historical and skip the internal generator endpoint (see [`witness_route`]).
 ///
 /// Matches the witness generator's default deployed local retention (`BACKUP=4096`): blocks
-/// deeper than this are guaranteed misses on the internal generator endpoint, so probing it
-/// first only burns a failover round trip.
+/// at least this far below the tip are guaranteed misses on the internal generator endpoint,
+/// so probing it first only burns a failover round trip.
 pub const DEFAULT_WITNESS_LOCAL_WINDOW: u64 = 4096;
 
 /// Default deadline for the full block-fetch pipeline (header + witness + block + contracts)
@@ -799,9 +800,9 @@ fn witness_route(
 /// Fetches witness data, routing by block age. The `deadline` is the witness stage's
 /// effective deadline (see [`witness_deadline_for`]).
 ///
-/// - **Recent block** (within `local_window` of the local tip, or tip unknown): the full RPC
-///   witness endpoint chain, tried in order — the internal generator first, so near-tip witnesses
-///   stay on the fast internal path.
+/// - **Recent block** (fewer than `local_window` blocks below the local tip, or tip unknown): the
+///   full RPC witness endpoint chain, tried in order — the internal generator first, so near-tip
+///   witnesses stay on the fast internal path.
 /// - **Historical block** with a fallback endpoint configured: the same chain minus the first
 ///   endpoint, the guaranteed-miss probe [`DEFAULT_WITNESS_LOCAL_WINDOW`] describes.
 ///
@@ -1018,6 +1019,38 @@ mod tests {
 
         ha.stop().unwrap();
         hb.stop().unwrap();
+    }
+
+    /// With a single witness endpoint there is nothing to skip to: a historical block must
+    /// still fetch through the sole (generator) endpoint without tripping the skip assert.
+    /// Pins the `>= 2` fallback derivation in `fetch_witness` — a `>= 1` regression would
+    /// pass every other test and panic in production on the first historical fetch.
+    #[tokio::test]
+    async fn fetch_witness_single_endpoint_serves_historical_from_generator() {
+        let (ha, url_a, hits_a) = start_counting_witness_rpc().await;
+
+        let config = RpcClientConfig {
+            rpc_retry: BackoffPolicy::new(Duration::from_millis(1), Duration::from_millis(2)),
+            ..RpcClientConfig::trace_server()
+        };
+        let rpc_client =
+            RpcClient::new_with_config(&[url_a.as_str()], &[url_a.as_str()], config, None).unwrap();
+        let cfg = WitnessFetchConfig {
+            witness_timeout: Duration::from_secs(1),
+            old_block_witness_timeout: Duration::from_secs(1),
+            local_window: 100,
+        };
+
+        // Historical block (900 + 100 <= 5000) with no fallback endpoint configured.
+        let deadline = Instant::now() + Duration::from_millis(150);
+        let result = fetch_witness(&rpc_client, &cfg, Some(5000), 900, B256::ZERO, deadline).await;
+        assert!(result.is_err(), "the mock only returns errors, so the deadline must fire");
+        assert!(
+            hits_a.load(Ordering::Relaxed) >= 1,
+            "the sole endpoint must serve historical blocks"
+        );
+
+        ha.stop().unwrap();
     }
 
     /// Old-block witness budget honors the configurable timeout and clamps to

--- a/bin/debug-trace-server/src/data_provider.rs
+++ b/bin/debug-trace-server/src/data_provider.rs
@@ -66,12 +66,13 @@ pub(crate) struct WitnessFetchConfig {
 }
 
 impl WitnessFetchConfig {
-    /// Config with default budgets and window.
+    /// Config with the default window and the default old-block budget (the full witness
+    /// budget, mirroring the unset `--witness-old-block-timeout` behavior).
     #[cfg(test)]
     pub fn with_defaults(witness_timeout_secs: u64) -> Self {
         Self {
             witness_timeout: Duration::from_secs(witness_timeout_secs),
-            old_block_witness_timeout: Duration::from_secs(DEFAULT_OLD_BLOCK_WITNESS_TIMEOUT_SECS),
+            old_block_witness_timeout: Duration::from_secs(witness_timeout_secs),
             local_window: DEFAULT_WITNESS_LOCAL_WINDOW,
         }
     }
@@ -108,13 +109,6 @@ pub struct BlockData {
 /// the witness is still being generated upstream" case where a few seconds of waiting is
 /// normal.
 pub const DEFAULT_WITNESS_TIMEOUT_SECS: u64 = 8;
-
-/// Default witness-stage budget for blocks at or below the local tip: the full witness budget.
-///
-/// A tighter fail-fast here converts slow-but-successful fetches into client-visible timeouts
-/// whenever the witness tail latency approaches the cap. Operators who prefer failing fast on
-/// blocks whose witness is likely gone everywhere can lower `--witness-old-block-timeout`.
-pub const DEFAULT_OLD_BLOCK_WITNESS_TIMEOUT_SECS: u64 = DEFAULT_WITNESS_TIMEOUT_SECS;
 
 /// Default local-tip window (in blocks): witnesses at least this far below the local tip are
 /// historical and skip the internal generator endpoint (see [`witness_route`]).

--- a/bin/debug-trace-server/src/data_provider.rs
+++ b/bin/debug-trace-server/src/data_provider.rs
@@ -50,33 +50,28 @@ use crate::{
     server_db::BlockStore,
 };
 
-/// Witness-source routing and budget configuration, shared by the single-flight fetch futures.
-#[derive(Clone)]
+/// Witness-stage budget and routing-window configuration, shared by the single-flight fetch
+/// futures. Whether the historical route is actually taken is derived per fetch from the
+/// client's endpoint count and the local tip (see [`witness_route`]).
+#[derive(Clone, Copy)]
 pub(crate) struct WitnessFetchConfig {
     /// Sub-deadline applied to the witness stage for blocks above the local tip.
     pub witness_timeout: Duration,
     /// Sub-deadline for blocks at or below the local tip (clamped to `witness_timeout`).
     pub old_block_witness_timeout: Duration,
-    /// Blocks at least this far below the local tip are historical: the internal witness
-    /// generator only retains about this window (its `BACKUP` env), so probing it first is a
-    /// guaranteed miss that costs a failover round trip.
+    /// Blocks at least this far below the local tip are historical and skip the internal
+    /// generator endpoint (see [`DEFAULT_WITNESS_LOCAL_WINDOW`] for the rationale).
     pub local_window: u64,
-    /// Whether historical blocks skip the first witness endpoint (the internal generator) and
-    /// fetch from the remaining endpoints only. Must only be set when at least two witness
-    /// endpoints are configured — the skip-aware fetch panics on an empty rotation — and is
-    /// only effective with a local DB, whose tip is the reference point for block age.
-    pub route_historical: bool,
 }
 
 impl WitnessFetchConfig {
-    /// Single-chain config (no historical split) with default budgets and window.
+    /// Config with default budgets and window.
     #[cfg(test)]
-    pub fn single_chain(witness_timeout_secs: u64) -> Self {
+    pub fn with_defaults(witness_timeout_secs: u64) -> Self {
         Self {
             witness_timeout: Duration::from_secs(witness_timeout_secs),
             old_block_witness_timeout: Duration::from_secs(DEFAULT_OLD_BLOCK_WITNESS_TIMEOUT_SECS),
             local_window: DEFAULT_WITNESS_LOCAL_WINDOW,
-            route_historical: false,
         }
     }
 }
@@ -113,16 +108,15 @@ pub struct BlockData {
 /// normal.
 pub const DEFAULT_WITNESS_TIMEOUT_SECS: u64 = 8;
 
-/// Default witness-stage budget for blocks at or below the local tip, in seconds.
+/// Default witness-stage budget for blocks at or below the local tip: the full witness budget.
 ///
-/// Defaults to the full witness budget: a tighter fail-fast here converts slow-but-successful
-/// fetches into client-visible timeouts whenever the witness tail latency approaches the cap.
-/// Operators who prefer failing fast on blocks whose witness is likely gone everywhere can
-/// lower `--witness-old-block-timeout`.
-pub const DEFAULT_OLD_BLOCK_WITNESS_TIMEOUT_SECS: u64 = 8;
+/// A tighter fail-fast here converts slow-but-successful fetches into client-visible timeouts
+/// whenever the witness tail latency approaches the cap. Operators who prefer failing fast on
+/// blocks whose witness is likely gone everywhere can lower `--witness-old-block-timeout`.
+pub const DEFAULT_OLD_BLOCK_WITNESS_TIMEOUT_SECS: u64 = DEFAULT_WITNESS_TIMEOUT_SECS;
 
 /// Default local-tip window (in blocks) below which witnesses are considered historical and
-/// skip the internal generator endpoint (see [`WitnessFetchConfig::route_historical`]).
+/// skip the internal generator endpoint (see [`witness_route`]).
 ///
 /// Matches the witness generator's default deployed local retention (`BACKUP=4096`): blocks
 /// deeper than this are guaranteed misses on the internal generator endpoint, so probing it
@@ -299,22 +293,22 @@ impl DataProvider {
     /// * `db` - Optional local database for cached block data
     /// * `contract_cache` - Shared in-memory contract cache (backed by the DB when present, or an
     ///   in-memory-only noop store in stateless mode)
-    /// * `witness_cfg` - Witness-source routing (by block age) and per-stage budgets
-    /// * `block_fetch_timeout_secs` - User-facing cap on the full block-fetch pipeline (header +
-    ///   witness + block + contracts), in seconds
+    /// * `witness_cfg` - Witness-source routing window (by block age) and per-stage budgets
+    /// * `block_fetch_timeout` - User-facing cap on the full block-fetch pipeline (header + witness
+    ///   + block + contracts)
     pub fn new(
         rpc_client: Arc<RpcClient>,
         db: Option<Arc<dyn BlockStore>>,
         contract_cache: Arc<ContractCache>,
         witness_cfg: WitnessFetchConfig,
-        block_fetch_timeout_secs: u64,
+        block_fetch_timeout: Duration,
     ) -> Self {
         Self {
             rpc_client,
             db,
             contract_cache,
             witness_cfg,
-            block_fetch_timeout: Duration::from_secs(block_fetch_timeout_secs),
+            block_fetch_timeout,
             in_flight: DashMap::new(),
         }
     }
@@ -459,10 +453,8 @@ impl DataProvider {
 
     /// Records the distance of a requested block from the local chain tip.
     fn record_block_distance(&self, block_number: u64) {
-        if let Some(db) = &self.db &&
-            let Ok(Some(tip)) = db.get_canonical_tip()
-        {
-            let distance = tip.block_number.saturating_sub(block_number);
+        if let Some(tip) = db_tip_height(self.db.as_deref()) {
+            let distance = tip.saturating_sub(block_number);
             ChainSyncMetrics::create().record_block_distance(distance);
         }
     }
@@ -561,7 +553,7 @@ impl DataProvider {
                 let rpc_client = Arc::clone(&self.rpc_client);
                 let db = self.db.clone();
                 let contract_cache = Arc::clone(&self.contract_cache);
-                let witness_cfg = self.witness_cfg.clone();
+                let witness_cfg = self.witness_cfg;
                 let fut: BlockDataFetchFuture = Box::pin(async move {
                     do_fetch_block_data(
                         rpc_client,
@@ -740,16 +732,21 @@ fn db_tip_height(db: Option<&dyn BlockStore>) -> Option<u64> {
     db.and_then(|db| db.get_canonical_tip().ok().flatten().map(|tip| tip.block_number))
 }
 
+/// Whether a block is at or below the local tip. `false` with no local DB — a new block's
+/// witness may still be generating upstream, so unknown conservatively counts as new.
+fn is_old_block(db_tip: Option<u64>, block_number: u64) -> bool {
+    db_tip.is_some_and(|tip| block_number <= tip)
+}
+
 /// Witness-stage budget for a block: full `witness_timeout` for **new** blocks (above local tip
 /// or no local DB — covers "witness still being generated upstream"), and the separately
 /// configurable `old_block_witness_timeout` (clamped to `witness_timeout`) for blocks at or
 /// below the tip.
 fn witness_budget(db_tip: Option<u64>, block_number: u64, cfg: &WitnessFetchConfig) -> Duration {
-    let is_new_block = db_tip.is_none_or(|max| block_number > max);
-    if is_new_block {
-        cfg.witness_timeout
-    } else {
+    if is_old_block(db_tip, block_number) {
         cfg.witness_timeout.min(cfg.old_block_witness_timeout)
+    } else {
+        cfg.witness_timeout
     }
 }
 
@@ -773,9 +770,8 @@ fn witness_deadline_for(
 }
 
 /// Whether a block is historical for witness routing: at least `local_window` blocks below the
-/// local tip. The internal witness generator retains only about the window (`BACKUP`), so its
-/// endpoint is a guaranteed miss for these; the remaining witness endpoints serve them.
-/// Unknown tip (or an overflowing window) conservatively counts as recent.
+/// local tip (see [`DEFAULT_WITNESS_LOCAL_WINDOW`] for why the window matters). Unknown tip
+/// (or an overflowing window) conservatively counts as recent.
 fn is_historical(db_tip: Option<u64>, block_number: u64, local_window: u64) -> bool {
     match (db_tip, block_number.checked_add(local_window)) {
         (Some(tip), Some(horizon)) => horizon <= tip,
@@ -784,14 +780,16 @@ fn is_historical(db_tip: Option<u64>, block_number: u64, local_window: u64) -> b
 }
 
 /// Witness route for a block: how many leading witness endpoints to skip, plus the metrics
-/// source label. Historical blocks (with [`WitnessFetchConfig::route_historical`] set) skip
-/// the internal generator at index 0; everything else uses the full chain.
+/// source label. Historical blocks skip the internal generator at index 0 — but only with a
+/// fallback endpoint to skip to (`have_fallback`, derived from the client's endpoint count, so
+/// the skip-aware fetch never sees an empty rotation); everything else uses the full chain.
 fn witness_route(
-    cfg: &WitnessFetchConfig,
+    have_fallback: bool,
     db_tip: Option<u64>,
     block_number: u64,
+    local_window: u64,
 ) -> (usize, &'static str) {
-    if cfg.route_historical && is_historical(db_tip, block_number, cfg.local_window) {
+    if have_fallback && is_historical(db_tip, block_number, local_window) {
         (1, "witness_historical")
     } else {
         (0, "witness_generator")
@@ -804,9 +802,8 @@ fn witness_route(
 /// - **Recent block** (within `local_window` of the local tip, or tip unknown): the full RPC
 ///   witness endpoint chain, tried in order — the internal generator first, so near-tip witnesses
 ///   stay on the fast internal path.
-/// - **Historical block** with `route_historical` set: the same chain minus the first endpoint. The
-///   generator only retains ~`local_window` blocks, so probing it for a historical block is a
-///   guaranteed miss that costs a failover round trip before every real fetch.
+/// - **Historical block** with a fallback endpoint configured: the same chain minus the first
+///   endpoint, the guaranteed-miss probe [`DEFAULT_WITNESS_LOCAL_WINDOW`] describes.
 ///
 /// Uses the zero-validation light decode: the trace server never verifies the witness proof,
 /// so the full decode's per-point elliptic-curve work bought nothing. The recorded size is
@@ -819,7 +816,8 @@ async fn fetch_witness(
     block_hash: B256,
     deadline: Instant,
 ) -> DataProviderResult<(LightWitness, MptWitness)> {
-    let (skip, source) = witness_route(cfg, db_tip, block_number);
+    let have_fallback = rpc_client.witness_provider_count() >= 2;
+    let (skip, source) = witness_route(have_fallback, db_tip, block_number, cfg.local_window);
     let metrics = WitnessSourceMetrics::new_for_source(source);
     let start = Instant::now();
     let budget = deadline.saturating_duration_since(start);
@@ -843,7 +841,7 @@ async fn fetch_witness(
                 block_number,
                 block_hash = %block_hash,
                 source,
-                old_block = db_tip.is_some_and(|tip| block_number <= tip),
+                old_block = is_old_block(db_tip, block_number),
                 budget_ms = budget.as_millis() as u64,
                 elapsed_ms = start.elapsed().as_millis() as u64,
                 "Witness fetch deadline exceeded",
@@ -949,18 +947,15 @@ mod tests {
     }
 
     /// Route selection: the skip-generator chain and the `witness_historical` label apply
-    /// only when routing is enabled AND the block is historical; everything else stays on
-    /// the full chain under the `witness_generator` label.
+    /// only with a fallback endpoint AND a historical block; everything else stays on the
+    /// full chain under the `witness_generator` label.
     #[test]
     fn witness_route_selection() {
-        let mut cfg = WitnessFetchConfig::single_chain(8);
-        cfg.local_window = 100;
-        // Routing disabled (single witness endpoint or no local DB): always the full chain.
-        assert_eq!(witness_route(&cfg, Some(5000), 900), (0, "witness_generator"));
-        cfg.route_historical = true;
-        assert_eq!(witness_route(&cfg, Some(5000), 900), (1, "witness_historical"));
-        assert_eq!(witness_route(&cfg, Some(5000), 4999), (0, "witness_generator"));
-        assert_eq!(witness_route(&cfg, None, 900), (0, "witness_generator"), "unknown tip");
+        // No fallback endpoint (single witness endpoint): always the full chain.
+        assert_eq!(witness_route(false, Some(5000), 900, 100), (0, "witness_generator"));
+        assert_eq!(witness_route(true, Some(5000), 900, 100), (1, "witness_historical"));
+        assert_eq!(witness_route(true, Some(5000), 4999, 100), (0, "witness_generator"));
+        assert_eq!(witness_route(true, None, 900, 100), (0, "witness_generator"), "unknown tip");
     }
 
     /// Serves `mega_getBlockWitness` returning an RPC error, counting hits per endpoint.
@@ -1006,7 +1001,6 @@ mod tests {
             witness_timeout: Duration::from_secs(1),
             old_block_witness_timeout: Duration::from_secs(1),
             local_window: 100,
-            route_historical: true,
         };
         let db_tip = Some(5000);
 
@@ -1030,7 +1024,7 @@ mod tests {
     /// `witness_timeout`.
     #[test]
     fn old_block_budget_is_configurable_and_clamped() {
-        let mut cfg = WitnessFetchConfig::single_chain(10);
+        let mut cfg = WitnessFetchConfig::with_defaults(10);
         cfg.old_block_witness_timeout = Duration::from_secs(8);
         // New block (above tip / no tip): full witness_timeout.
         assert_eq!(witness_budget(None, 42, &cfg), Duration::from_secs(10));
@@ -1098,8 +1092,8 @@ mod tests {
             rpc_client,
             None,
             contract_cache,
-            WitnessFetchConfig::single_chain(DEFAULT_WITNESS_TIMEOUT_SECS),
-            1, // 1-second block fetch timeout
+            WitnessFetchConfig::with_defaults(DEFAULT_WITNESS_TIMEOUT_SECS),
+            Duration::from_secs(1),
         );
 
         let start = std::time::Instant::now();
@@ -1142,8 +1136,8 @@ mod tests {
             rpc_client,
             None,
             contract_cache,
-            WitnessFetchConfig::single_chain(DEFAULT_WITNESS_TIMEOUT_SECS),
-            1, // 1-second block fetch timeout
+            WitnessFetchConfig::with_defaults(DEFAULT_WITNESS_TIMEOUT_SECS),
+            Duration::from_secs(1),
         );
 
         for tag in [BlockNumberOrTag::Latest, BlockNumberOrTag::Finalized, BlockNumberOrTag::Safe] {
@@ -1189,8 +1183,8 @@ mod tests {
             rpc_client,
             None,
             contract_cache,
-            WitnessFetchConfig::single_chain(DEFAULT_WITNESS_TIMEOUT_SECS),
-            60,
+            WitnessFetchConfig::with_defaults(DEFAULT_WITNESS_TIMEOUT_SECS),
+            Duration::from_secs(60),
         ));
 
         let block_hash = B256::from([0xAB; 32]);

--- a/bin/debug-trace-server/src/data_provider.rs
+++ b/bin/debug-trace-server/src/data_provider.rs
@@ -6,6 +6,11 @@
 //! 1. **Local Database** (fast) - Local DB for pre-fetched blocks (if configured)
 //! 2. **Remote RPC** (slower) - Upstream RPC endpoints as fallback
 //!
+//! Within the RPC fallback, the witness stage routes by block age (see [`WitnessFetchConfig`]):
+//! blocks within `local_window` of the local tip use the full witness endpoint chain (internal
+//! generator first), while historical blocks — which the generator has long pruned — skip the
+//! generator and go straight to the remaining endpoints.
+//!
 //! # Features
 //! - **Single-flight request coalescing**: concurrent callers for the same block hash share one
 //!   in-flight fetch via [`futures::future::Shared`]; the result is handed out as `Arc<BlockData>`
@@ -45,6 +50,37 @@ use crate::{
     server_db::BlockStore,
 };
 
+/// Witness-source routing and budget configuration, shared by the single-flight fetch futures.
+#[derive(Clone)]
+pub(crate) struct WitnessFetchConfig {
+    /// Sub-deadline applied to the witness stage for blocks above the local tip.
+    pub witness_timeout: Duration,
+    /// Sub-deadline for blocks at or below the local tip (clamped to `witness_timeout`).
+    pub old_block_witness_timeout: Duration,
+    /// Blocks at least this far below the local tip are historical: the internal witness
+    /// generator only retains about this window (its `BACKUP` env), so probing it first is a
+    /// guaranteed miss that costs a failover round trip.
+    pub local_window: u64,
+    /// Whether historical blocks skip the first witness endpoint (the internal generator) and
+    /// fetch from the remaining endpoints only. Must only be set when at least two witness
+    /// endpoints are configured — the skip-aware fetch panics on an empty rotation — and is
+    /// only effective with a local DB, whose tip is the reference point for block age.
+    pub route_historical: bool,
+}
+
+impl WitnessFetchConfig {
+    /// Single-chain config (no historical split) with default budgets and window.
+    #[cfg(test)]
+    pub fn single_chain(witness_timeout_secs: u64) -> Self {
+        Self {
+            witness_timeout: Duration::from_secs(witness_timeout_secs),
+            old_block_witness_timeout: Duration::from_secs(DEFAULT_OLD_BLOCK_WITNESS_TIMEOUT_SECS),
+            local_window: DEFAULT_WITNESS_LOCAL_WINDOW,
+            route_historical: false,
+        }
+    }
+}
+
 /// Block data bundle containing all information needed for stateless execution.
 ///
 /// This struct aggregates the block, its witness (state proof), and all
@@ -76,6 +112,22 @@ pub struct BlockData {
 /// the witness is still being generated upstream" case where a few seconds of waiting is
 /// normal.
 pub const DEFAULT_WITNESS_TIMEOUT_SECS: u64 = 8;
+
+/// Default witness-stage budget for blocks at or below the local tip, in seconds.
+///
+/// Defaults to the full witness budget: a tighter fail-fast here converts slow-but-successful
+/// fetches into client-visible timeouts whenever the witness tail latency approaches the cap.
+/// Operators who prefer failing fast on blocks whose witness is likely gone everywhere can
+/// lower `--witness-old-block-timeout`.
+pub const DEFAULT_OLD_BLOCK_WITNESS_TIMEOUT_SECS: u64 = 8;
+
+/// Default local-tip window (in blocks) below which witnesses are considered historical and
+/// skip the internal generator endpoint (see [`WitnessFetchConfig::route_historical`]).
+///
+/// Matches the witness generator's default deployed local retention (`BACKUP=4096`): blocks
+/// deeper than this are guaranteed misses on the internal generator endpoint, so probing it
+/// first only burns a failover round trip.
+pub const DEFAULT_WITNESS_LOCAL_WINDOW: u64 = 4096;
 
 /// Default deadline for the full block-fetch pipeline (header + witness + block + contracts)
 /// in seconds (13 seconds).
@@ -222,9 +274,10 @@ pub(crate) struct DataProvider {
     /// repeated trace requests for the same contract hit memory instead of
     /// redb (slow) or RPC (slowest).
     contract_cache: Arc<ContractCache>,
-    /// Sub-deadline applied to the witness stage only. The full-call deadline still
-    /// dominates; this caps how long the witness fetch can burn out of that budget.
-    witness_timeout: Duration,
+    /// Witness-stage routing (full chain vs historical skip-generator chain) and budgets.
+    /// The full-call deadline still dominates; the per-stage budgets cap how much of it the
+    /// witness fetch can burn.
+    witness_cfg: WitnessFetchConfig,
     /// Wall-clock budget for one user-facing block-data call, from entry through
     /// header + witness + block + contract resolution. The retry loop in `RpcClient`
     /// checks this before each round and clamps its sleep accordingly, so a missing
@@ -246,21 +299,21 @@ impl DataProvider {
     /// * `db` - Optional local database for cached block data
     /// * `contract_cache` - Shared in-memory contract cache (backed by the DB when present, or an
     ///   in-memory-only noop store in stateless mode)
-    /// * `witness_timeout_secs` - User-facing cap on a single witness fetch, in seconds
+    /// * `witness_cfg` - Witness-source routing (by block age) and per-stage budgets
     /// * `block_fetch_timeout_secs` - User-facing cap on the full block-fetch pipeline (header +
     ///   witness + block + contracts), in seconds
     pub fn new(
         rpc_client: Arc<RpcClient>,
         db: Option<Arc<dyn BlockStore>>,
         contract_cache: Arc<ContractCache>,
-        witness_timeout_secs: u64,
+        witness_cfg: WitnessFetchConfig,
         block_fetch_timeout_secs: u64,
     ) -> Self {
         Self {
             rpc_client,
             db,
             contract_cache,
-            witness_timeout: Duration::from_secs(witness_timeout_secs),
+            witness_cfg,
             block_fetch_timeout: Duration::from_secs(block_fetch_timeout_secs),
             in_flight: DashMap::new(),
         }
@@ -508,13 +561,13 @@ impl DataProvider {
                 let rpc_client = Arc::clone(&self.rpc_client);
                 let db = self.db.clone();
                 let contract_cache = Arc::clone(&self.contract_cache);
-                let witness_timeout = self.witness_timeout;
+                let witness_cfg = self.witness_cfg.clone();
                 let fut: BlockDataFetchFuture = Box::pin(async move {
                     do_fetch_block_data(
                         rpc_client,
                         db,
                         contract_cache,
-                        witness_timeout,
+                        witness_cfg,
                         block_hash,
                         deadline,
                     )
@@ -597,7 +650,7 @@ async fn do_fetch_block_data(
     rpc_client: Arc<RpcClient>,
     db: Option<Arc<dyn BlockStore>>,
     contract_cache: Arc<ContractCache>,
-    witness_timeout: Duration,
+    witness_cfg: WitnessFetchConfig,
     block_hash: B256,
     deadline: Instant,
 ) -> DataProviderResult<BlockData> {
@@ -612,14 +665,22 @@ async fn do_fetch_block_data(
     let fetch_header_ms = start.elapsed().as_millis();
 
     // Step 2: Pick the witness deadline based on "new vs old" heuristic, then run witness
-    // and full-block fetches in parallel.
-    let witness_deadline =
-        witness_deadline_for(db.as_deref(), block_number, witness_timeout, deadline);
+    // and full-block fetches in parallel. The tip is read once and shared by the deadline
+    // heuristic and the witness-source routing.
+    let db_tip = db_tip_height(db.as_deref());
+    let witness_deadline = witness_deadline_for(db_tip, block_number, &witness_cfg, deadline);
     let (witness_timed, block_timed) = tokio::join!(
         async {
             let start = Instant::now();
-            let result =
-                fetch_witness(&rpc_client, block_number, header.hash, witness_deadline).await;
+            let result = fetch_witness(
+                &rpc_client,
+                &witness_cfg,
+                db_tip,
+                block_number,
+                header.hash,
+                witness_deadline,
+            )
+            .await;
             (result, start.elapsed())
         },
         async {
@@ -673,71 +734,117 @@ async fn do_fetch_block_data(
     Ok(BlockData { block, witness, contracts })
 }
 
-/// Picks the effective deadline for a witness fetch.
-///
-/// - **New block** (above local tip or no local DB): full `witness_timeout` sub-deadline, clamped
-///   by the outer call deadline. Covers "witness still being generated upstream".
-/// - **Old / pruned block** (at or below local tip): tightened to `OLD_BLOCK_WITNESS_TIMEOUT` (≤
-///   witness_timeout) because witness data for such blocks is either available immediately or not
-///   at all; burning the full witness_timeout on a pruned block is a bad tradeoff.
+/// Reads the local DB's canonical tip height, `None` when no DB is configured or the tip is
+/// unknown.
+fn db_tip_height(db: Option<&dyn BlockStore>) -> Option<u64> {
+    db.and_then(|db| db.get_canonical_tip().ok().flatten().map(|tip| tip.block_number))
+}
+
+/// Witness-stage budget for a block: full `witness_timeout` for **new** blocks (above local tip
+/// or no local DB — covers "witness still being generated upstream"), and the separately
+/// configurable `old_block_witness_timeout` (clamped to `witness_timeout`) for blocks at or
+/// below the tip.
+fn witness_budget(db_tip: Option<u64>, block_number: u64, cfg: &WitnessFetchConfig) -> Duration {
+    let is_new_block = db_tip.is_none_or(|max| block_number > max);
+    if is_new_block {
+        cfg.witness_timeout
+    } else {
+        cfg.witness_timeout.min(cfg.old_block_witness_timeout)
+    }
+}
+
+/// Picks the effective deadline for a witness fetch: [`witness_budget`] from now, clamped by the
+/// outer call deadline.
 fn witness_deadline_for(
-    db: Option<&dyn BlockStore>,
+    db_tip: Option<u64>,
     block_number: u64,
-    witness_timeout: Duration,
+    cfg: &WitnessFetchConfig,
     outer_deadline: Instant,
 ) -> Instant {
-    /// Cap on witness fetches for blocks at or below the local tip.
-    ///
-    /// Sized against the default [`BackoffPolicy`](stateless_common::BackoffPolicy)
-    /// (`initial = 500 ms`, 2× doubling): 500 ms + 1 s + 2 s ≈ 3.5 s, so 3 s lets
-    /// every provider be probed across ~2–3 rounds before we fail.
-    const OLD_BLOCK_WITNESS_TIMEOUT: Duration = Duration::from_secs(3);
-
-    let db_max_height =
-        db.and_then(|db| db.get_canonical_tip().ok().flatten().map(|tip| tip.block_number));
-    let is_new_block = db_max_height.is_none_or(|max| block_number > max);
-    let budget =
-        if is_new_block { witness_timeout } else { witness_timeout.min(OLD_BLOCK_WITNESS_TIMEOUT) };
+    let budget = witness_budget(db_tip, block_number, cfg);
     let stage_deadline = Instant::now() + budget;
     trace!(
         block_number,
-        db_max_height,
-        is_new_block,
+        db_tip,
         budget_ms = budget.as_millis() as u64,
         "Computed witness stage deadline",
     );
     stage_deadline.min(outer_deadline)
 }
 
-/// Fetches witness data via the deadline-aware `RpcClient` API. The `deadline` is the
-/// witness stage's effective deadline (see [`witness_deadline_for`]).
+/// Whether a block is historical for witness routing: at least `local_window` blocks below the
+/// local tip. The internal witness generator retains only about the window (`BACKUP`), so its
+/// endpoint is a guaranteed miss for these; the remaining witness endpoints serve them.
+/// Unknown tip (or an overflowing window) conservatively counts as recent.
+fn is_historical(db_tip: Option<u64>, block_number: u64, local_window: u64) -> bool {
+    match (db_tip, block_number.checked_add(local_window)) {
+        (Some(tip), Some(horizon)) => horizon <= tip,
+        _ => false,
+    }
+}
+
+/// Witness route for a block: how many leading witness endpoints to skip, plus the metrics
+/// source label. Historical blocks (with [`WitnessFetchConfig::route_historical`] set) skip
+/// the internal generator at index 0; everything else uses the full chain.
+fn witness_route(
+    cfg: &WitnessFetchConfig,
+    db_tip: Option<u64>,
+    block_number: u64,
+) -> (usize, &'static str) {
+    if cfg.route_historical && is_historical(db_tip, block_number, cfg.local_window) {
+        (1, "witness_historical")
+    } else {
+        (0, "witness_generator")
+    }
+}
+
+/// Fetches witness data, routing by block age. The `deadline` is the witness stage's
+/// effective deadline (see [`witness_deadline_for`]).
 ///
-/// Uses the zero-validation light decode: the trace server never verifies the
-/// witness proof, so the full decode's per-point elliptic-curve work bought
-/// nothing. The recorded size is the light lower bound (excludes the
-/// never-decoded parent commitments).
+/// - **Recent block** (within `local_window` of the local tip, or tip unknown): the full RPC
+///   witness endpoint chain, tried in order — the internal generator first, so near-tip witnesses
+///   stay on the fast internal path.
+/// - **Historical block** with `route_historical` set: the same chain minus the first endpoint. The
+///   generator only retains ~`local_window` blocks, so probing it for a historical block is a
+///   guaranteed miss that costs a failover round trip before every real fetch.
+///
+/// Uses the zero-validation light decode: the trace server never verifies the witness proof,
+/// so the full decode's per-point elliptic-curve work bought nothing. The recorded size is
+/// the light lower bound (excludes the never-decoded parent commitments).
 async fn fetch_witness(
     rpc_client: &RpcClient,
+    cfg: &WitnessFetchConfig,
+    db_tip: Option<u64>,
     block_number: u64,
     block_hash: B256,
     deadline: Instant,
 ) -> DataProviderResult<(LightWitness, MptWitness)> {
-    let wg_metrics = WitnessSourceMetrics::new_for_source("witness_generator");
+    let (skip, source) = witness_route(cfg, db_tip, block_number);
+    let metrics = WitnessSourceMetrics::new_for_source(source);
     let start = Instant::now();
+    let budget = deadline.saturating_duration_since(start);
 
-    match rpc_client.get_witness_light_with_deadline(block_number, block_hash, Some(deadline)).await
+    match rpc_client
+        .get_witness_light_with_deadline_from(skip, block_number, block_hash, Some(deadline))
+        .await
     {
         Ok(w) => {
-            wg_metrics.record_request(true, start.elapsed().as_secs_f64());
-            wg_metrics.record_size(WitnessSizeBreakdown::new_light(&w.0, &w.1).total());
-            DataSourceMetrics::new_for_source("witness_generator").record();
+            metrics.record_request(true, start.elapsed().as_secs_f64());
+            metrics.record_size(WitnessSizeBreakdown::new_light(&w.0, &w.1).total());
+            DataSourceMetrics::new_for_source(source).record();
             Ok(w)
         }
         Err(e) => {
-            wg_metrics.record_request(false, start.elapsed().as_secs_f64());
+            metrics.record_request(false, start.elapsed().as_secs_f64());
+            // Attribution-grade context for the next timeout incident: the effective stage
+            // budget, the route taken, and whether the old-block clamp applied — the client
+            // only ever sees the generic `-32001` message.
             warn!(
                 block_number,
                 block_hash = %block_hash,
+                source,
+                old_block = db_tip.is_some_and(|tip| block_number <= tip),
+                budget_ms = budget.as_millis() as u64,
                 elapsed_ms = start.elapsed().as_millis() as u64,
                 "Witness fetch deadline exceeded",
             );
@@ -802,9 +909,12 @@ impl ContractStore for NoopContractStore {
 
 #[cfg(test)]
 mod tests {
-    use std::net::TcpListener;
+    use std::{
+        net::TcpListener,
+        sync::atomic::{AtomicUsize, Ordering},
+    };
 
-    use stateless_common::RpcClientConfig;
+    use stateless_common::{BackoffPolicy, RpcClientConfig};
 
     use super::*;
 
@@ -822,6 +932,114 @@ mod tests {
 
         assert_eq!(DEFAULT_WITNESS_TIMEOUT_SECS, 8);
         assert_eq!(Duration::from_secs(DEFAULT_WITNESS_TIMEOUT_SECS).as_millis(), 8000);
+    }
+
+    /// Witness-source routing boundary: historical iff `number + local_window <= tip`;
+    /// unknown tip and window overflow are conservatively recent (RPC path).
+    #[test]
+    fn historical_routing_boundary() {
+        assert!(!is_historical(None, 100, 4096), "unknown tip is recent");
+        assert!(is_historical(Some(5000), 904, 4096), "904 + 4096 == 5000: exactly at the window");
+        assert!(!is_historical(Some(5000), 905, 4096), "one inside the window is recent");
+        assert!(!is_historical(Some(5000), 5000, 4096), "the tip itself is recent");
+        assert!(is_historical(Some(4096), 0, 4096), "genesis with tip == window");
+        assert!(!is_historical(Some(4095), 0, 4096));
+        assert!(!is_historical(Some(u64::MAX), u64::MAX, 4096), "overflowing horizon is recent");
+        assert!(is_historical(Some(100), 50, 0), "zero window: everything at/below tip");
+    }
+
+    /// Route selection: the skip-generator chain and the `witness_historical` label apply
+    /// only when routing is enabled AND the block is historical; everything else stays on
+    /// the full chain under the `witness_generator` label.
+    #[test]
+    fn witness_route_selection() {
+        let mut cfg = WitnessFetchConfig::single_chain(8);
+        cfg.local_window = 100;
+        // Routing disabled (single witness endpoint or no local DB): always the full chain.
+        assert_eq!(witness_route(&cfg, Some(5000), 900), (0, "witness_generator"));
+        cfg.route_historical = true;
+        assert_eq!(witness_route(&cfg, Some(5000), 900), (1, "witness_historical"));
+        assert_eq!(witness_route(&cfg, Some(5000), 4999), (0, "witness_generator"));
+        assert_eq!(witness_route(&cfg, None, 900), (0, "witness_generator"), "unknown tip");
+    }
+
+    /// Serves `mega_getBlockWitness` returning an RPC error, counting hits per endpoint.
+    async fn start_counting_witness_rpc()
+    -> (jsonrpsee::server::ServerHandle, String, Arc<AtomicUsize>) {
+        let hits = Arc::new(AtomicUsize::new(0));
+        let mut module = jsonrpsee::server::RpcModule::new(hits.clone());
+        module
+            .register_method("mega_getBlockWitness", |_p, hits, _| {
+                hits.fetch_add(1, Ordering::Relaxed);
+                Err::<String, _>(jsonrpsee::types::ErrorObjectOwned::owned::<()>(
+                    -32000,
+                    "no witness",
+                    None,
+                ))
+            })
+            .unwrap();
+        let server =
+            jsonrpsee::server::ServerBuilder::default().build("127.0.0.1:0").await.unwrap();
+        let url = format!("http://{}", server.local_addr().unwrap());
+        (server.start(module), url, hits)
+    }
+
+    /// End-to-end routing dispatch through `fetch_witness`: a historical block must never
+    /// touch the first (generator) endpoint, while a recent block probes it first.
+    #[tokio::test]
+    async fn fetch_witness_routes_historical_blocks_past_the_generator() {
+        let (ha, url_a, hits_a) = start_counting_witness_rpc().await;
+        let (hb, url_b, hits_b) = start_counting_witness_rpc().await;
+
+        let config = RpcClientConfig {
+            rpc_retry: BackoffPolicy::new(Duration::from_millis(1), Duration::from_millis(2)),
+            ..RpcClientConfig::trace_server()
+        };
+        let rpc_client = RpcClient::new_with_config(
+            &[url_a.as_str()],
+            &[url_a.as_str(), url_b.as_str()],
+            config,
+            None,
+        )
+        .unwrap();
+        let cfg = WitnessFetchConfig {
+            witness_timeout: Duration::from_secs(1),
+            old_block_witness_timeout: Duration::from_secs(1),
+            local_window: 100,
+            route_historical: true,
+        };
+        let db_tip = Some(5000);
+
+        // Historical block (900 + 100 <= 5000): the generator endpoint must stay untouched.
+        let deadline = Instant::now() + Duration::from_millis(150);
+        let result = fetch_witness(&rpc_client, &cfg, db_tip, 900, B256::ZERO, deadline).await;
+        assert!(result.is_err(), "the mock only returns errors, so the deadline must fire");
+        assert_eq!(hits_a.load(Ordering::Relaxed), 0, "historical fetch must skip the generator");
+        assert!(hits_b.load(Ordering::Relaxed) >= 1, "the fallback endpoint must be tried");
+
+        // Recent block (the tip itself): the full chain, generator first.
+        let deadline = Instant::now() + Duration::from_millis(150);
+        let _ = fetch_witness(&rpc_client, &cfg, db_tip, 5000, B256::ZERO, deadline).await;
+        assert!(hits_a.load(Ordering::Relaxed) >= 1, "recent fetch must probe the generator");
+
+        ha.stop().unwrap();
+        hb.stop().unwrap();
+    }
+
+    /// Old-block witness budget honors the configurable timeout and clamps to
+    /// `witness_timeout`.
+    #[test]
+    fn old_block_budget_is_configurable_and_clamped() {
+        let mut cfg = WitnessFetchConfig::single_chain(10);
+        cfg.old_block_witness_timeout = Duration::from_secs(8);
+        // New block (above tip / no tip): full witness_timeout.
+        assert_eq!(witness_budget(None, 42, &cfg), Duration::from_secs(10));
+        assert_eq!(witness_budget(Some(41), 42, &cfg), Duration::from_secs(10));
+        // Old block (at/below tip): the configured old-block budget.
+        assert_eq!(witness_budget(Some(42), 42, &cfg), Duration::from_secs(8));
+        // Clamped: old-block budget can never exceed witness_timeout.
+        cfg.old_block_witness_timeout = Duration::from_secs(30);
+        assert_eq!(witness_budget(Some(42), 42, &cfg), Duration::from_secs(10));
     }
 
     /// `BlockNumberOrTag` / `BlockId` variants that `resolve_block_number` matches on.
@@ -880,7 +1098,7 @@ mod tests {
             rpc_client,
             None,
             contract_cache,
-            DEFAULT_WITNESS_TIMEOUT_SECS,
+            WitnessFetchConfig::single_chain(DEFAULT_WITNESS_TIMEOUT_SECS),
             1, // 1-second block fetch timeout
         );
 
@@ -924,7 +1142,7 @@ mod tests {
             rpc_client,
             None,
             contract_cache,
-            DEFAULT_WITNESS_TIMEOUT_SECS,
+            WitnessFetchConfig::single_chain(DEFAULT_WITNESS_TIMEOUT_SECS),
             1, // 1-second block fetch timeout
         );
 
@@ -971,7 +1189,7 @@ mod tests {
             rpc_client,
             None,
             contract_cache,
-            DEFAULT_WITNESS_TIMEOUT_SECS,
+            WitnessFetchConfig::single_chain(DEFAULT_WITNESS_TIMEOUT_SECS),
             60,
         ));
 

--- a/bin/debug-trace-server/src/main.rs
+++ b/bin/debug-trace-server/src/main.rs
@@ -225,14 +225,10 @@ struct Args {
     witness_local_window: u64,
 
     /// Witness-stage budget in seconds for blocks at or below the local tip. Defaults to the
-    /// full witness budget; lower it to fail fast on blocks whose witness is likely pruned
-    /// everywhere. Clamped to `--witness-timeout`.
-    #[clap(
-        long,
-        env = "DEBUG_TRACE_SERVER_WITNESS_OLD_BLOCK_TIMEOUT",
-        default_value_t = data_provider::DEFAULT_OLD_BLOCK_WITNESS_TIMEOUT_SECS
-    )]
-    witness_old_block_timeout: u64,
+    /// full `--witness-timeout` budget (tracking it when raised); lower it to fail fast on
+    /// blocks whose witness is likely pruned everywhere. Clamped to `--witness-timeout`.
+    #[clap(long, env = "DEBUG_TRACE_SERVER_WITNESS_OLD_BLOCK_TIMEOUT")]
+    witness_old_block_timeout: Option<u64>,
 
     /// Chain-sync pipeline tip buffer: stay this many blocks behind the upstream head so the
     /// fetcher does not race the witness generator — a fetch issued the moment a block appears
@@ -294,6 +290,13 @@ fn parse_size(s: &str) -> Result<u64, String> {
     value.checked_mul(multiplier).ok_or_else(|| format!("size overflow: '{}'", s))
 }
 
+/// Effective old-block witness budget in seconds: the flag when set (clamped to
+/// `--witness-timeout`), otherwise the full `--witness-timeout` budget — raising the witness
+/// budget also raises the old-block cap.
+fn old_block_witness_timeout_secs(args: &Args) -> u64 {
+    args.witness_old_block_timeout.unwrap_or(args.witness_timeout).min(args.witness_timeout)
+}
+
 /// Validates cross-flag invariants that clap cannot express per-field.
 fn validate_args(args: &Args) -> Result<()> {
     // Only meaningful with chain sync: the fetcher holds the local tip `tip_buffer` blocks
@@ -325,7 +328,7 @@ async fn main() -> Result<()> {
         rpc_endpoints = ?args.rpc_endpoint,
         witness_endpoints = ?args.witness_endpoint,
         witness_timeout_secs = args.witness_timeout,
-        witness_old_block_timeout_secs = args.witness_old_block_timeout,
+        witness_old_block_timeout_secs = old_block_witness_timeout_secs(&args),
         witness_local_window = args.witness_local_window,
         tip_buffer = args.tip_buffer,
         response_cache_disabled,
@@ -401,7 +404,9 @@ async fn main() -> Result<()> {
 
     let witness_cfg = WitnessFetchConfig {
         witness_timeout: std::time::Duration::from_secs(args.witness_timeout),
-        old_block_witness_timeout: std::time::Duration::from_secs(args.witness_old_block_timeout),
+        old_block_witness_timeout: std::time::Duration::from_secs(old_block_witness_timeout_secs(
+            &args,
+        )),
         local_window: args.witness_local_window,
     };
     let data_provider = Arc::new(DataProvider::new(
@@ -773,20 +778,32 @@ mod tests {
 
         let defaults = parse_args(&[]);
         assert_eq!(defaults.witness_local_window, data_provider::DEFAULT_WITNESS_LOCAL_WINDOW);
+        assert_eq!(defaults.witness_old_block_timeout, None);
         assert_eq!(
-            defaults.witness_old_block_timeout,
-            data_provider::DEFAULT_OLD_BLOCK_WITNESS_TIMEOUT_SECS
-        );
-        assert_eq!(
-            data_provider::DEFAULT_OLD_BLOCK_WITNESS_TIMEOUT_SECS,
+            old_block_witness_timeout_secs(&defaults),
             data_provider::DEFAULT_WITNESS_TIMEOUT_SECS,
             "old blocks default to the full witness budget",
         );
         assert_eq!(defaults.tip_buffer, 2);
 
+        // The unset default tracks a raised --witness-timeout; an explicit flag wins.
+        assert_eq!(old_block_witness_timeout_secs(&parse_args(&["--witness-timeout", "20"])), 20);
+        assert_eq!(
+            old_block_witness_timeout_secs(&parse_args(&[
+                "--witness-timeout",
+                "20",
+                "--witness-old-block-timeout",
+                "3"
+            ])),
+            3
+        );
+
         assert_eq!(parse_args(&["--tip-buffer", "0"]).tip_buffer, 0);
         assert_eq!(parse_args(&["--witness-local-window", "128"]).witness_local_window, 128);
-        assert_eq!(parse_args(&["--witness-old-block-timeout", "3"]).witness_old_block_timeout, 3);
+        assert_eq!(
+            parse_args(&["--witness-old-block-timeout", "3"]).witness_old_block_timeout,
+            Some(3)
+        );
 
         let env = |name, value: &str| {
             stateless_test_utils::env::with_env_var(&guard, name, value, || parse_args(&[]))
@@ -795,7 +812,7 @@ mod tests {
         assert_eq!(env("DEBUG_TRACE_SERVER_WITNESS_LOCAL_WINDOW", "256").witness_local_window, 256);
         assert_eq!(
             env("DEBUG_TRACE_SERVER_WITNESS_OLD_BLOCK_TIMEOUT", "4").witness_old_block_timeout,
-            4
+            Some(4)
         );
     }
 

--- a/bin/debug-trace-server/src/main.rs
+++ b/bin/debug-trace-server/src/main.rs
@@ -208,12 +208,13 @@ struct Args {
     #[clap(long, env = "DEBUG_TRACE_SERVER_WITNESS_MAX_CONCURRENT_REQUESTS")]
     witness_max_concurrent_requests: Option<usize>,
 
-    /// Blocks within this many blocks of the local tip fetch witnesses through the full
-    /// witness endpoint chain (internal generator first); older blocks skip the first witness
-    /// endpoint — the generator only retains about this window (its `BACKUP` env, deployed at
-    /// 4096), so probing it for historical blocks is a guaranteed miss. Requires at least two
-    /// witness endpoints and a local DB (`--data-dir`), whose tip anchors block age; otherwise
-    /// all blocks use the full chain. Should match the generator's `BACKUP`.
+    /// Blocks fewer than this many blocks below the local tip fetch witnesses through the
+    /// full witness endpoint chain (internal generator first); blocks at least this far below
+    /// skip the first witness endpoint — the generator only retains about this window (its
+    /// `BACKUP` env, deployed at 4096), so probing it for historical blocks is a guaranteed
+    /// miss. Requires at least two witness endpoints and a local DB (`--data-dir`), whose tip
+    /// anchors block age; otherwise all blocks use the full chain. Should match the
+    /// generator's `BACKUP`.
     #[clap(
         long,
         env = "DEBUG_TRACE_SERVER_WITNESS_LOCAL_WINDOW",
@@ -366,7 +367,9 @@ async fn main() -> Result<()> {
     match (witness_apis.len() >= 2, args.data_dir.is_some()) {
         (true, true) => info!(
             witness_local_window = args.witness_local_window,
-            skipped_endpoint = witness_apis[0],
+            // The credential-stripped label, not the raw URL — configured endpoint URLs may
+            // carry userinfo or token queries and this log line is info-level.
+            skipped_endpoint = rpc_client.witness_provider_label(0).unwrap_or("<none>"),
             "Historical witnesses (at least the local window below the tip) skip the internal \
              generator endpoint"
         ),

--- a/bin/debug-trace-server/src/main.rs
+++ b/bin/debug-trace-server/src/main.rs
@@ -100,19 +100,28 @@ struct Args {
     )]
     rpc_endpoint: Vec<String>,
 
-    /// One or more upstream witness endpoint URLs for fetching witness data (tried in order).
+    /// One or more durable witness endpoint URLs for fetching witness data (tried in order).
     /// Accepts repeated flags (`--witness-endpoint a --witness-endpoint b`) or a comma-separated
-    /// list (`--witness-endpoint a,b`, also via the env var). The first endpoint is positionally
-    /// special: it is treated as the internal witness generator and is skipped for historical
-    /// blocks (see `--witness-local-window`).
+    /// list (`--witness-endpoint a,b`, also via the env var). Deprecated fallback: when
+    /// `--witness-generator-endpoint` is absent and two or more endpoints are listed here, the
+    /// first is treated as the internal generator (see that flag).
     #[clap(
         long,
         env = "DEBUG_TRACE_SERVER_WITNESS_ENDPOINT",
-        required = true,
+        required_unless_present = "witness_generator_endpoint",
         value_delimiter = ',',
         action = clap::ArgAction::Append,
     )]
     witness_endpoint: Vec<String>,
+
+    /// The internal witness generator endpoint. It is probed first for recent blocks and
+    /// skipped for historical ones (it only retains about `--witness-local-window` blocks),
+    /// while `--witness-endpoint` lists the durable fallbacks (optional when this flag is
+    /// set — generator-only works like any single-endpoint config, without routing). When
+    /// absent, the first of two or more `--witness-endpoint` values fills this role
+    /// (deprecated positional form).
+    #[clap(long, env = "DEBUG_TRACE_SERVER_WITNESS_GENERATOR_ENDPOINT")]
+    witness_generator_endpoint: Option<String>,
 
     /// Enable Prometheus metrics exporter.
     #[clap(long, env = "DEBUG_TRACE_SERVER_METRICS_ENABLED")]
@@ -213,7 +222,8 @@ struct Args {
     /// full witness endpoint chain (internal generator first); blocks at least this far below
     /// skip the first witness endpoint — the generator only retains about this window (its
     /// `BACKUP` env, deployed at 4096), so probing it for historical blocks is a guaranteed
-    /// miss. Requires at least two witness endpoints and a local DB (`--data-dir`), whose tip
+    /// miss. Requires a generator plus at least one fallback witness endpoint (see
+    /// `--witness-generator-endpoint`) and a local DB (`--data-dir`), whose tip
     /// anchors block age; otherwise all blocks use the full chain. Applies to request
     /// serving; chain-sync prefetch always uses the full chain. Should match the generator's
     /// `BACKUP`.
@@ -297,6 +307,22 @@ fn old_block_witness_timeout_secs(args: &Args) -> u64 {
     args.witness_old_block_timeout.unwrap_or(args.witness_timeout).min(args.witness_timeout)
 }
 
+/// The combined witness endpoint chain — the internal generator (when configured) first, then
+/// the durable fallbacks — plus whether the generator slot comes from the deprecated
+/// positional form (no `--witness-generator-endpoint`, two or more `--witness-endpoint`).
+///
+/// The chain always has the generator at index 0 when one exists, so the fetch-side routing
+/// derivation (skip the first endpoint iff the chain has at least two) holds under both the
+/// typed flag and the deprecated form.
+fn witness_endpoint_chain(args: &Args) -> (Vec<&str>, bool) {
+    let mut chain: Vec<&str> = Vec::with_capacity(args.witness_endpoint.len() + 1);
+    chain.extend(args.witness_generator_endpoint.as_deref());
+    chain.extend(args.witness_endpoint.iter().map(String::as_str));
+    let deprecated_positional =
+        args.witness_generator_endpoint.is_none() && args.witness_endpoint.len() >= 2;
+    (chain, deprecated_positional)
+}
+
 /// Validates cross-flag invariants that clap cannot express per-field.
 fn validate_args(args: &Args) -> Result<()> {
     // Only meaningful with chain sync: the fetcher holds the local tip `tip_buffer` blocks
@@ -308,6 +334,18 @@ fn validate_args(args: &Args) -> Result<()> {
             "--tip-buffer ({}) must be smaller than --blocks-to-keep ({})",
             args.tip_buffer,
             args.blocks_to_keep
+        );
+    }
+    // A generator listed again under --witness-endpoint would put the generator back into the
+    // historical route's fallback rotation — every historical fetch would probe the pruned
+    // endpoint the routing exists to skip, silently. The likely cause is migrating to
+    // --witness-generator-endpoint without removing the generator from the fallback list.
+    if let Some(generator) = &args.witness_generator_endpoint &&
+        args.witness_endpoint.contains(generator)
+    {
+        eyre::bail!(
+            "--witness-generator-endpoint ({generator}) must not also appear in \
+             --witness-endpoint: list the generator once, via the dedicated flag"
         );
     }
     Ok(())
@@ -324,9 +362,13 @@ async fn main() -> Result<()> {
         "Debug-trace-server starting"
     );
     let response_cache_disabled = args.response_cache_estimated_items == 0;
+    // The combined witness chain (generator first when configured) — the list actually fed to
+    // the RPC client, not just the fallback flag values.
+    let (witness_apis, deprecated_positional_generator) = witness_endpoint_chain(&args);
     debug!(
         rpc_endpoints = ?args.rpc_endpoint,
-        witness_endpoints = ?args.witness_endpoint,
+        witness_endpoints = ?witness_apis,
+        witness_generator_configured = args.witness_generator_endpoint.is_some(),
         witness_timeout_secs = args.witness_timeout,
         witness_old_block_timeout_secs = old_block_witness_timeout_secs(&args),
         witness_local_window = args.witness_local_window,
@@ -353,7 +395,6 @@ async fn main() -> Result<()> {
 
     // Initialize components
     let data_apis: Vec<&str> = args.rpc_endpoint.iter().map(String::as_str).collect();
-    let witness_apis: Vec<&str> = args.witness_endpoint.iter().map(String::as_str).collect();
     let rpc_defaults = RpcClientConfig::trace_server();
     let per_attempt_timeout = args
         .rpc_per_attempt_timeout_ms
@@ -370,18 +411,27 @@ async fn main() -> Result<()> {
         Arc::new(RpcClient::new_with_config(&data_apis, &witness_apis, rpc_config, None)?);
 
     match (witness_apis.len() >= 2, args.data_dir.is_some()) {
-        (true, true) => info!(
-            witness_local_window = args.witness_local_window,
-            // The credential-stripped label, not the raw URL — configured endpoint URLs may
-            // carry userinfo or token queries and this log line is info-level.
-            skipped_endpoint = rpc_client.witness_provider_label(0).unwrap_or("<none>"),
-            "Historical witnesses (at least the local window below the tip) skip the internal \
-             generator endpoint"
-        ),
+        (true, true) => {
+            info!(
+                witness_local_window = args.witness_local_window,
+                // The credential-stripped label, not the raw URL — configured endpoint URLs
+                // may carry userinfo or token queries and this log line is info-level.
+                skipped_endpoint = rpc_client.witness_provider_label(0).unwrap_or("<none>"),
+                "Historical witnesses (at least the local window below the tip) skip the \
+                 internal generator endpoint"
+            );
+            if deprecated_positional_generator {
+                warn!(
+                    "The first --witness-endpoint is being treated as the internal generator; \
+                     this positional form is deprecated — declare the generator explicitly via \
+                     --witness-generator-endpoint"
+                );
+            }
+        }
         (true, false) => warn!(
-            "Multiple witness endpoints but no --data-dir: historical witness routing is \
-             inactive (block age is anchored to the local DB tip); all witness fetches use the \
-             full endpoint chain"
+            "Witness generator plus fallback endpoints but no --data-dir: historical witness \
+             routing is inactive (block age is anchored to the local DB tip); all witness \
+             fetches use the full endpoint chain"
         ),
         (false, _) => debug!("Single witness endpoint configured; no historical witness routing"),
     }
@@ -814,6 +864,68 @@ mod tests {
             env("DEBUG_TRACE_SERVER_WITNESS_OLD_BLOCK_TIMEOUT", "4").witness_old_block_timeout,
             Some(4)
         );
+    }
+
+    /// The witness chain always puts the generator at index 0 — from the typed flag when
+    /// present, else (deprecated) the first of two or more `--witness-endpoint` values — so
+    /// the fetch-side skip derivation holds under both forms; a single durable endpoint has
+    /// no generator slot at all.
+    #[test]
+    fn witness_generator_endpoint_chain_and_deprecation() {
+        let guard = stateless_test_utils::env::env_lock();
+
+        // Typed flag: generator prepended, not deprecated.
+        let typed = parse_args(&["--witness-generator-endpoint", "http://gen"]);
+        assert_eq!(witness_endpoint_chain(&typed), (vec!["http://gen", "http://w"], false));
+
+        // Typed flag with multiple fallbacks keeps their order after the generator.
+        let multi = parse_args(&[
+            "--witness-generator-endpoint",
+            "http://gen",
+            "--witness-endpoint",
+            "http://w2",
+        ]);
+        assert_eq!(
+            witness_endpoint_chain(&multi),
+            (vec!["http://gen", "http://w", "http://w2"], false)
+        );
+
+        // Deprecated positional form: two-plus endpoints, no typed flag.
+        let legacy = parse_args(&["--witness-endpoint", "http://w2"]);
+        assert_eq!(witness_endpoint_chain(&legacy), (vec!["http://w", "http://w2"], true));
+
+        // Single endpoint without the flag: no generator slot, nothing deprecated.
+        assert_eq!(witness_endpoint_chain(&parse_args(&[])), (vec!["http://w"], false));
+
+        // Generator-only: --witness-endpoint becomes optional, chain is the lone generator.
+        let gen_only = Args::try_parse_from([
+            "debug-trace-server",
+            "--rpc-endpoint",
+            "http://r",
+            "--witness-generator-endpoint",
+            "http://gen",
+        ])
+        .unwrap();
+        assert_eq!(witness_endpoint_chain(&gen_only), (vec!["http://gen"], false));
+        // Neither witness flag: still rejected.
+        assert!(
+            Args::try_parse_from(["debug-trace-server", "--rpc-endpoint", "http://r"]).is_err()
+        );
+
+        // The generator duplicated in the fallback list is a rejected misconfiguration —
+        // it would put the generator back into the historical route's rotation.
+        let dup = parse_args(&["--witness-generator-endpoint", "http://w"]);
+        assert!(validate_args(&dup).is_err());
+        assert!(validate_args(&typed).is_ok());
+
+        // Env var parity with the CLI flag.
+        let from_env = stateless_test_utils::env::with_env_var(
+            &guard,
+            "DEBUG_TRACE_SERVER_WITNESS_GENERATOR_ENDPOINT",
+            "http://gen-env",
+            || parse_args(&[]),
+        );
+        assert_eq!(from_env.witness_generator_endpoint.as_deref(), Some("http://gen-env"));
     }
 
     /// `--tip-buffer` must stay below `--blocks-to-keep` when chain sync is enabled: the

--- a/bin/debug-trace-server/src/main.rs
+++ b/bin/debug-trace-server/src/main.rs
@@ -363,26 +363,19 @@ async fn main() -> Result<()> {
     let rpc_client =
         Arc::new(RpcClient::new_with_config(&data_apis, &witness_apis, rpc_config, None)?);
 
-    // Historical witness routing: blocks at least `--witness-local-window` below the local
-    // tip skip the first witness endpoint (the internal generator, which only retains about
-    // that window and is a guaranteed miss for anything older). Needs a fallback endpoint to
-    // route to, and a local DB whose tip anchors block age.
-    let route_historical = witness_apis.len() >= 2 && args.data_dir.is_some();
-    if route_historical {
-        info!(
+    match (witness_apis.len() >= 2, args.data_dir.is_some()) {
+        (true, true) => info!(
             witness_local_window = args.witness_local_window,
             skipped_endpoint = witness_apis[0],
             "Historical witnesses (at least the local window below the tip) skip the internal \
              generator endpoint"
-        );
-    } else if witness_apis.len() >= 2 {
-        warn!(
+        ),
+        (true, false) => warn!(
             "Multiple witness endpoints but no --data-dir: historical witness routing is \
              inactive (block age is anchored to the local DB tip); all witness fetches use the \
              full endpoint chain"
-        );
-    } else {
-        debug!("Single witness endpoint configured; no historical witness routing");
+        ),
+        (false, _) => debug!("Single witness endpoint configured; no historical witness routing"),
     }
 
     let validator_db = init_validator_db(&args, &rpc_client).await?;
@@ -405,14 +398,13 @@ async fn main() -> Result<()> {
         witness_timeout: std::time::Duration::from_secs(args.witness_timeout),
         old_block_witness_timeout: std::time::Duration::from_secs(args.witness_old_block_timeout),
         local_window: args.witness_local_window,
-        route_historical,
     };
     let data_provider = Arc::new(DataProvider::new(
         rpc_client.clone(),
         block_store.clone(),
         contract_cache,
         witness_cfg,
-        args.block_fetch_timeout,
+        std::time::Duration::from_secs(args.block_fetch_timeout),
     ));
 
     let chain_spec = load_chain_spec(&args)?;
@@ -761,28 +753,38 @@ mod tests {
     /// generator's `BACKUP`, the old-block budget defaults to the full witness budget) and the
     /// CLI + env parsing of all three knobs — a typo in an env attribute string would
     /// otherwise ship silently to env-only container deployments.
+    /// Parses `Args` from the minimal required flags plus `extra`. Callers must hold
+    /// `stateless_test_utils::env::env_lock()` — parsing reads `DEBUG_TRACE_SERVER_*` env
+    /// vars, so it must be serialized with the tests that mutate them.
+    fn parse_args(extra: &[&str]) -> Args {
+        let base =
+            ["debug-trace-server", "--rpc-endpoint", "http://r", "--witness-endpoint", "http://w"];
+        Args::try_parse_from(base.iter().chain(extra)).unwrap()
+    }
+
     #[test]
     fn tiered_routing_flag_defaults() {
         let guard = stateless_test_utils::env::env_lock();
-        let base =
-            ["debug-trace-server", "--rpc-endpoint", "http://r", "--witness-endpoint", "http://w"];
-        let parse = |extra: &[&str]| Args::try_parse_from(base.iter().chain(extra)).unwrap();
 
-        let defaults = parse(&[]);
+        let defaults = parse_args(&[]);
         assert_eq!(defaults.witness_local_window, data_provider::DEFAULT_WITNESS_LOCAL_WINDOW);
         assert_eq!(
             defaults.witness_old_block_timeout,
             data_provider::DEFAULT_OLD_BLOCK_WITNESS_TIMEOUT_SECS
         );
-        assert_eq!(data_provider::DEFAULT_OLD_BLOCK_WITNESS_TIMEOUT_SECS, 8);
+        assert_eq!(
+            data_provider::DEFAULT_OLD_BLOCK_WITNESS_TIMEOUT_SECS,
+            data_provider::DEFAULT_WITNESS_TIMEOUT_SECS,
+            "old blocks default to the full witness budget",
+        );
         assert_eq!(defaults.tip_buffer, 2);
 
-        assert_eq!(parse(&["--tip-buffer", "0"]).tip_buffer, 0);
-        assert_eq!(parse(&["--witness-local-window", "128"]).witness_local_window, 128);
-        assert_eq!(parse(&["--witness-old-block-timeout", "3"]).witness_old_block_timeout, 3);
+        assert_eq!(parse_args(&["--tip-buffer", "0"]).tip_buffer, 0);
+        assert_eq!(parse_args(&["--witness-local-window", "128"]).witness_local_window, 128);
+        assert_eq!(parse_args(&["--witness-old-block-timeout", "3"]).witness_old_block_timeout, 3);
 
         let env = |name, value: &str| {
-            stateless_test_utils::env::with_env_var(&guard, name, value, || parse(&[]))
+            stateless_test_utils::env::with_env_var(&guard, name, value, || parse_args(&[]))
         };
         assert_eq!(env("DEBUG_TRACE_SERVER_TIP_BUFFER", "5").tip_buffer, 5);
         assert_eq!(env("DEBUG_TRACE_SERVER_WITNESS_LOCAL_WINDOW", "256").witness_local_window, 256);
@@ -797,20 +799,15 @@ mod tests {
     /// transient restart. Inert in stateless mode, where neither flag is used.
     #[test]
     fn tip_buffer_must_stay_below_blocks_to_keep() {
-        // Args parsing reads `DEBUG_TRACE_SERVER_*` env vars, so it must be serialized with
-        // the tests that mutate them.
         let _guard = stateless_test_utils::env::env_lock();
-        let base =
-            ["debug-trace-server", "--rpc-endpoint", "http://r", "--witness-endpoint", "http://w"];
-        let parse = |extra: &[&str]| Args::try_parse_from(base.iter().chain(extra)).unwrap();
 
         // Stateless mode (no data dir): both flags are inert, any combination is accepted.
-        assert!(validate_args(&parse(&["--tip-buffer", "2000"])).is_ok());
+        assert!(validate_args(&parse_args(&["--tip-buffer", "2000"])).is_ok());
 
         let with_db = |extra: &[&str]| {
             let mut v = vec!["--data-dir", "/tmp/x"];
             v.extend_from_slice(extra);
-            parse(&v)
+            parse_args(&v)
         };
         assert!(validate_args(&with_db(&[])).is_ok());
         assert!(validate_args(&with_db(&["--tip-buffer", "999"])).is_ok());

--- a/bin/debug-trace-server/src/main.rs
+++ b/bin/debug-trace-server/src/main.rs
@@ -28,8 +28,6 @@
 //! ┌─────────────────────────────────────────────────────────────────┐
 //! │                      DataProvider                               │
 //! │  Multi-level lookup: Local DB → Remote RPC (with single-flight) │
-//! │  Witnesses: near-tip → full endpoint chain; historical skips    │
-//! │  the internal generator (guaranteed miss) → fallback endpoints  │
 //! └─────────────────────────────────────────────────────────────────┘
 //! ```
 //!
@@ -102,9 +100,8 @@ struct Args {
 
     /// One or more durable witness endpoint URLs for fetching witness data (tried in order).
     /// Accepts repeated flags (`--witness-endpoint a --witness-endpoint b`) or a comma-separated
-    /// list (`--witness-endpoint a,b`, also via the env var). Deprecated fallback: when
-    /// `--witness-generator-endpoint` is absent and two or more endpoints are listed here, the
-    /// first is treated as the internal generator (see that flag).
+    /// list (`--witness-endpoint a,b`, also via the env var). No endpoint here is ever special
+    /// by position; declare the internal generator via `--witness-generator-endpoint`.
     #[clap(
         long,
         env = "DEBUG_TRACE_SERVER_WITNESS_ENDPOINT",
@@ -118,8 +115,7 @@ struct Args {
     /// skipped for historical ones (it only retains about `--witness-local-window` blocks),
     /// while `--witness-endpoint` lists the durable fallbacks (optional when this flag is
     /// set — generator-only works like any single-endpoint config, without routing). When
-    /// absent, the first of two or more `--witness-endpoint` values fills this role
-    /// (deprecated positional form).
+    /// absent, historical routing is disabled and every witness endpoint is plain failover.
     #[clap(long, env = "DEBUG_TRACE_SERVER_WITNESS_GENERATOR_ENDPOINT")]
     witness_generator_endpoint: Option<String>,
 
@@ -307,28 +303,23 @@ fn old_block_witness_timeout_secs(args: &Args) -> u64 {
     args.witness_old_block_timeout.unwrap_or(args.witness_timeout).min(args.witness_timeout)
 }
 
-/// The combined witness endpoint chain — the internal generator (when configured) first, then
-/// the durable fallbacks — plus whether the generator slot comes from the deprecated
-/// positional form (no `--witness-generator-endpoint`, two or more `--witness-endpoint`).
-///
-/// The chain always has the generator at index 0 when one exists, so the fetch-side routing
-/// derivation (skip the first endpoint iff the chain has at least two) holds under both the
-/// typed flag and the deprecated form.
-fn witness_endpoint_chain(args: &Args) -> (Vec<&str>, bool) {
-    let mut chain: Vec<&str> = Vec::with_capacity(args.witness_endpoint.len() + 1);
-    chain.extend(args.witness_generator_endpoint.as_deref());
-    chain.extend(args.witness_endpoint.iter().map(String::as_str));
-    let deprecated_positional =
-        args.witness_generator_endpoint.is_none() && args.witness_endpoint.len() >= 2;
-    (chain, deprecated_positional)
+/// The combined witness endpoint chain: the declared internal generator
+/// (`--witness-generator-endpoint`) first when configured, then the durable fallbacks in
+/// their configured order. Without the flag no endpoint is special — the chain is plain
+/// failover.
+fn witness_endpoint_chain(args: &Args) -> Vec<&str> {
+    args.witness_generator_endpoint
+        .as_deref()
+        .into_iter()
+        .chain(args.witness_endpoint.iter().map(String::as_str))
+        .collect()
 }
 
 /// Validates cross-flag invariants that clap cannot express per-field.
 fn validate_args(args: &Args) -> Result<()> {
-    // Only meaningful with chain sync: the fetcher holds the local tip `tip_buffer` blocks
-    // behind the head, and `blocks_to_keep` doubles as the stale-reset threshold. A buffer at
-    // or past the threshold makes the built-in lag itself look stale, so every transient
-    // restart would reset the anchor and leave gaps in stored history.
+    // Early, flag-named mirror of `PipelineConfig::validate` (see its doc for the rationale);
+    // only meaningful with chain sync, where `blocks_to_keep` becomes the stale-reset
+    // threshold.
     if args.data_dir.is_some() && args.tip_buffer >= args.blocks_to_keep {
         eyre::bail!(
             "--tip-buffer ({}) must be smaller than --blocks-to-keep ({})",
@@ -364,11 +355,19 @@ async fn main() -> Result<()> {
     let response_cache_disabled = args.response_cache_estimated_items == 0;
     // The combined witness chain (generator first when configured) — the list actually fed to
     // the RPC client, not just the fallback flag values.
-    let (witness_apis, deprecated_positional_generator) = witness_endpoint_chain(&args);
+    let witness_apis = witness_endpoint_chain(&args);
+    let witness_cfg = WitnessFetchConfig {
+        witness_timeout: std::time::Duration::from_secs(args.witness_timeout),
+        old_block_witness_timeout: std::time::Duration::from_secs(old_block_witness_timeout_secs(
+            &args,
+        )),
+        local_window: args.witness_local_window,
+        generator_first: args.witness_generator_endpoint.is_some(),
+    };
     debug!(
         rpc_endpoints = ?args.rpc_endpoint,
         witness_endpoints = ?witness_apis,
-        witness_generator_configured = args.witness_generator_endpoint.is_some(),
+        witness_generator_configured = witness_cfg.generator_first,
         witness_timeout_secs = args.witness_timeout,
         witness_old_block_timeout_secs = old_block_witness_timeout_secs(&args),
         witness_local_window = args.witness_local_window,
@@ -410,30 +409,27 @@ async fn main() -> Result<()> {
     let rpc_client =
         Arc::new(RpcClient::new_with_config(&data_apis, &witness_apis, rpc_config, None)?);
 
-    match (witness_apis.len() >= 2, args.data_dir.is_some()) {
-        (true, true) => {
-            info!(
-                witness_local_window = args.witness_local_window,
-                // The credential-stripped label, not the raw URL — configured endpoint URLs
-                // may carry userinfo or token queries and this log line is info-level.
-                skipped_endpoint = rpc_client.witness_provider_label(0).unwrap_or("<none>"),
-                "Historical witnesses (at least the local window below the tip) skip the \
-                 internal generator endpoint"
-            );
-            if deprecated_positional_generator {
-                warn!(
-                    "The first --witness-endpoint is being treated as the internal generator; \
-                     this positional form is deprecated — declare the generator explicitly via \
-                     --witness-generator-endpoint"
-                );
-            }
-        }
+    // The same predicate `fetch_witness` evaluates per request: a declared generator plus at
+    // least one fallback in the combined chain.
+    let routing_configured = witness_cfg.generator_first && witness_apis.len() >= 2;
+    match (routing_configured, args.data_dir.is_some()) {
+        (true, true) => info!(
+            witness_local_window = args.witness_local_window,
+            // The credential-stripped label, not the raw URL — configured endpoint URLs
+            // may carry userinfo or token queries and this log line is info-level.
+            skipped_endpoint = rpc_client.witness_provider_label(0).unwrap_or("<none>"),
+            "Historical witnesses (at least the local window below the tip) skip the \
+             internal generator endpoint"
+        ),
         (true, false) => warn!(
             "Witness generator plus fallback endpoints but no --data-dir: historical witness \
              routing is inactive (block age is anchored to the local DB tip); all witness \
              fetches use the full endpoint chain"
         ),
-        (false, _) => debug!("Single witness endpoint configured; no historical witness routing"),
+        (false, _) => debug!(
+            "No --witness-generator-endpoint (or no fallback endpoints); historical witness \
+             routing disabled — witness endpoints are plain failover"
+        ),
     }
 
     let validator_db = init_validator_db(&args, &rpc_client).await?;
@@ -452,13 +448,6 @@ async fn main() -> Result<()> {
     };
     let contract_cache = Arc::new(ContractCache::new(contract_store));
 
-    let witness_cfg = WitnessFetchConfig {
-        witness_timeout: std::time::Duration::from_secs(args.witness_timeout),
-        old_block_witness_timeout: std::time::Duration::from_secs(old_block_witness_timeout_secs(
-            &args,
-        )),
-        local_window: args.witness_local_window,
-    };
     let data_provider = Arc::new(DataProvider::new(
         rpc_client.clone(),
         block_store.clone(),
@@ -809,10 +798,6 @@ mod tests {
         );
     }
 
-    /// Pins the tiered-witness-routing knob defaults (`--witness-local-window` must track the
-    /// generator's `BACKUP`, the old-block budget defaults to the full witness budget) and the
-    /// CLI + env parsing of all three knobs — a typo in an env attribute string would
-    /// otherwise ship silently to env-only container deployments.
     /// Parses `Args` from the minimal required flags plus `extra`. Callers must hold
     /// `stateless_test_utils::env::env_lock()` — parsing reads `DEBUG_TRACE_SERVER_*` env
     /// vars, so it must be serialized with the tests that mutate them.
@@ -822,6 +807,10 @@ mod tests {
         Args::try_parse_from(base.iter().chain(extra)).unwrap()
     }
 
+    /// Pins the tiered-witness-routing knob defaults (`--witness-local-window` must track the
+    /// generator's `BACKUP`, the old-block budget defaults to the full witness budget) and the
+    /// CLI + env parsing of all three knobs — a typo in an env attribute string would
+    /// otherwise ship silently to env-only container deployments.
     #[test]
     fn tiered_routing_flag_defaults() {
         let guard = stateless_test_utils::env::env_lock();
@@ -866,36 +855,30 @@ mod tests {
         );
     }
 
-    /// The witness chain always puts the generator at index 0 — from the typed flag when
-    /// present, else (deprecated) the first of two or more `--witness-endpoint` values — so
-    /// the fetch-side skip derivation holds under both forms; a single durable endpoint has
-    /// no generator slot at all.
+    /// The witness chain puts the declared generator at index 0; without the flag no endpoint
+    /// is special — even a multi-endpoint list is plain failover, keeping its pre-routing
+    /// behavior.
     #[test]
-    fn witness_generator_endpoint_chain_and_deprecation() {
+    fn witness_generator_endpoint_chain() {
         let guard = stateless_test_utils::env::env_lock();
 
-        // Typed flag: generator prepended, not deprecated.
+        // Typed flag: generator prepended ahead of the fallbacks.
         let typed = parse_args(&["--witness-generator-endpoint", "http://gen"]);
-        assert_eq!(witness_endpoint_chain(&typed), (vec!["http://gen", "http://w"], false));
+        assert_eq!(witness_endpoint_chain(&typed), vec!["http://gen", "http://w"]);
 
-        // Typed flag with multiple fallbacks keeps their order after the generator.
+        // Multiple fallbacks keep their order after the generator.
         let multi = parse_args(&[
             "--witness-generator-endpoint",
             "http://gen",
             "--witness-endpoint",
             "http://w2",
         ]);
-        assert_eq!(
-            witness_endpoint_chain(&multi),
-            (vec!["http://gen", "http://w", "http://w2"], false)
-        );
+        assert_eq!(witness_endpoint_chain(&multi), vec!["http://gen", "http://w", "http://w2"]);
 
-        // Deprecated positional form: two-plus endpoints, no typed flag.
-        let legacy = parse_args(&["--witness-endpoint", "http://w2"]);
-        assert_eq!(witness_endpoint_chain(&legacy), (vec!["http://w", "http://w2"], true));
-
-        // Single endpoint without the flag: no generator slot, nothing deprecated.
-        assert_eq!(witness_endpoint_chain(&parse_args(&[])), (vec!["http://w"], false));
+        // No flag: plain failover chains, regardless of endpoint count.
+        assert_eq!(witness_endpoint_chain(&parse_args(&[])), vec!["http://w"]);
+        let failover_pair = parse_args(&["--witness-endpoint", "http://w2"]);
+        assert_eq!(witness_endpoint_chain(&failover_pair), vec!["http://w", "http://w2"]);
 
         // Generator-only: --witness-endpoint becomes optional, chain is the lone generator.
         let gen_only = Args::try_parse_from([
@@ -906,7 +889,7 @@ mod tests {
             "http://gen",
         ])
         .unwrap();
-        assert_eq!(witness_endpoint_chain(&gen_only), (vec!["http://gen"], false));
+        assert_eq!(witness_endpoint_chain(&gen_only), vec!["http://gen"]);
         // Neither witness flag: still rejected.
         assert!(
             Args::try_parse_from(["debug-trace-server", "--rpc-endpoint", "http://r"]).is_err()

--- a/bin/debug-trace-server/src/main.rs
+++ b/bin/debug-trace-server/src/main.rs
@@ -3,6 +3,8 @@
 //! # Overview
 //! A standalone RPC server for `debug_*` and `trace_*` methods using stateless execution.
 //! Data can be fetched from upstream RPC endpoints or from a local database with chain sync.
+//! Witness fetches route by block age: historical blocks skip the internal generator endpoint
+//! (which only retains a small recent window) and go straight to the fallback endpoints.
 //!
 //! # Architecture
 //! ```text
@@ -25,6 +27,8 @@
 //! ┌─────────────────────────────────────────────────────────────────┐
 //! │                      DataProvider                               │
 //! │  Multi-level lookup: Local DB → Remote RPC (with single-flight) │
+//! │  Witnesses: near-tip → full endpoint chain; historical skips    │
+//! │  the internal generator (guaranteed miss) → fallback endpoints  │
 //! └─────────────────────────────────────────────────────────────────┘
 //! ```
 //!
@@ -37,7 +41,7 @@
 //! - `debug_getCacheStatus` - Query current response cache status
 //!
 //! # Operating Modes
-//! - **Stateless mode**: Without `data_dir`, all data is fetched from remote RPC
+//! - **Stateless mode**: Without `data_dir`, all data is fetched from remote RPC endpoints
 //! - **Local cache mode**: With `data_dir`, enables chain sync to pre-fetch blocks into local DB
 
 use std::{path::PathBuf, sync::Arc};
@@ -68,7 +72,7 @@ mod server_db;
 mod timing;
 mod tracing_executor;
 
-use data_provider::{DataProvider, NoopContractStore};
+use data_provider::{DataProvider, NoopContractStore, WitnessFetchConfig};
 use response_cache::{DEFAULT_RESPONSE_CACHE_ESTIMATED_ITEMS, ResponseCache, ResponseCacheConfig};
 use rpc_service::RpcContext;
 use server_db::{BlockStore, ServerDB};
@@ -97,7 +101,9 @@ struct Args {
 
     /// One or more upstream witness endpoint URLs for fetching witness data (tried in order).
     /// Accepts repeated flags (`--witness-endpoint a --witness-endpoint b`) or a comma-separated
-    /// list (`--witness-endpoint a,b`, also via the env var).
+    /// list (`--witness-endpoint a,b`, also via the env var). The first endpoint is positionally
+    /// special: it is treated as the internal witness generator and is skipped for historical
+    /// blocks (see `--witness-local-window`).
     #[clap(
         long,
         env = "DEBUG_TRACE_SERVER_WITNESS_ENDPOINT",
@@ -198,9 +204,39 @@ struct Args {
     data_max_concurrent_requests: Option<usize>,
 
     /// Maximum concurrent in-flight witness fetches, independent of the data cap.
-    /// Omit for unlimited.
+    /// Omit for unlimited. One global cap: recent and historical witness routes share it.
     #[clap(long, env = "DEBUG_TRACE_SERVER_WITNESS_MAX_CONCURRENT_REQUESTS")]
     witness_max_concurrent_requests: Option<usize>,
+
+    /// Blocks within this many blocks of the local tip fetch witnesses through the full
+    /// witness endpoint chain (internal generator first); older blocks skip the first witness
+    /// endpoint — the generator only retains about this window (its `BACKUP` env, deployed at
+    /// 4096), so probing it for historical blocks is a guaranteed miss. Requires at least two
+    /// witness endpoints and a local DB (`--data-dir`), whose tip anchors block age; otherwise
+    /// all blocks use the full chain. Should match the generator's `BACKUP`.
+    #[clap(
+        long,
+        env = "DEBUG_TRACE_SERVER_WITNESS_LOCAL_WINDOW",
+        default_value_t = data_provider::DEFAULT_WITNESS_LOCAL_WINDOW
+    )]
+    witness_local_window: u64,
+
+    /// Witness-stage budget in seconds for blocks at or below the local tip. Defaults to the
+    /// full witness budget; lower it to fail fast on blocks whose witness is likely pruned
+    /// everywhere. Clamped to `--witness-timeout`.
+    #[clap(
+        long,
+        env = "DEBUG_TRACE_SERVER_WITNESS_OLD_BLOCK_TIMEOUT",
+        default_value_t = data_provider::DEFAULT_OLD_BLOCK_WITNESS_TIMEOUT_SECS
+    )]
+    witness_old_block_timeout: u64,
+
+    /// Chain-sync pipeline tip buffer: stay this many blocks behind the upstream head so the
+    /// fetcher does not race the witness generator — a fetch issued the moment a block appears
+    /// typically arrives before its witness is written and burns a failed round plus a backoff
+    /// sleep. 0 = fetch right at the head.
+    #[clap(long, env = "DEBUG_TRACE_SERVER_TIP_BUFFER", default_value_t = 2)]
+    tip_buffer: u64,
 
     /// Per-attempt RPC timeout (milliseconds). Must be ≥ 100ms.
     #[clap(
@@ -255,9 +291,26 @@ fn parse_size(s: &str) -> Result<u64, String> {
     value.checked_mul(multiplier).ok_or_else(|| format!("size overflow: '{}'", s))
 }
 
+/// Validates cross-flag invariants that clap cannot express per-field.
+fn validate_args(args: &Args) -> Result<()> {
+    // Only meaningful with chain sync: the fetcher holds the local tip `tip_buffer` blocks
+    // behind the head, and `blocks_to_keep` doubles as the stale-reset threshold. A buffer at
+    // or past the threshold makes the built-in lag itself look stale, so every transient
+    // restart would reset the anchor and leave gaps in stored history.
+    if args.data_dir.is_some() && args.tip_buffer >= args.blocks_to_keep {
+        eyre::bail!(
+            "--tip-buffer ({}) must be smaller than --blocks-to-keep ({})",
+            args.tip_buffer,
+            args.blocks_to_keep
+        );
+    }
+    Ok(())
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     let args = Args::parse();
+    validate_args(&args)?;
     let _log_guard = args.log.init_tracing()?;
 
     info!(
@@ -269,6 +322,9 @@ async fn main() -> Result<()> {
         rpc_endpoints = ?args.rpc_endpoint,
         witness_endpoints = ?args.witness_endpoint,
         witness_timeout_secs = args.witness_timeout,
+        witness_old_block_timeout_secs = args.witness_old_block_timeout,
+        witness_local_window = args.witness_local_window,
+        tip_buffer = args.tip_buffer,
         response_cache_disabled,
         response_cache_max_size = args.response_cache_max_size,
         response_cache_estimated_items = args.response_cache_estimated_items,
@@ -306,6 +362,29 @@ async fn main() -> Result<()> {
     .with_metrics(Arc::new(metrics::TraceRpcMetrics));
     let rpc_client =
         Arc::new(RpcClient::new_with_config(&data_apis, &witness_apis, rpc_config, None)?);
+
+    // Historical witness routing: blocks at least `--witness-local-window` below the local
+    // tip skip the first witness endpoint (the internal generator, which only retains about
+    // that window and is a guaranteed miss for anything older). Needs a fallback endpoint to
+    // route to, and a local DB whose tip anchors block age.
+    let route_historical = witness_apis.len() >= 2 && args.data_dir.is_some();
+    if route_historical {
+        info!(
+            witness_local_window = args.witness_local_window,
+            skipped_endpoint = witness_apis[0],
+            "Historical witnesses (at least the local window below the tip) skip the internal \
+             generator endpoint"
+        );
+    } else if witness_apis.len() >= 2 {
+        warn!(
+            "Multiple witness endpoints but no --data-dir: historical witness routing is \
+             inactive (block age is anchored to the local DB tip); all witness fetches use the \
+             full endpoint chain"
+        );
+    } else {
+        debug!("Single witness endpoint configured; no historical witness routing");
+    }
+
     let validator_db = init_validator_db(&args, &rpc_client).await?;
 
     // Keep concrete ServerDB for pipeline (needs Sized), and dyn BlockStore for data_provider
@@ -322,11 +401,17 @@ async fn main() -> Result<()> {
     };
     let contract_cache = Arc::new(ContractCache::new(contract_store));
 
+    let witness_cfg = WitnessFetchConfig {
+        witness_timeout: std::time::Duration::from_secs(args.witness_timeout),
+        old_block_witness_timeout: std::time::Duration::from_secs(args.witness_old_block_timeout),
+        local_window: args.witness_local_window,
+        route_historical,
+    };
     let data_provider = Arc::new(DataProvider::new(
         rpc_client.clone(),
         block_store.clone(),
         contract_cache,
-        args.witness_timeout,
+        witness_cfg,
         args.block_fetch_timeout,
     ));
 
@@ -358,6 +443,7 @@ async fn main() -> Result<()> {
         // the crate boundary; mutate a default instance instead.
         let mut pipeline_cfg = PipelineConfig::default();
         pipeline_cfg.concurrent_workers = 1;
+        pipeline_cfg.tip_buffer = args.tip_buffer;
         pipeline_cfg.stale_reset_threshold = Some(args.blocks_to_keep);
         let config = Arc::new(pipeline_cfg);
         let processor = Arc::new(TraceProcessor);
@@ -669,6 +755,67 @@ mod tests {
             &["debug-trace-server", "--witness-endpoint", "http://w"],
             |a| a.rpc_endpoint,
         );
+    }
+
+    /// Pins the tiered-witness-routing knob defaults (`--witness-local-window` must track the
+    /// generator's `BACKUP`, the old-block budget defaults to the full witness budget) and the
+    /// CLI + env parsing of all three knobs — a typo in an env attribute string would
+    /// otherwise ship silently to env-only container deployments.
+    #[test]
+    fn tiered_routing_flag_defaults() {
+        let guard = stateless_test_utils::env::env_lock();
+        let base =
+            ["debug-trace-server", "--rpc-endpoint", "http://r", "--witness-endpoint", "http://w"];
+        let parse = |extra: &[&str]| Args::try_parse_from(base.iter().chain(extra)).unwrap();
+
+        let defaults = parse(&[]);
+        assert_eq!(defaults.witness_local_window, data_provider::DEFAULT_WITNESS_LOCAL_WINDOW);
+        assert_eq!(
+            defaults.witness_old_block_timeout,
+            data_provider::DEFAULT_OLD_BLOCK_WITNESS_TIMEOUT_SECS
+        );
+        assert_eq!(data_provider::DEFAULT_OLD_BLOCK_WITNESS_TIMEOUT_SECS, 8);
+        assert_eq!(defaults.tip_buffer, 2);
+
+        assert_eq!(parse(&["--tip-buffer", "0"]).tip_buffer, 0);
+        assert_eq!(parse(&["--witness-local-window", "128"]).witness_local_window, 128);
+        assert_eq!(parse(&["--witness-old-block-timeout", "3"]).witness_old_block_timeout, 3);
+
+        let env = |name, value: &str| {
+            stateless_test_utils::env::with_env_var(&guard, name, value, || parse(&[]))
+        };
+        assert_eq!(env("DEBUG_TRACE_SERVER_TIP_BUFFER", "5").tip_buffer, 5);
+        assert_eq!(env("DEBUG_TRACE_SERVER_WITNESS_LOCAL_WINDOW", "256").witness_local_window, 256);
+        assert_eq!(
+            env("DEBUG_TRACE_SERVER_WITNESS_OLD_BLOCK_TIMEOUT", "4").witness_old_block_timeout,
+            4
+        );
+    }
+
+    /// `--tip-buffer` must stay below `--blocks-to-keep` when chain sync is enabled: the
+    /// pipeline's built-in lag would otherwise satisfy the stale-reset test on every
+    /// transient restart. Inert in stateless mode, where neither flag is used.
+    #[test]
+    fn tip_buffer_must_stay_below_blocks_to_keep() {
+        // Args parsing reads `DEBUG_TRACE_SERVER_*` env vars, so it must be serialized with
+        // the tests that mutate them.
+        let _guard = stateless_test_utils::env::env_lock();
+        let base =
+            ["debug-trace-server", "--rpc-endpoint", "http://r", "--witness-endpoint", "http://w"];
+        let parse = |extra: &[&str]| Args::try_parse_from(base.iter().chain(extra)).unwrap();
+
+        // Stateless mode (no data dir): both flags are inert, any combination is accepted.
+        assert!(validate_args(&parse(&["--tip-buffer", "2000"])).is_ok());
+
+        let with_db = |extra: &[&str]| {
+            let mut v = vec!["--data-dir", "/tmp/x"];
+            v.extend_from_slice(extra);
+            parse(&v)
+        };
+        assert!(validate_args(&with_db(&[])).is_ok());
+        assert!(validate_args(&with_db(&["--tip-buffer", "999"])).is_ok());
+        assert!(validate_args(&with_db(&["--tip-buffer", "1000"])).is_err());
+        assert!(validate_args(&with_db(&["--tip-buffer", "5", "--blocks-to-keep", "5"])).is_err());
     }
 
     /// Verifies a concurrency cap flag parses via CLI and env var, and defaults to `None`.

--- a/bin/debug-trace-server/src/main.rs
+++ b/bin/debug-trace-server/src/main.rs
@@ -3,8 +3,9 @@
 //! # Overview
 //! A standalone RPC server for `debug_*` and `trace_*` methods using stateless execution.
 //! Data can be fetched from upstream RPC endpoints or from a local database with chain sync.
-//! Witness fetches route by block age: historical blocks skip the internal generator endpoint
-//! (which only retains a small recent window) and go straight to the fallback endpoints.
+//! Request-serving witness fetches route by block age: historical blocks skip the internal
+//! generator endpoint (which only retains a small recent window) and go straight to the
+//! fallback endpoints. Chain-sync prefetch always uses the full chain.
 //!
 //! # Architecture
 //! ```text
@@ -213,8 +214,9 @@ struct Args {
     /// skip the first witness endpoint — the generator only retains about this window (its
     /// `BACKUP` env, deployed at 4096), so probing it for historical blocks is a guaranteed
     /// miss. Requires at least two witness endpoints and a local DB (`--data-dir`), whose tip
-    /// anchors block age; otherwise all blocks use the full chain. Should match the
-    /// generator's `BACKUP`.
+    /// anchors block age; otherwise all blocks use the full chain. Applies to request
+    /// serving; chain-sync prefetch always uses the full chain. Should match the generator's
+    /// `BACKUP`.
     #[clap(
         long,
         env = "DEBUG_TRACE_SERVER_WITNESS_LOCAL_WINDOW",

--- a/bin/debug-trace-server/src/metrics.rs
+++ b/bin/debug-trace-server/src/metrics.rs
@@ -206,7 +206,10 @@ impl CacheMetrics {
     }
 }
 
-/// Tracks which source provided block data (cache/db/witness_generator).
+/// Tracks which source provided block data. Sources: `cache`, `db`, and the two RPC witness
+/// routes — `witness_generator` (full endpoint chain, generator first) and
+/// `witness_historical` (skip-generator chain for blocks beyond the local window). The RPC
+/// path as a whole is the sum of the two witness labels.
 #[derive(Clone, Metrics)]
 #[metrics(scope = "debug_trace")]
 pub struct DataSourceMetrics {
@@ -420,6 +423,7 @@ fn pre_register_all_metrics() {
     let _ = DataSourceMetrics::new_for_source("cache");
     let _ = DataSourceMetrics::new_for_source("db");
     let _ = DataSourceMetrics::new_for_source("witness_generator");
+    let _ = DataSourceMetrics::new_for_source("witness_historical");
 
     // Data Fetch Layer: single-flight
     let _ = SingleFlightMetrics::new_for_type("new");
@@ -434,6 +438,7 @@ fn pre_register_all_metrics() {
 
     // Witness Layer
     let _ = WitnessSourceMetrics::new_for_source("witness_generator");
+    let _ = WitnessSourceMetrics::new_for_source("witness_historical");
 
     // Execution Layer (per method)
     let _ = EvmExecutionMetrics::new_for_method(METHOD_DEBUG_TRACE_BLOCK_BY_NUMBER);

--- a/bin/debug-trace-server/src/metrics.rs
+++ b/bin/debug-trace-server/src/metrics.rs
@@ -208,8 +208,8 @@ impl CacheMetrics {
 
 /// Tracks which source provided block data. Sources: `cache`, `db`, and the two RPC witness
 /// routes — `witness_generator` (full endpoint chain, generator first) and
-/// `witness_historical` (skip-generator chain for blocks beyond the local window). The RPC
-/// path as a whole is the sum of the two witness labels.
+/// `witness_historical` (skip-generator chain for blocks at least the local window below the
+/// tip). The RPC path as a whole is the sum of the two witness labels.
 #[derive(Clone, Metrics)]
 #[metrics(scope = "debug_trace")]
 pub struct DataSourceMetrics {

--- a/crates/stateless-common/src/rpc_client.rs
+++ b/crates/stateless-common/src/rpc_client.rs
@@ -391,7 +391,6 @@ impl RpcClient {
         round_robin_with_backoff(
             &self.data_providers,
             &self.data_provider_labels,
-            0,
             &self.data_concurrency,
             &self.config.rpc_retry,
             self.config.per_attempt_timeout,
@@ -634,9 +633,9 @@ impl RpcClient {
 
     /// Like [`Self::get_witness_light_with_deadline`], but skips the first `skip` witness
     /// providers, for callers that know those endpoints cannot serve the request (e.g. an
-    /// internal generator that has pruned the block). Logged provider indices stay relative
-    /// to the full configured witness endpoint list, and the shared witness concurrency cap
-    /// still applies.
+    /// internal generator that has pruned the block). Logged endpoint labels keep their
+    /// position in the full configured witness endpoint list, and the shared witness
+    /// concurrency cap still applies.
     ///
     /// # Panics
     /// Panics if `skip >= witness_provider_count()` — at least one provider must remain.
@@ -663,8 +662,9 @@ impl RpcClient {
     /// are touched only while it is failing), each attempt one RPC round trip followed by the
     /// caller-chosen `decode` (see [`fetch_witness_with`]).
     ///
-    /// `skip` drops the first `skip` witness providers from the rotation while keeping logged
-    /// provider indices and endpoint labels aligned with the full configured list.
+    /// `skip` drops the first `skip` witness providers from the rotation; the logged endpoint
+    /// labels stay aligned with the full configured list because each label bakes in its
+    /// original index (see [`endpoint_label`]).
     // A `warn`-level span (not the usual `info`) so it stays enabled at the default `warn` log
     // filter: the generic retry loop's per-attempt failure logs then inherit `block_number`,
     // which they cannot see otherwise, so an endpoint stall/error is traceable to its block.
@@ -686,7 +686,6 @@ impl RpcClient {
         round_robin_with_backoff(
             &self.witness_providers[skip..],
             &self.witness_provider_labels[skip..],
-            skip,
             &self.witness_concurrency,
             &self.config.rpc_retry,
             self.config.per_attempt_timeout,
@@ -916,20 +915,18 @@ fn endpoint_label(url: &str, idx: usize) -> Arc<str> {
 /// `get_witness()` (pins `rr_start=0` for primary-failover).
 ///
 /// `providers`/`provider_labels` may be parallel slices of the caller's full configured list;
-/// `provider_idx_base` is the offset of those slices within the full list, so logged provider
-/// indices always match the operator's endpoint ordering regardless of slicing (the labels
-/// already carry their original global index, baked in at construction).
-// 11-argument retry primitive. Each field plays a distinct role (providers, their metric/log
-// labels, index base, concurrency, backoff policy, per-attempt timeout, starting provider,
-// method label, metrics sink, deadline, per-attempt closure) and bundling them into a struct
-// would be ceremony without encapsulation — there are exactly two call sites in this crate.
-// Prefer clarity at the definition over fewer commas at the call. `provider_labels` is parallel
-// to `providers` by index.
+/// attempts are identified in logs and errors by their label alone, which bakes in the
+/// endpoint's index in the full list at construction, so slicing never misattributes an
+/// attempt.
+// 10-argument retry primitive. Each field plays a distinct role (providers, their metric/log
+// labels, concurrency, backoff policy, per-attempt timeout, starting provider, method label,
+// metrics sink, deadline, per-attempt closure) and bundling them into a struct would be ceremony
+// without encapsulation — there are exactly two call sites in this crate. Prefer clarity at the
+// definition over fewer commas at the call. `provider_labels` is parallel to `providers` by index.
 #[allow(clippy::too_many_arguments)]
 async fn round_robin_with_backoff<N, T>(
     providers: &[RootProvider<N>],
     provider_labels: &[Arc<str>],
-    provider_idx_base: usize,
     semaphore: &Semaphore,
     policy: &BackoffPolicy,
     per_attempt_timeout: Duration,
@@ -946,7 +943,7 @@ where
     debug_assert_eq!(
         providers.len(),
         provider_labels.len(),
-        "provider_labels must be parallel to providers (indexed by the same provider_idx)",
+        "provider_labels must be parallel to providers (indexed by the same slot)",
     );
 
     // Records the logical-call deadline give-up (once) and builds the typed error. Called from
@@ -990,9 +987,6 @@ where
                 return Err(record_deadline(call_start.elapsed()));
             }
             let slot = (rr_start + offset) % n;
-            // Index into the operator's full configured endpoint list (see
-            // `provider_idx_base`); `slot` indexes the possibly-sliced `providers`/labels.
-            let provider_idx = provider_idx_base + slot;
             let provider_label: &str = &provider_labels[slot];
             let permit = semaphore.acquire().await.expect("semaphore closed unexpectedly");
             // Per-attempt timing: record each provider call individually so histograms
@@ -1020,9 +1014,8 @@ where
                     Ok(Err(e)) => Err((e, RpcAttemptOutcome::Error)),
                     Err(_) => Err((
                         eyre!(
-                            "{} attempt against provider {} ({}) timed out after {:?} (per_attempt_timeout)",
+                            "{} attempt against provider {} timed out after {:?} (per_attempt_timeout)",
                             method.as_str(),
-                            provider_idx,
                             provider_label,
                             attempt_timeout,
                         ),
@@ -1071,7 +1064,6 @@ where
                 // and ops need to see it on round 0 instead of waiting for the round-3 escalation.
                 warn!(
                     method = method.as_str(),
-                    provider_idx,
                     provider = %provider_label,
                     round,
                     attempt_timeout_ms = attempt_timeout.as_millis() as u64,
@@ -1091,7 +1083,6 @@ where
                 log_at!(
                     warn_level,
                     method = method.as_str(),
-                    provider_idx,
                     provider = %provider_label,
                     round,
                     error = %err,
@@ -2234,32 +2225,35 @@ mod tests {
         //   WARNs lose their `block_number` field. Periodically rebuilding the interest cache and
         //   respawning the fetch creates a fresh span under the repaired cache, so the test
         //   self-heals instead of flaking.
-        let spawn_fetch = |client: RpcClient| {
+        // 60 spawns × 20 polls × 25 ms = a 30 s give-up ceiling with a ~500 ms respawn cadence;
+        // the happy path exits on the first poll after the first ~50 ms attempt timeout.
+        let spawn_fetch = || {
+            let client = client.clone();
             tokio::spawn(async move {
                 let _ = client.get_witness_light_with_deadline(4242, B256::ZERO, None).await;
             })
         };
-        let mut fetch = spawn_fetch(client.clone());
-        let give_up = Instant::now() + Duration::from_secs(30);
-        let mut respawn_at = Instant::now() + Duration::from_millis(500);
-        loop {
-            let logs = String::from_utf8(buf.lock().unwrap().clone()).unwrap();
-            if logs.contains("block_number") && logs.contains("4242") {
-                break;
-            }
-            assert!(
-                Instant::now() < give_up,
-                "witness failure log must carry the block_number span field, got:\n{logs}"
-            );
-            if Instant::now() >= respawn_at {
-                fetch.abort();
+        let mut logs = String::new();
+        let mut found = false;
+        for attempt in 0..60 {
+            if attempt > 0 {
                 tracing::callsite::rebuild_interest_cache();
                 buf.lock().unwrap().clear();
-                fetch = spawn_fetch(client.clone());
-                respawn_at = Instant::now() + Duration::from_millis(500);
             }
-            tokio::time::sleep(Duration::from_millis(25)).await;
+            let fetch = spawn_fetch();
+            for _ in 0..20 {
+                tokio::time::sleep(Duration::from_millis(25)).await;
+                logs = String::from_utf8(buf.lock().unwrap().clone()).unwrap();
+                if logs.contains("block_number") && logs.contains("4242") {
+                    found = true;
+                    break;
+                }
+            }
+            fetch.abort();
+            if found {
+                break;
+            }
         }
-        fetch.abort();
+        assert!(found, "witness failure log must carry the block_number span field, got:\n{logs}");
     }
 }

--- a/crates/stateless-common/src/rpc_client.rs
+++ b/crates/stateless-common/src/rpc_client.rs
@@ -2222,18 +2222,44 @@ mod tests {
             RpcClient::new_with_config(&[&stalled_url], &[&stalled_url], config, None).unwrap();
 
         // `deadline = None` so every per-attempt timeout emits the stall WARN (no deadline branch
-        // can steal it) — the assertion is independent of runner load. The outer timeout bounds
-        // the otherwise-unbounded retry so the test terminates.
-        let _ = tokio::time::timeout(
-            Duration::from_secs(1),
-            client.get_witness_light_with_deadline(4242, B256::ZERO, None),
-        )
-        .await;
-
-        let logs = String::from_utf8(buf.lock().unwrap().clone()).unwrap();
-        assert!(
-            logs.contains("block_number") && logs.contains("4242"),
-            "witness failure log must carry the block_number span field, got:\n{logs}"
-        );
+        // can steal it). The unbounded retry runs as a background task while the test polls the
+        // captured logs and finishes on the first stall WARN that carries the span context.
+        //
+        // Two hardenings, both observed failure modes rather than paranoia:
+        // - No fixed wall-clock window around the fetch: a loaded runner can delay the first 50 ms
+        //   attempt timeout past any fixed budget.
+        // - Concurrent tests drive these same span/event callsites with no subscriber installed,
+        //   which can race `set_default`'s interest-cache rebuild and re-cache a stale `never` for
+        //   the span callsite — every span created afterwards on this thread is `none` and the
+        //   WARNs lose their `block_number` field. Periodically rebuilding the interest cache and
+        //   respawning the fetch creates a fresh span under the repaired cache, so the test
+        //   self-heals instead of flaking.
+        let spawn_fetch = |client: RpcClient| {
+            tokio::spawn(async move {
+                let _ = client.get_witness_light_with_deadline(4242, B256::ZERO, None).await;
+            })
+        };
+        let mut fetch = spawn_fetch(client.clone());
+        let give_up = Instant::now() + Duration::from_secs(30);
+        let mut respawn_at = Instant::now() + Duration::from_millis(500);
+        loop {
+            let logs = String::from_utf8(buf.lock().unwrap().clone()).unwrap();
+            if logs.contains("block_number") && logs.contains("4242") {
+                break;
+            }
+            assert!(
+                Instant::now() < give_up,
+                "witness failure log must carry the block_number span field, got:\n{logs}"
+            );
+            if Instant::now() >= respawn_at {
+                fetch.abort();
+                tracing::callsite::rebuild_interest_cache();
+                buf.lock().unwrap().clear();
+                fetch = spawn_fetch(client.clone());
+                respawn_at = Instant::now() + Duration::from_millis(500);
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+        fetch.abort();
     }
 }

--- a/crates/stateless-common/src/rpc_client.rs
+++ b/crates/stateless-common/src/rpc_client.rs
@@ -372,6 +372,7 @@ impl RpcClient {
             if n > 1 { self.data_rr_counter.fetch_add(1, Ordering::Relaxed) % n } else { 0 };
         round_robin_with_backoff(
             &self.data_providers,
+            0,
             &self.data_concurrency,
             &self.config.rpc_retry,
             self.config.per_attempt_timeout,
@@ -570,7 +571,14 @@ impl RpcClient {
         deadline: Option<Instant>,
     ) -> std::result::Result<(SaltWitness, MptWitness), RpcDeadlineExceeded> {
         let witness = self
-            .witness_round_robin(number, hash, deadline, decode_witness_response, "Witness decoded")
+            .witness_round_robin(
+                0,
+                number,
+                hash,
+                deadline,
+                decode_witness_response,
+                "Witness decoded",
+            )
             .await?;
 
         if let Some(ref metrics) = self.config.metrics {
@@ -602,7 +610,26 @@ impl RpcClient {
         hash: B256,
         deadline: Option<Instant>,
     ) -> std::result::Result<(LightWitness, MptWitness), RpcDeadlineExceeded> {
+        self.get_witness_light_with_deadline_from(0, number, hash, deadline).await
+    }
+
+    /// Like [`Self::get_witness_light_with_deadline`], but skips the first `skip` witness
+    /// providers, for callers that know those endpoints cannot serve the request (e.g. an
+    /// internal generator that has pruned the block). Logged provider indices stay relative
+    /// to the full configured witness endpoint list, and the shared witness concurrency cap
+    /// still applies.
+    ///
+    /// # Panics
+    /// Panics if `skip >= witness_provider_count()` — at least one provider must remain.
+    pub async fn get_witness_light_with_deadline_from(
+        &self,
+        skip: usize,
+        number: u64,
+        hash: B256,
+        deadline: Option<Instant>,
+    ) -> std::result::Result<(LightWitness, MptWitness), RpcDeadlineExceeded> {
         self.witness_round_robin(
+            skip,
             number,
             hash,
             deadline,
@@ -613,19 +640,29 @@ impl RpcClient {
     }
 
     /// Shared `mega_getBlockWitness` retry loop: primary-failover rounds (always start from
-    /// provider 0 so the primary takes all traffic while healthy; backups are touched only
-    /// while it is failing), each attempt one RPC round trip followed by the caller-chosen
-    /// `decode` (see [`fetch_witness_with`]).
+    /// the first non-skipped provider so the primary takes all traffic while healthy; backups
+    /// are touched only while it is failing), each attempt one RPC round trip followed by the
+    /// caller-chosen `decode` (see [`fetch_witness_with`]).
+    ///
+    /// `skip` drops the first `skip` witness providers from the rotation while keeping logged
+    /// provider indices aligned with the full configured list.
     async fn witness_round_robin<T: Send + 'static>(
         &self,
+        skip: usize,
         number: u64,
         hash: B256,
         deadline: Option<Instant>,
         decode: fn(&str) -> std::result::Result<T, crate::WitnessDecodingError>,
         trace_msg: &'static str,
     ) -> std::result::Result<T, RpcDeadlineExceeded> {
+        assert!(
+            skip < self.witness_providers.len(),
+            "witness provider skip ({skip}) must leave at least one of {} providers",
+            self.witness_providers.len()
+        );
         round_robin_with_backoff(
-            &self.witness_providers,
+            &self.witness_providers[skip..],
+            skip,
             &self.witness_concurrency,
             &self.config.rpc_retry,
             self.config.per_attempt_timeout,
@@ -824,14 +861,19 @@ macro_rules! log_at {
 ///
 /// Used by both the data-method `call()` (rotates `rr_start` per call for load balancing) and
 /// `get_witness()` (pins `rr_start=0` for primary-failover).
-// 9-argument retry primitive. Each field plays a distinct role (providers, concurrency,
-// backoff policy, per-attempt timeout, starting provider, method label, metrics sink, deadline,
-// per-attempt closure) and bundling them into a struct would be ceremony without encapsulation —
-// there are exactly two call sites in this crate. Prefer clarity at the definition over fewer
-// commas at the call.
+///
+/// `providers` may be a slice of the caller's full configured list; `provider_idx_base` is the
+/// offset of that slice within the full list, so logged/reported provider indices always match
+/// the operator's endpoint ordering regardless of slicing.
+// 10-argument retry primitive. Each field plays a distinct role (providers, index base,
+// concurrency, backoff policy, per-attempt timeout, starting provider, method label, metrics
+// sink, deadline, per-attempt closure) and bundling them into a struct would be ceremony without
+// encapsulation — there are exactly two call sites in this crate. Prefer clarity at the
+// definition over fewer commas at the call.
 #[allow(clippy::too_many_arguments)]
 async fn round_robin_with_backoff<N, T>(
     providers: &[RootProvider<N>],
+    provider_idx_base: usize,
     semaphore: &Semaphore,
     policy: &BackoffPolicy,
     per_attempt_timeout: Duration,
@@ -875,7 +917,10 @@ where
             {
                 return Err(RpcDeadlineExceeded { method, elapsed: call_start.elapsed() });
             }
-            let provider_idx = (rr_start + offset) % n;
+            let slot = (rr_start + offset) % n;
+            // Index into the operator's full configured endpoint list (see
+            // `provider_idx_base`); `slot` indexes the possibly-sliced `providers`.
+            let provider_idx = provider_idx_base + slot;
             let permit = semaphore.acquire().await.expect("semaphore closed unexpectedly");
             // Per-attempt timing: record each provider call individually so histograms
             // and success/error counters reflect what actually happened in the retry loop
@@ -889,11 +934,8 @@ where
                 Some(d) => d.saturating_duration_since(Instant::now()).min(per_attempt_timeout),
                 None => per_attempt_timeout,
             };
-            let result = match tokio::time::timeout(
-                attempt_timeout,
-                f(providers[provider_idx].clone()),
-            )
-            .await
+            let result = match tokio::time::timeout(attempt_timeout, f(providers[slot].clone()))
+                .await
             {
                 Ok(r) => r,
                 Err(_) => {
@@ -1624,6 +1666,49 @@ mod tests {
 
         ha.stop().unwrap();
         hb.stop().unwrap();
+    }
+
+    /// `get_witness_light_with_deadline_from(skip=1, ..)` must never touch the first witness
+    /// provider: the rotation runs entirely over the remaining endpoints.
+    #[tokio::test]
+    async fn test_witness_fetch_with_skip_never_hits_skipped_provider() {
+        let order = Arc::new(std::sync::Mutex::new(Vec::<char>::new()));
+        let (ha, url_a) = start_ordered_witness_rpc('A', order.clone()).await;
+        let (hb, url_b) = start_ordered_witness_rpc('B', order.clone()).await;
+
+        let config = RpcClientConfig {
+            rpc_retry: BackoffPolicy::new(Duration::from_millis(1), Duration::from_millis(2)),
+            ..Default::default()
+        };
+        let client = RpcClient::new_with_config(
+            &[url_a.as_str()],
+            &[url_a.as_str(), url_b.as_str()],
+            config,
+            None,
+        )
+        .unwrap();
+
+        let deadline = Instant::now() + Duration::from_millis(100);
+        let result = client
+            .get_witness_light_with_deadline_from(1, 1, BlockHash::ZERO, Some(deadline))
+            .await;
+        assert!(result.is_err(), "stub payloads fail decode, so the deadline must fire");
+
+        let log = order.lock().unwrap();
+        assert!(!log.is_empty(), "the non-skipped provider must have been tried");
+        assert!(log.iter().all(|&l| l == 'B'), "skipped provider A must never be hit: {log:?}");
+
+        ha.stop().unwrap();
+        hb.stop().unwrap();
+    }
+
+    /// Skipping every configured witness provider is a caller bug and must panic loudly
+    /// instead of silently retrying over an empty provider set.
+    #[tokio::test]
+    #[should_panic(expected = "must leave at least one")]
+    async fn test_witness_fetch_skip_of_all_providers_panics() {
+        let client = RpcClient::new(&[LOCALHOST_A], &[LOCALHOST_B]).unwrap();
+        let _ = client.get_witness_light_with_deadline_from(1, 1, BlockHash::ZERO, None).await;
     }
 
     /// Serves `mega_getBlockWitness` returning a stub that decodes-fails, while recording

--- a/crates/stateless-common/src/rpc_client.rs
+++ b/crates/stateless-common/src/rpc_client.rs
@@ -353,6 +353,13 @@ impl RpcClient {
         self.witness_providers.len()
     }
 
+    /// Returns the credential-stripped `{idx}:{host}` metric/log label of the witness
+    /// endpoint at `idx`, or `None` when out of range. Use this instead of the raw
+    /// configured URL wherever an endpoint identity is logged.
+    pub fn witness_provider_label(&self, idx: usize) -> Option<&str> {
+        self.witness_provider_labels.get(idx).map(|label| &**label)
+    }
+
     /// Wraps a data-method RPC call with round-robin load balancing and round-level backoff.
     ///
     /// Retries forever — transient failures never surface to callers. Use
@@ -1516,6 +1523,12 @@ mod tests {
                 endpoints.len()
             );
         }
+
+        // The public label accessor exposes the credential-stripped `{idx}:{host}` form and
+        // is total over out-of-range indices.
+        let client = RpcClient::new(&[LOCALHOST_A], &[LOCALHOST_B]).unwrap();
+        assert_eq!(client.witness_provider_label(0), Some("0:localhost:8546"));
+        assert_eq!(client.witness_provider_label(1), None);
     }
 
     #[test]
@@ -1780,6 +1793,60 @@ mod tests {
 
         ha.stop().unwrap();
         hb.stop().unwrap();
+    }
+
+    /// Label alignment under skip: with three witness endpoints and `skip = 1`, every
+    /// recorded attempt must carry its ORIGINAL-index label (`1:` / `2:`, never `0:`), and
+    /// the first non-skipped endpoint stays the rotation's primary. Pins the documented
+    /// parallel-slicing property the per-endpoint metrics rely on — a refactor that
+    /// re-derived labels from the sliced list would misattribute every backup attempt.
+    #[tokio::test]
+    async fn test_witness_skip_attempts_keep_original_index_labels() {
+        let order = Arc::new(std::sync::Mutex::new(Vec::<char>::new()));
+        let (ha, url_a) = start_ordered_witness_rpc('A', order.clone()).await;
+        let (hb, url_b) = start_ordered_witness_rpc('B', order.clone()).await;
+        let (hc, url_c) = start_ordered_witness_rpc('C', order.clone()).await;
+
+        let metrics = Arc::new(CapturingMetrics::default());
+        let config = RpcClientConfig {
+            rpc_retry: BackoffPolicy::new(Duration::from_millis(1), Duration::from_millis(2)),
+            ..Default::default()
+        }
+        .with_metrics(metrics.clone());
+        let client = RpcClient::new_with_config(
+            &[url_a.as_str()],
+            &[url_a.as_str(), url_b.as_str(), url_c.as_str()],
+            config,
+            None,
+        )
+        .unwrap();
+
+        let deadline = Instant::now() + Duration::from_millis(120);
+        let result = client
+            .get_witness_light_with_deadline_from(1, 1, BlockHash::ZERO, Some(deadline))
+            .await;
+        assert!(result.is_err(), "stub payloads fail decode, so the deadline must fire");
+
+        let attempts = metrics.attempts.lock().unwrap();
+        let labels: Vec<&str> = attempts
+            .iter()
+            .filter(|(m, _, _)| *m == RpcMethod::MegaGetBlockWitness)
+            .map(|(_, label, _)| label.as_str())
+            .collect();
+        assert!(labels.len() >= 2, "at least one full round over both non-skipped endpoints");
+        assert!(
+            labels.iter().all(|l| l.starts_with("1:") || l.starts_with("2:")),
+            "skipped endpoint 0 must never be attributed: {labels:?}"
+        );
+        assert!(labels[0].starts_with("1:"), "first non-skipped endpoint is the primary");
+        assert!(
+            labels.iter().any(|l| l.starts_with("2:")),
+            "the failover endpoint keeps its original index label: {labels:?}"
+        );
+
+        ha.stop().unwrap();
+        hb.stop().unwrap();
+        hc.stop().unwrap();
     }
 
     /// Skipping every configured witness provider is a caller bug and must panic loudly

--- a/crates/stateless-core/src/pipeline/config.rs
+++ b/crates/stateless-core/src/pipeline/config.rs
@@ -42,6 +42,24 @@ pub struct PipelineConfig {
 }
 
 impl PipelineConfig {
+    /// Validates cross-field invariants.
+    ///
+    /// The fetcher holds the local tip at least `tip_buffer` behind the remote head, while the
+    /// outer loop treats a lag beyond `stale_reset_threshold` as stale data — a buffer at or
+    /// past the threshold would make the built-in lag itself trigger an anchor reset (and the
+    /// history gap that comes with it) on every transient restart.
+    pub fn validate(&self) -> Result<(), String> {
+        if let Some(threshold) = self.stale_reset_threshold &&
+            self.tip_buffer >= threshold
+        {
+            return Err(format!(
+                "tip_buffer ({}) must be smaller than stale_reset_threshold ({threshold})",
+                self.tip_buffer
+            ));
+        }
+        Ok(())
+    }
+
     /// Fetcher in-flight window: number of concurrent `BlockFetcher::fetch` tasks the
     /// fetcher stage may have outstanding at once. Derived from `concurrent_workers ×
     /// in_flight_multiplier`.

--- a/crates/stateless-core/src/pipeline/mod.rs
+++ b/crates/stateless-core/src/pipeline/mod.rs
@@ -62,6 +62,8 @@ where
     H: PipelineHooks<Output = P::Output>,
     R: ReorgResolver<F, S>,
 {
+    config.validate().map_err(|e| anyhow!("invalid pipeline config: {e}"))?;
+
     loop {
         if shutdown.is_cancelled() {
             return Ok(());

--- a/crates/stateless-core/src/pipeline/tests.rs
+++ b/crates/stateless-core/src/pipeline/tests.rs
@@ -736,6 +736,18 @@ async fn test_block_fetcher_streams_out_of_order() {
     assert!(tokio::time::timeout(Duration::from_secs(5), handle).await.is_ok());
 }
 
+/// `tip_buffer` must stay below `stale_reset_threshold`: the fetcher's built-in lag would
+/// otherwise satisfy the staleness test and anchor-reset on every transient restart.
+#[test]
+fn test_pipeline_config_rejects_tip_buffer_at_or_past_stale_threshold() {
+    let mut cfg = PipelineConfig { tip_buffer: 1000, ..PipelineConfig::default() };
+    assert!(cfg.validate().is_ok(), "no stale threshold: any buffer is fine");
+    cfg.stale_reset_threshold = Some(1000);
+    assert!(cfg.validate().is_err(), "equal is already pathological");
+    cfg.tip_buffer = 999;
+    assert!(cfg.validate().is_ok());
+}
+
 /// `tip_buffer` must keep the fetcher from spawning any fetch within that distance of the
 /// remote tip, so the upstream witness generator has headroom.
 #[tokio::test]


### PR DESCRIPTION
## Summary

Witness fetches in the debug-trace-server now route by block age: blocks at least `--witness-local-window` (default 4096, matching the witness generator's `BACKUP` retention) below the local DB tip skip the first witness endpoint — the internal generator, a guaranteed miss for anything it has pruned — and fetch straight from the fallback endpoints. Previously every historical request burned a doomed generator probe plus a failover round trip before reaching an endpoint that could actually serve it, and the hardcoded 3s old-block fail-fast was the dominant source of customer-visible `-32001` timeouts.

## Design

The historical route is a skip parameter on the shared witness path, not a second client: `RpcClient::get_witness_light_with_deadline_from(skip, ..)` (`crates/stateless-common/src/rpc_client.rs:649`) slices `witness_providers[skip..]` and its parallel endpoint labels into the existing retry loop. Attribution rides on the `{idx}:{host}` labels (`endpoint_label`, `rpc_client.rs:899`), which bake in each endpoint's index in the full configured list at construction, so sliced routes stay globally correct in logs and per-endpoint metrics; the numeric `provider_idx` field #156 added to the retry logs is dropped — under slicing the raw loop index would misattribute, and the label already carries the index. One client means one witness concurrency semaphore (the `--witness-max-concurrent-requests` cap stays global) and no duplicate connection pools.

Routing is derived per fetch, not configured: `witness_route` (`bin/debug-trace-server/src/data_provider.rs:781`) skips the generator when the block is historical and a fallback endpoint exists (`witness_provider_count() >= 2`, `data_provider.rs:814`), so the skip can never see an empty rotation. An unknown local tip counts as recent, so stateless mode (no `--data-dir`) never routes; the background chain-sync prefetch deliberately always uses the full chain (it fetches at the sync frontier, within the generator's retention except during deep catch-up with `--blocks-to-keep` beyond it — documented on `TraceFetcher`). Startup logs state which mode is in effect, identifying the skipped endpoint by its credential-stripped label via the new `RpcClient::witness_provider_label` (`rpc_client.rs:359`). The first `--witness-endpoint` is positionally the internal generator; README and AGENTS.md document the contract.

New knobs: `--witness-old-block-timeout` (`main.rs:231`) replaces the hardcoded 3s old-block fail-fast; when unset it tracks the effective `--witness-timeout` budget (raising the witness budget also raises the old-block cap), and explicit values are clamped to `--witness-timeout`. `--witness-local-window` (`main.rs:225`) sets the routing threshold; `--tip-buffer` (`main.rs:238`, default 2) keeps the chain-sync fetcher from racing the generator at the head. The `tip_buffer < stale-reset-threshold` invariant is enforced twice: `validate_args` (`main.rs:301`) gives flag-named CLI errors, and the new `PipelineConfig::validate()` (`crates/stateless-core/src/pipeline/config.rs:51`) — enforced at `run_pipeline` entry (`pipeline/mod.rs:65`) — protects every embedder that constructs `PipelineConfig` directly (the mega-reth FullNode sets `stale_reset_threshold = None` and is unaffected). Witness-fetch failure logs carry `source`/`old_block`/`budget_ms`/`elapsed_ms` for incident attribution.

## Testing

The routing dispatch is pinned end-to-end in both directions: with two mock endpoints a historical block never touches the generator and a recent block probes it first; with a single endpoint a historical block is served by the sole endpoint without tripping the skip assert — a `>= 1` regression of the fallback derivation now fails the suite (mutation-verified). A three-endpoint skip test asserts every recorded attempt keeps its original-index `{idx}:{host}` label, pinning the parallel-slicing property the per-endpoint metrics rely on. Unit tests cover the `is_historical` boundary (including overflow and zero-window), the old-block budget clamp and its tracking default (unset follows a raised `--witness-timeout`; an explicit flag wins), route/label selection, CLI+env parsing of all three knobs, and the tip-buffer validation at both the CLI and core levels; a previously-flaky tracing log-capture test was made robust to runner load and callsite-interest races. Full workspace `cargo test`, `cargo fmt --check`, `cargo sort --check`, and `cargo clippy` are clean.

## Operational notes (dashboards & behavior changes)

- `source="witness_generator"` no longer covers the whole RPC witness path: once routing is active, historical traffic records under `source="witness_historical"` in both `DataSourceMetrics` and `WitnessSourceMetrics`, and the RPC path is the sum of the two labels — rescope dashboards/alerts keyed on `witness_generator` (same class of change as #154/#156).
- Retry-loop logs drop the numeric `provider_idx` field introduced by #156; `provider={idx}:{host}` is the attribution mechanism — migrate any tooling that greps the numeric field.
- The old-block witness budget default moves from a hardcoded 3s to the full `--witness-timeout` budget (tracking it when unset); deployments that relied on the fail-fast should set `--witness-old-block-timeout 3`.
- New startup validation rejects `--tip-buffer >= --blocks-to-keep` (the built-in lag would otherwise trip a stale-anchor reset on every transient restart).
- With a single witness endpoint or no `--data-dir`, routing is inert (fetch order unchanged from main); a startup warn calls out the multi-endpoint-without-data-dir case.

## Notes

- The branch merges `origin/main` (#156, per-endpoint RPC attempt metrics) rather than rebasing; the retry-loop conflict was resolved by slicing providers and their labels in parallel onto #156's `RpcAttemptOutcome` classification, keeping the deadline-pressure timeout attribution intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
