### PR TITLE
chore: sync stateless-r2 Cargo.lock entry to v2.0.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5745,7 +5745,7 @@ dependencies = [
 
 [[package]]
 name = "stateless-r2"
-version = "2.0.14"
+version = "2.0.15"
 dependencies = [
  "bytes",
  "chrono",


### PR DESCRIPTION
## Summary
`crates/stateless-r2` landed while the workspace was at `2.0.14`, and #150 (workspace bump to `2.0.15`) branched before the crate existed, so the squash-merged `Cargo.lock` kept a stale `stateless-r2 2.0.14` entry while the manifest resolves to `2.0.15` via `version.workspace = true`. This regenerates the lock entry to `2.0.15` — a one-hunk, lock-only change.

## Testing
`cargo check --workspace --locked` passes (it would fail on any remaining manifest/lock mismatch); `cargo update -w` reports nothing further to change.

## Notes
The v2.0.15 release has been deleted and will be re-cut after this lands, so the tagged `Cargo.lock` is consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)