### PR TITLE
feat: Rex6 genesis wiring (rex6Time + rex6MinRotationDelay)

### DIFF
--- a/crates/stateless-core/src/chain_spec.rs
+++ b/crates/stateless-core/src/chain_spec.rs
@@ -69,7 +69,7 @@ impl MegaHardforks for ChainSpec {
 }
 
 impl ChainSpec {
-    /// Creates a new [`ChainSpec`] from a [`Genesis`].
+    /// Create a new [`ChainSpec`] from a [`Genesis`].
     ///
     /// Ordering rules:
     /// - [`OpChainSpec`] already yields Optimism/Ethereum hardforks in the correct order, so they
@@ -81,13 +81,19 @@ impl ChainSpec {
     /// - The MegaETH set is then merged with the Optimism/Ethereum set to build a single
     ///   [`ChainHardforks`] that drives fork activation.
     ///
-    /// When `rex5Time` is configured, the genesis `config` extra fields must also carry the flat
-    /// `rex5InitialSequencer` / `rex5InitialAdmin` addresses; both are validated immediately so a
-    /// misconfigured genesis fails at load rather than at the first Rex5 block. Likewise, when
-    /// `rex6Time` is configured the extra fields must carry a non-zero `rex6MinRotationDelay`.
-    /// Scheduling Rex6 also requires Rex5 at the same or an earlier timestamp — Rex6 depends on
-    /// the SequencerRegistry that the Rex5 activation deploys, so a partial ladder is rejected
-    /// at load instead of stalling at the Rex6 activation block.
+    /// Panics if genesis schedules Rex5 (`rex5Time` set) or Rex6 (`rex6Time` set) but the bootstrap
+    /// config is missing or malformed. The bootstrap is conditionally required: dropping the
+    /// failure here would produce a chainspec that loads cleanly today and stalls the chain at
+    /// the fork's activation with `"... active but SequencerRegistry...Config not configured"`.
+    /// Surfacing it at chainspec-load means an operator typo fails fast on node start, before
+    /// any block is ever produced.
+    ///
+    /// Also panics if genesis schedules Rex6 without Rex5, or with Rex5 after it
+    /// (`rex5Time > rex6Time`; equal timestamps are legal — both forks activate together).
+    /// Rex6 depends on the SequencerRegistry that the Rex5 activation deploys, so such a
+    /// schedule would activate Rex6 with no registry in state and stall every block from the
+    /// activation on with `"Rex5 active but SequencerRegistryConfig not configured"` — the
+    /// same late-failure mode the load-time validation above exists to prevent.
     pub fn from_genesis(genesis: Genesis) -> Self {
         // A malformed `rex5Time`/`rex6Time` treated as "fork absent" would skip the
         // bootstrap-required check and diverge from mega-reth at the activation timestamp, so
@@ -272,24 +278,21 @@ impl MegaethGenesisSequencerRegistryConfig {
     }
 }
 
-/// Rex6 `SequencerRegistry` rotation-hardening config, parsed from genesis `config` extra fields.
+/// Optional SequencerRegistryRex6 bootstrap config embedded in genesis extra fields.
 ///
-/// Flat schema (matches mega-reth) so a single genesis.json works for both binaries.
-/// The delay must be non-zero or [`SequencerRegistryRex6Config::validate`] rejects it.
+/// Only relevant when Rex6 is enabled.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct MegaethGenesisSequencerRegistryRex6Config {
-    /// Minimum number of blocks between scheduling a sequencer change and its activation,
-    /// seeded into the registry at Rex6 activation.
+    /// Minimum rotation delay (governance parameter) for the SequencerRegistry at Rex6 activation.
     pub rex6_min_rotation_delay: u64,
 }
 
 impl MegaethGenesisSequencerRegistryRex6Config {
-    /// Parse the required Rex6 rotation config from genesis extra fields.
+    /// Parse the required SequencerRegistryRex6 bootstrap config from genesis extra fields.
     ///
-    /// Returns a serde error if the delay field is missing or malformed. Callers should only
-    /// invoke it once they have decided the config is required, i.e. when `rex6Time` is
-    /// configured.
+    /// Missing fields and malformed u64 are returned as serde errors. Callers should only
+    /// invoke it after deciding the bootstrap is required, e.g. when `rex6Time` is configured.
     pub fn parse_required_from(others: &OtherFields) -> serde_json::Result<Self> {
         others.deserialize_as()
     }
@@ -583,9 +586,10 @@ mod tests {
         let _ = ChainSpec::from_genesis(genesis);
     }
 
-    /// `from_genesis` must reject a genesis that schedules Rex6 without Rex5: Rex6 depends on
-    /// the SequencerRegistry deployed by the Rex5 activation, so the chain would stall at the
-    /// Rex6 activation block — this load-time check turns that into a fail-fast on node start.
+    /// `from_genesis` must reject a genesis that schedules Rex6 without Rex5: mega-evm's
+    /// `hardfork()` would report REX6 at activation, but the Rex5-gated SequencerRegistry
+    /// deploy never runs, so `resolve_system_address` fails every block from the activation
+    /// on — a permanent stall this load-time check turns into a fail-fast on node start.
     #[test]
     #[should_panic(expected = "genesis schedules Rex6 but Rex5 is missing or scheduled after it")]
     fn test_chain_spec_rex6_without_rex5_panics() {

--- a/crates/stateless-core/src/chain_spec.rs
+++ b/crates/stateless-core/src/chain_spec.rs
@@ -8,7 +8,10 @@ use alloy_hardforks::{EthereumHardfork, EthereumHardforks, ForkCondition, Hardfo
 use alloy_op_hardforks::{OpHardfork, OpHardforks};
 use alloy_primitives::Address;
 use alloy_serde::OtherFields;
-use mega_evm::{HardforkParams, MegaHardfork, MegaHardforks, SequencerRegistryConfig};
+use mega_evm::{
+    HardforkParams, MegaHardfork, MegaHardforks, SequencerRegistryConfig,
+    SequencerRegistryRex6Config,
+};
 use reth_ethereum_forks::ChainHardforks;
 use reth_optimism_chainspec::OpChainSpec;
 
@@ -28,6 +31,11 @@ pub struct ChainSpec {
     ///
     /// `None` for pre-Rex5 chains; `Some(...)` when `rex5Time` is configured.
     pub sequencer_registry_config: Option<SequencerRegistryConfig>,
+    /// Rex6 `SequencerRegistry` rotation-hardening config, parsed from genesis `config` extra
+    /// fields.
+    ///
+    /// `None` for pre-Rex6 chains; `Some(...)` when `rex6Time` is configured.
+    pub sequencer_registry_rex6_config: Option<SequencerRegistryRex6Config>,
 }
 
 impl EthereumHardforks for ChainSpec {
@@ -52,6 +60,9 @@ impl MegaHardforks for ChainSpec {
             MegaHardfork::Rex5 => {
                 self.sequencer_registry_config.as_ref().map(|c| c as &(dyn Any + Send + Sync))
             }
+            MegaHardfork::Rex6 => {
+                self.sequencer_registry_rex6_config.as_ref().map(|c| c as &(dyn Any + Send + Sync))
+            }
             _ => None,
         }
     }
@@ -72,13 +83,16 @@ impl ChainSpec {
     ///
     /// When `rex5Time` is configured, the genesis `config` extra fields must also carry the flat
     /// `rex5InitialSequencer` / `rex5InitialAdmin` addresses; both are validated immediately so a
-    /// misconfigured genesis fails at load rather than at the first Rex5 block.
+    /// misconfigured genesis fails at load rather than at the first Rex5 block. Likewise, when
+    /// `rex6Time` is configured the extra fields must carry a non-zero `rex6MinRotationDelay`.
     pub fn from_genesis(genesis: Genesis) -> Self {
-        // A malformed `rex5Time` treated as "Rex5 absent" would skip the bootstrap-required
-        // check and diverge from mega-reth at the activation timestamp, so surface parse errors.
+        // A malformed `rex5Time`/`rex6Time` treated as "fork absent" would skip the
+        // bootstrap-required check and diverge from mega-reth at the activation timestamp, so
+        // surface parse errors.
         let megaeth_hardforks = MegaethGenesisHardforks::extract_from(&genesis.config.extra_fields)
             .unwrap_or_else(|err| panic!("malformed MegaETH hardforks in genesis: {err}"));
         let rex5_scheduled = megaeth_hardforks.rex_5_time.is_some();
+        let rex6_scheduled = megaeth_hardforks.rex_6_time.is_some();
         let mut megaeth_hardforks = megaeth_hardforks.into_vec();
 
         // Rex5 SequencerRegistry bootstrap, required iff `rex5Time` is scheduled. Parsed from
@@ -93,6 +107,23 @@ impl ChainSpec {
             });
             let cfg = parsed.into_config();
             cfg.validate().unwrap_or_else(|err| panic!("invalid SequencerRegistryConfig: {err}"));
+            Some(cfg)
+        } else {
+            None
+        };
+
+        // Rex6 `SequencerRegistry` rotation hardening, required iff `rex6Time` is scheduled.
+        // Same flat schema as mega-reth (`rex6MinRotationDelay` as a top-level `config` field).
+        let sequencer_registry_rex6_config = if rex6_scheduled {
+            let parsed = MegaethGenesisSequencerRegistryRex6Config::parse_required_from(
+                &genesis.config.extra_fields,
+            )
+            .unwrap_or_else(|err| {
+                panic!("malformed or missing SequencerRegistryRex6Config in genesis: {err}")
+            });
+            let cfg = parsed.into_config();
+            cfg.validate()
+                .unwrap_or_else(|err| panic!("invalid SequencerRegistryRex6Config: {err}"));
             Some(cfg)
         } else {
             None
@@ -125,7 +156,12 @@ impl ChainSpec {
         // we merge megaeth_hardforks with op_hardforks
         all_hardforks.append(&mut op_hardforks);
 
-        Self { chain_id, hardforks: ChainHardforks::new(all_hardforks), sequencer_registry_config }
+        Self {
+            chain_id,
+            hardforks: ChainHardforks::new(all_hardforks),
+            sequencer_registry_config,
+            sequencer_registry_rex6_config,
+        }
     }
 }
 
@@ -151,6 +187,8 @@ pub struct MegaethGenesisHardforks {
     pub rex_4_time: Option<u64>,
     /// Rex5 hardfork timestamp.
     pub rex_5_time: Option<u64>,
+    /// Rex6 hardfork timestamp.
+    pub rex_6_time: Option<u64>,
 }
 
 impl MegaethGenesisHardforks {
@@ -173,6 +211,7 @@ impl MegaethGenesisHardforks {
             (MegaHardfork::Rex3.boxed(), self.rex_3_time.map(ForkCondition::Timestamp)),
             (MegaHardfork::Rex4.boxed(), self.rex_4_time.map(ForkCondition::Timestamp)),
             (MegaHardfork::Rex5.boxed(), self.rex_5_time.map(ForkCondition::Timestamp)),
+            (MegaHardfork::Rex6.boxed(), self.rex_6_time.map(ForkCondition::Timestamp)),
         ]
         .into_iter()
         .filter_map(|(hardfork, condition)| condition.map(|c| (hardfork, c)))
@@ -212,6 +251,34 @@ impl MegaethGenesisSequencerRegistryConfig {
     }
 }
 
+/// Rex6 `SequencerRegistry` rotation-hardening config, parsed from genesis `config` extra fields.
+///
+/// Flat schema (matches mega-reth) so a single genesis.json works for both binaries.
+/// The delay must be non-zero or [`SequencerRegistryRex6Config::validate`] rejects it.
+#[derive(Debug, Clone, Copy, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MegaethGenesisSequencerRegistryRex6Config {
+    /// Minimum number of blocks between scheduling a sequencer change and its activation,
+    /// seeded into the registry at Rex6 activation.
+    pub rex6_min_rotation_delay: u64,
+}
+
+impl MegaethGenesisSequencerRegistryRex6Config {
+    /// Parse the required Rex6 rotation config from genesis extra fields.
+    ///
+    /// Returns a serde error if the delay field is missing or malformed. Callers should only
+    /// invoke it once they have decided the config is required, i.e. when `rex6Time` is
+    /// configured.
+    pub fn parse_required_from(others: &OtherFields) -> serde_json::Result<Self> {
+        others.deserialize_as()
+    }
+
+    /// Convert to the canonical mega-evm [`SequencerRegistryRex6Config`].
+    pub fn into_config(self) -> SequencerRegistryRex6Config {
+        SequencerRegistryRex6Config { rex6_min_rotation_delay: self.rex6_min_rotation_delay }
+    }
+}
+
 /// Build a fresh `ChainHardforks` describing MegaETH's canonical hardfork sequence.
 pub fn mega_mainnet_hardforks() -> ChainHardforks {
     ChainHardforks::new(vec![
@@ -224,6 +291,7 @@ pub fn mega_mainnet_hardforks() -> ChainHardforks {
         (MegaHardfork::Rex3.boxed(), ForkCondition::Timestamp(0)),
         (MegaHardfork::Rex4.boxed(), ForkCondition::Timestamp(0)),
         (MegaHardfork::Rex5.boxed(), ForkCondition::Timestamp(0)),
+        (MegaHardfork::Rex6.boxed(), ForkCondition::Timestamp(0)),
     ])
 }
 
@@ -279,7 +347,8 @@ mod tests {
           "rex2Time": 6,
           "rex3Time": 7,
           "rex4Time": 8,
-          "rex5Time": 9
+          "rex5Time": 9,
+          "rex6Time": 10
         }
         "#;
         let fields = serde_json::from_str::<OtherFields>(genesis_info).unwrap();
@@ -293,6 +362,7 @@ mod tests {
         assert_eq!(hardforks.rex_3_time, Some(7));
         assert_eq!(hardforks.rex_4_time, Some(8));
         assert_eq!(hardforks.rex_5_time, Some(9));
+        assert_eq!(hardforks.rex_6_time, Some(10));
     }
 
     #[test]
@@ -382,6 +452,123 @@ mod tests {
             )
             .unwrap();
         let _ = ChainSpec::from_genesis(genesis);
+    }
+
+    #[test]
+    #[should_panic(expected = "malformed MegaETH hardforks in genesis")]
+    fn test_chain_spec_malformed_rex6_time_panics() {
+        let mut genesis = Genesis::default();
+        genesis.config.extra_fields.insert_value("rex6Time".to_string(), "not-a-number").unwrap();
+        let _ = ChainSpec::from_genesis(genesis);
+    }
+
+    #[test]
+    fn test_parse_sequencer_registry_rex6_from_flat_json() {
+        let genesis_info = r#"
+        {
+          "rex6Time": 0,
+          "rex6MinRotationDelay": 7200
+        }
+        "#;
+        let fields = serde_json::from_str::<OtherFields>(genesis_info).unwrap();
+        let parsed =
+            MegaethGenesisSequencerRegistryRex6Config::parse_required_from(&fields).unwrap();
+        assert_eq!(parsed.rex6_min_rotation_delay, 7200);
+    }
+
+    #[test]
+    fn test_chain_spec_carries_rex6_registry_as_fork_params() {
+        let mut genesis = Genesis::default();
+        genesis.config.extra_fields.insert_value("rex6Time".to_string(), 0).unwrap();
+        genesis.config.extra_fields.insert_value("rex6MinRotationDelay".to_string(), 7200).unwrap();
+        let spec = ChainSpec::from_genesis(genesis);
+        let params =
+            spec.fork_params::<SequencerRegistryRex6Config>().expect("Rex6 params present");
+        assert_eq!(params.rex6_min_rotation_delay, 7200);
+        assert_eq!(spec.hardforks.fork(MegaHardfork::Rex6), ForkCondition::Timestamp(0));
+    }
+
+    #[test]
+    fn test_chain_spec_no_rex6_returns_none() {
+        let genesis = Genesis::default();
+        let spec = ChainSpec::from_genesis(genesis);
+        assert!(spec.fork_params::<SequencerRegistryRex6Config>().is_none());
+        assert!(spec.sequencer_registry_rex6_config.is_none());
+    }
+
+    #[test]
+    fn test_chain_spec_rex6_delay_without_time_ignored() {
+        let mut genesis = Genesis::default();
+        genesis.config.extra_fields.insert_value("rex6MinRotationDelay".to_string(), 7200).unwrap();
+        let spec = ChainSpec::from_genesis(genesis);
+        assert_eq!(spec.hardforks.fork(MegaHardfork::Rex6), ForkCondition::Never);
+        assert!(spec.sequencer_registry_rex6_config.is_none());
+    }
+
+    #[test]
+    #[should_panic(expected = "malformed or missing SequencerRegistryRex6Config in genesis")]
+    fn test_chain_spec_rex6_without_bootstrap_panics() {
+        let mut genesis = Genesis::default();
+        genesis.config.extra_fields.insert_value("rex6Time".to_string(), 0).unwrap();
+        let _ = ChainSpec::from_genesis(genesis);
+    }
+
+    #[test]
+    #[should_panic(expected = "malformed or missing SequencerRegistryRex6Config in genesis")]
+    fn test_chain_spec_rex6_malformed_delay_panics() {
+        let mut genesis = Genesis::default();
+        genesis.config.extra_fields.insert_value("rex6Time".to_string(), 0).unwrap();
+        genesis
+            .config
+            .extra_fields
+            .insert_value("rex6MinRotationDelay".to_string(), "not-a-number")
+            .unwrap();
+        let _ = ChainSpec::from_genesis(genesis);
+    }
+
+    #[test]
+    #[should_panic(expected = "invalid SequencerRegistryRex6Config")]
+    fn test_chain_spec_rex6_zero_delay_panics() {
+        let mut genesis = Genesis::default();
+        genesis.config.extra_fields.insert_value("rex6Time".to_string(), 0).unwrap();
+        genesis.config.extra_fields.insert_value("rex6MinRotationDelay".to_string(), 0).unwrap();
+        let _ = ChainSpec::from_genesis(genesis);
+    }
+
+    #[test]
+    fn test_chain_spec_rex5_and_rex6_coexist_in_canonical_order() {
+        let mut genesis = Genesis::default();
+        genesis.config.extra_fields.insert_value("rex5Time".to_string(), 100).unwrap();
+        genesis
+            .config
+            .extra_fields
+            .insert_value(
+                "rex5InitialSequencer".to_string(),
+                "0x0000000000000000000000000000000000000001",
+            )
+            .unwrap();
+        genesis
+            .config
+            .extra_fields
+            .insert_value(
+                "rex5InitialAdmin".to_string(),
+                "0x0000000000000000000000000000000000000002",
+            )
+            .unwrap();
+        genesis.config.extra_fields.insert_value("rex6Time".to_string(), 200).unwrap();
+        genesis.config.extra_fields.insert_value("rex6MinRotationDelay".to_string(), 7200).unwrap();
+        let spec = ChainSpec::from_genesis(genesis);
+
+        assert_eq!(spec.hardforks.fork(MegaHardfork::Rex5), ForkCondition::Timestamp(100));
+        assert_eq!(spec.hardforks.fork(MegaHardfork::Rex6), ForkCondition::Timestamp(200));
+        assert!(spec.fork_params::<SequencerRegistryConfig>().is_some());
+        assert!(spec.fork_params::<SequencerRegistryRex6Config>().is_some());
+
+        // Rex6 must sort after Rex5 in the merged canonical ordering.
+        let names: Vec<_> = spec.hardforks.forks_iter().map(|(f, _)| f.name()).collect();
+        let rex5_pos = names.iter().position(|n| *n == MegaHardfork::Rex5.name()).unwrap();
+        let rex6_pos = names.iter().position(|n| *n == MegaHardfork::Rex6.name()).unwrap();
+        assert!(rex5_pos < rex6_pos, "Rex6 must come after Rex5 in the hardfork order");
     }
 
     #[test]

--- a/crates/stateless-core/src/chain_spec.rs
+++ b/crates/stateless-core/src/chain_spec.rs
@@ -85,6 +85,9 @@ impl ChainSpec {
     /// `rex5InitialSequencer` / `rex5InitialAdmin` addresses; both are validated immediately so a
     /// misconfigured genesis fails at load rather than at the first Rex5 block. Likewise, when
     /// `rex6Time` is configured the extra fields must carry a non-zero `rex6MinRotationDelay`.
+    /// Scheduling Rex6 also requires Rex5 at the same or an earlier timestamp — Rex6 depends on
+    /// the SequencerRegistry that the Rex5 activation deploys, so a partial ladder is rejected
+    /// at load instead of stalling at the Rex6 activation block.
     pub fn from_genesis(genesis: Genesis) -> Self {
         // A malformed `rex5Time`/`rex6Time` treated as "fork absent" would skip the
         // bootstrap-required check and diverge from mega-reth at the activation timestamp, so
@@ -93,6 +96,24 @@ impl ChainSpec {
             .unwrap_or_else(|err| panic!("malformed MegaETH hardforks in genesis: {err}"));
         let rex5_scheduled = megaeth_hardforks.rex_5_time.is_some();
         let rex6_scheduled = megaeth_hardforks.rex_6_time.is_some();
+
+        // Rex6 needs the SequencerRegistry deployed by the Rex5 activation. A partial ladder
+        // (Rex6 without Rex5, or Rex5 after Rex6) would load cleanly and then stall at the
+        // Rex6 activation block, so reject it here. Equal timestamps are fine: both forks
+        // activate together.
+        if rex6_scheduled &&
+            megaeth_hardforks
+                .rex_5_time
+                .zip(megaeth_hardforks.rex_6_time)
+                .is_none_or(|(rex5, rex6)| rex5 > rex6)
+        {
+            panic!(
+                "genesis schedules Rex6 but Rex5 is missing or scheduled after it \
+                 (rex5Time={:?}, rex6Time={:?})",
+                megaeth_hardforks.rex_5_time, megaeth_hardforks.rex_6_time
+            );
+        }
+
         let mut megaeth_hardforks = megaeth_hardforks.into_vec();
 
         // Rex5 SequencerRegistry bootstrap, required iff `rex5Time` is scheduled. Parsed from
@@ -303,6 +324,29 @@ mod tests {
 
     use super::*;
 
+    /// Inserts a complete, valid Rex5 schedule (`rex5Time` plus both bootstrap seeds) into
+    /// `genesis`, so Rex6 fixtures can build on a well-formed ladder and exercise only the
+    /// Rex6 behavior their names describe.
+    fn schedule_valid_rex5(genesis: &mut Genesis, rex5_time: u64) {
+        genesis.config.extra_fields.insert_value("rex5Time".to_string(), rex5_time).unwrap();
+        genesis
+            .config
+            .extra_fields
+            .insert_value(
+                "rex5InitialSequencer".to_string(),
+                "0x0000000000000000000000000000000000000001",
+            )
+            .unwrap();
+        genesis
+            .config
+            .extra_fields
+            .insert_value(
+                "rex5InitialAdmin".to_string(),
+                "0x0000000000000000000000000000000000000002",
+            )
+            .unwrap();
+    }
+
     #[test]
     fn test_create_from_default_genesis() {
         let genesis = Genesis::default();
@@ -479,13 +523,14 @@ mod tests {
     #[test]
     fn test_chain_spec_carries_rex6_registry_as_fork_params() {
         let mut genesis = Genesis::default();
-        genesis.config.extra_fields.insert_value("rex6Time".to_string(), 0).unwrap();
+        schedule_valid_rex5(&mut genesis, 0);
+        genesis.config.extra_fields.insert_value("rex6Time".to_string(), 10).unwrap();
         genesis.config.extra_fields.insert_value("rex6MinRotationDelay".to_string(), 7200).unwrap();
         let spec = ChainSpec::from_genesis(genesis);
         let params =
             spec.fork_params::<SequencerRegistryRex6Config>().expect("Rex6 params present");
         assert_eq!(params.rex6_min_rotation_delay, 7200);
-        assert_eq!(spec.hardforks.fork(MegaHardfork::Rex6), ForkCondition::Timestamp(0));
+        assert_eq!(spec.hardforks.fork(MegaHardfork::Rex6), ForkCondition::Timestamp(10));
     }
 
     #[test]
@@ -509,6 +554,7 @@ mod tests {
     #[should_panic(expected = "malformed or missing SequencerRegistryRex6Config in genesis")]
     fn test_chain_spec_rex6_without_bootstrap_panics() {
         let mut genesis = Genesis::default();
+        schedule_valid_rex5(&mut genesis, 0);
         genesis.config.extra_fields.insert_value("rex6Time".to_string(), 0).unwrap();
         let _ = ChainSpec::from_genesis(genesis);
     }
@@ -517,6 +563,7 @@ mod tests {
     #[should_panic(expected = "malformed or missing SequencerRegistryRex6Config in genesis")]
     fn test_chain_spec_rex6_malformed_delay_panics() {
         let mut genesis = Genesis::default();
+        schedule_valid_rex5(&mut genesis, 0);
         genesis.config.extra_fields.insert_value("rex6Time".to_string(), 0).unwrap();
         genesis
             .config
@@ -530,31 +577,53 @@ mod tests {
     #[should_panic(expected = "invalid SequencerRegistryRex6Config")]
     fn test_chain_spec_rex6_zero_delay_panics() {
         let mut genesis = Genesis::default();
+        schedule_valid_rex5(&mut genesis, 0);
         genesis.config.extra_fields.insert_value("rex6Time".to_string(), 0).unwrap();
         genesis.config.extra_fields.insert_value("rex6MinRotationDelay".to_string(), 0).unwrap();
         let _ = ChainSpec::from_genesis(genesis);
     }
 
+    /// `from_genesis` must reject a genesis that schedules Rex6 without Rex5: Rex6 depends on
+    /// the SequencerRegistry deployed by the Rex5 activation, so the chain would stall at the
+    /// Rex6 activation block — this load-time check turns that into a fail-fast on node start.
+    #[test]
+    #[should_panic(expected = "genesis schedules Rex6 but Rex5 is missing or scheduled after it")]
+    fn test_chain_spec_rex6_without_rex5_panics() {
+        let mut genesis = Genesis::default();
+        genesis.config.extra_fields.insert_value("rex6Time".to_string(), 0).unwrap();
+        genesis.config.extra_fields.insert_value("rex6MinRotationDelay".to_string(), 7200).unwrap();
+        // Intentionally omit rex5Time (and the Rex5 bootstrap).
+        let _ = ChainSpec::from_genesis(genesis);
+    }
+
+    /// Rex5 scheduled after Rex6 is the same hazard as a missing Rex5 — Rex6 activates first
+    /// with no registry deployed — and must fail at load, not at the activation block.
+    #[test]
+    #[should_panic(expected = "genesis schedules Rex6 but Rex5 is missing or scheduled after it")]
+    fn test_chain_spec_rex5_after_rex6_panics() {
+        let mut genesis = Genesis::default();
+        schedule_valid_rex5(&mut genesis, 10);
+        genesis.config.extra_fields.insert_value("rex6Time".to_string(), 5).unwrap();
+        genesis.config.extra_fields.insert_value("rex6MinRotationDelay".to_string(), 7200).unwrap();
+        let _ = ChainSpec::from_genesis(genesis);
+    }
+
+    /// Rex5 and Rex6 at the same timestamp is a legal ladder — both forks activate together.
+    #[test]
+    fn test_chain_spec_rex5_and_rex6_at_same_timestamp_ok() {
+        let mut genesis = Genesis::default();
+        schedule_valid_rex5(&mut genesis, 5);
+        genesis.config.extra_fields.insert_value("rex6Time".to_string(), 5).unwrap();
+        genesis.config.extra_fields.insert_value("rex6MinRotationDelay".to_string(), 7200).unwrap();
+        let spec = ChainSpec::from_genesis(genesis);
+        assert!(spec.fork_params::<SequencerRegistryConfig>().is_some(), "Rex5 config loaded");
+        assert!(spec.fork_params::<SequencerRegistryRex6Config>().is_some(), "Rex6 config loaded");
+    }
+
     #[test]
     fn test_chain_spec_rex5_and_rex6_coexist_in_canonical_order() {
         let mut genesis = Genesis::default();
-        genesis.config.extra_fields.insert_value("rex5Time".to_string(), 100).unwrap();
-        genesis
-            .config
-            .extra_fields
-            .insert_value(
-                "rex5InitialSequencer".to_string(),
-                "0x0000000000000000000000000000000000000001",
-            )
-            .unwrap();
-        genesis
-            .config
-            .extra_fields
-            .insert_value(
-                "rex5InitialAdmin".to_string(),
-                "0x0000000000000000000000000000000000000002",
-            )
-            .unwrap();
+        schedule_valid_rex5(&mut genesis, 100);
         genesis.config.extra_fields.insert_value("rex6Time".to_string(), 200).unwrap();
         genesis.config.extra_fields.insert_value("rex6MinRotationDelay".to_string(), 7200).unwrap();
         let spec = ChainSpec::from_genesis(genesis);


### PR DESCRIPTION
## Summary
Mirrors megaeth-labs/mega-reth#2007 (as merged) for the stateless validator: wires the Rex6 hardfork (mega-evm v1.7.0) through `stateless-core`'s `ChainSpec`. Genesis extra fields `rex6Time` and `rex6MinRotationDelay` are parsed into `MegaHardfork::Rex6` scheduling plus `SequencerRegistryRex6Config`, served to mega-evm via `fork_params_any` for the pre-block SequencerRegistry v2.0.0 upgrade at activation.

`rex6MinRotationDelay` is conditionally required: scheduling Rex6 without it (or with a malformed/zero value) panics at genesis load instead of stalling at the activation block — the same fail-fast contract as the Rex5 bootstrap, and the same flat schema as mega-reth so a single genesis.json drives both binaries. Scheduling Rex6 also requires Rex5 at the same or an earlier timestamp: a partial ladder (Rex6 without Rex5, or Rex5 after it) is rejected at load, matching mega-reth's merged behavior exactly — Rex6 depends on the SequencerRegistry that the Rex5 activation deploys, and equal timestamps are legal (both forks activate together). `mega_mainnet_hardforks()` registers Rex6 after Rex5 in the canonical order; a genesis without `rex6Time` leaves Rex6 unscheduled, so existing chains are unaffected. mega-reth #2007's builder/dev-chain parts have no counterpart here — the validator always builds its spec from genesis.

## Testing
`cargo test -p stateless-core --lib chain_spec`: 22 tests, 12 new (extraction, fork-params round-trip, missing/malformed/zero-delay panics, delay-without-time ignored, ladder rejection for missing/late Rex5, same-timestamp acceptance, Rex5+Rex6 coexistence and canonical ordering). Full `cargo test --workspace`: 294 passed. no-std check + no-std test compile, `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features`, `cargo sort --check`: all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)