### PR TITLE
ci: use CI app identity for pr-review

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -70,14 +70,28 @@ jobs:
       id-token: write
       actions: read
     steps:
+      # Review under the CI app identity rather than the job token: it is what
+      # lets the action resolve stale review threads (the shared action gates
+      # --resolve-threads on github_identity_token being non-empty).
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          app-id: ${{ vars.CI_APP_ID }}
+          private-key: ${{ secrets.MEGA_CI_APP_PK }}
+          owner: megaeth-labs
+          repositories: stateless-validator
+
       - uses: actions/checkout@v4
         with:
+          token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: false
           submodules: recursive
           fetch-depth: 1
 
       - uses: megaeth-labs/documentation/.github/actions/claude-pr-review@main
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_identity_token: ${{ steps.app-token.outputs.token }}
           allowed_bots: "mega-putin"
 
   label-check:


### PR DESCRIPTION
## Summary

- Mint a `megaeth-labs` CI app installation token in the `pr-review` job and pass it to the shared `claude-pr-review` action as `github_identity_token`, matching the pattern already used in `mega-e2e`.
- Use the same token for `actions/checkout` with `persist-credentials: false`, so the credential is used for the clone only and is not left in the git config.

Until now this repo passed no identity token, so the shared action fell back to the default job token. That has two consequences it fixes:

- Reviews were published by `github-actions[bot]` instead of the CI app.
- Stale review threads were never resolved — the action gates thread resolution on the identity token being non-empty (`--resolve-threads "${{ inputs.github_identity_token != '' }}"`), so it was permanently disabled here.

The app token is scoped to `repositories: stateless-validator` only.

## Prerequisite

The CI app was recently installed on this repo, which is what makes this possible. Two org-level settings must also allow it, otherwise the `Create token` step fails immediately with a JWT decode error:

- `vars.CI_APP_ID` and `secrets.MEGA_CI_APP_PK` must be readable from this repository.
- This repo is **public**, unlike the other consumers of this app (`mega-e2e`, `mega-reth`, both private). If the org secret visibility is set to "Private repositories", it cannot be read here.

## Test plan

- CI on this PR exercises the changed job directly: the `pr-review` job must complete the `Create token` step and publish its review as the CI app rather than `github-actions[bot]`.
- On a follow-up push, confirm review threads from the previous round are auto-resolved.
- If the `Create token` step fails, the org secret/variable visibility above is the cause, and the job can be reverted to the default token without affecting anything else.

## Follow-up (not in this PR)

Three comments in `mega-e2e` still assert that the CI app is not installed on this repo and route around it with the default token — `publish-devnet-images.yml` (lines ~95 and ~265-270) and `bump-component-pins.yml` (line ~48). Those code paths still work since this repo is public; only the comments are now stale.