### PR TITLE
ci: let PR comments trigger a Claude review reconcile round

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -54,14 +54,17 @@ jobs:
     # rather than cancelling it, so a partial run never leaves comments/threads
     # in an inconsistent state.
     concurrency:
-      group: claude-pr-review-${{ github.event.pull_request.number }}
+      group: claude-pr-review-${{ github.event.pull_request.number || github.event.issue.number }}
       cancel-in-progress: false
     if: |
-      github.event_name == 'pull_request' &&
-      (github.event.action == 'opened' ||
-       github.event.action == 'synchronize' ||
-       github.event.action == 'ready_for_review' ||
-       github.event.action == 'reopened')
+      (github.event_name == 'pull_request' &&
+       (github.event.action == 'opened' ||
+        github.event.action == 'synchronize' ||
+        github.event.action == 'ready_for_review' ||
+        github.event.action == 'reopened')) ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request != null &&
+       github.event.comment.user.login != 'mega-maxwell[bot]')
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     permissions:
@@ -83,6 +86,7 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
+          ref: ${{ github.event_name == 'issue_comment' && format('refs/pull/{0}/head', github.event.issue.number) || '' }}
           token: ${{ steps.app-token.outputs.token }}
           persist-credentials: false
           submodules: recursive


### PR DESCRIPTION
## Summary

Extends the Claude **pr-review** job in `.github/workflows/claude.yml` to support `issue_comment`-triggered reconciliation of open review questions/findings, using the shared `claude-pr-review` action's new support for this (see megaeth-labs/.github#8).

The `on:` block already delivers `issue_comment: [created]`; this change wires those events into the pr-review job. Three changes, everything else preserved:

1. **`if:`** — the existing `pull_request` condition is kept verbatim (wrapped in parens) and OR'd with an `issue_comment` branch that only fires on PR comments and skips the bot's own comments (`mega-maxwell[bot]`).
2. **Concurrency group** — falls back to `github.event.issue.number` when `github.event.pull_request.number` is absent (comment events), so a comment-triggered run serializes against the same PR.
3. **Checkout** — checks out `refs/pull/<n>/head` when triggered by a comment, so the review runs against the PR head.

No other job and the `on:` block are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)