### PR TITLE
perf(debug-trace-server): serve cache hits as raw JSON bytes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,6 +107,7 @@ Two operating modes:
 - **Local cache mode** — With `data_dir`, enables chain sync to pre-fetch blocks into `ValidatorDB` for faster serving.
 
 The server includes an HTTP response cache (`quick_cache`) for pre-serialized JSON and a `DataProvider` with single-flight request coalescing.
+Responses are serialized exactly once, straight from the trace output into raw JSON bytes (`RawJson`) spliced verbatim into the reply; the cache shares those bytes by `Arc`, so a hit never re-parses or re-serializes the JSON tree.
 The response cache is keyed by `(resource, block hash, typed tracer variant)`; by-number handlers resolve number → canonical hash before the lookup (local `CANONICAL_CHAIN` first, upstream fallback).
 It only stores idempotent request shapes: the five built-in tracers (keyed by their parsed typed `tracerConfig`) and the bare default struct-logger request; JS tracers, `muxTracer`, and struct-logger requests with non-default flags bypass it entirely, and a type-malformed `tracerConfig` on call/prestate/flatCall is rejected with `-32602`.
 Canonical-hash resolution reads the bounded `CANONICAL_CHAIN` window first (local cache mode), then a bounded in-memory memo of upstream-resolved bindings (`--canonical-hash-memo-capacity`; only depth-final heights are memoized, so a memoized binding can no longer reorg), and only then upstream — so historical heights resolve locally after first touch within a process lifetime.

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Two operating modes:
 
 **Response cache:**
 The HTTP response cache is keyed by `(resource, block hash, tracer variant)` — an entry is an immutable fact about that exact block, so reorgs need no serve-time validation.
+Entries hold the reply's raw JSON bytes, serialized exactly once from the trace output and spliced verbatim into every response — a hit shares the bytes by `Arc` instead of re-parsing and re-serializing the JSON tree.
 By-number requests resolve their canonical hash before the lookup (local index, then an in-memory memo, then upstream `eth_getHeaderByNumber`), so a reorged height resolves to the new hash and misses cleanly.
 Cacheable shapes are the five built-in tracers (`callTracer`, `prestateTracer`, `4byteTracer`, `noopTracer`, `flatCallTracer`, keyed by their parsed, typed `tracerConfig` — equivalent configs collapse onto one entry) and the bare default struct-logger request (no tracer, no `tracerConfig`, default flags).
 JS tracers, `muxTracer`, and struct-logger requests with non-default flags bypass the cache and are recomputed on every request.

--- a/bin/debug-trace-server/Cargo.toml
+++ b/bin/debug-trace-server/Cargo.toml
@@ -50,7 +50,7 @@ quick_cache.workspace = true
 rayon.workspace = true
 redb.workspace = true
 serde.workspace = true
-serde_json.workspace = true
+serde_json = { workspace = true, features = ["raw_value"] }
 thiserror.workspace = true
 tokio = { workspace = true, features = ["sync"] }
 tokio-util.workspace = true

--- a/bin/debug-trace-server/src/chain_sync.rs
+++ b/bin/debug-trace-server/src/chain_sync.rs
@@ -548,7 +548,9 @@ mod tests {
     /// hash before the lookup.
     #[test]
     fn reorg_invalidates_hash_keyed_entries() {
-        use crate::response_cache::{CachedResource, ResponseCacheConfig, ResponseVariant};
+        use crate::response_cache::{
+            CachedResource, RawJson, ResponseCacheConfig, ResponseVariant,
+        };
 
         let cache = ResponseCache::new(ResponseCacheConfig::new(1_000_000, 100));
         let h1 = B256::from([1u8; 32]);
@@ -558,8 +560,9 @@ mod tests {
             (CachedResource::TraceBlock, h1),
             (CachedResource::DebugTraceBlock, h2),
         ];
+        let response = RawJson::from_value(&serde_json::json!({"v": 1}));
         for (resource, hash) in entries {
-            cache.insert(resource, hash, ResponseVariant::Default, &serde_json::json!({"v": 1}));
+            cache.insert(resource, hash, ResponseVariant::Default, &response);
         }
 
         let hooks =

--- a/bin/debug-trace-server/src/chain_sync.rs
+++ b/bin/debug-trace-server/src/chain_sync.rs
@@ -548,8 +548,9 @@ mod tests {
     /// hash before the lookup.
     #[test]
     fn reorg_invalidates_hash_keyed_entries() {
-        use crate::response_cache::{
-            CachedResource, RawJson, ResponseCacheConfig, ResponseVariant,
+        use crate::{
+            raw_json::RawJson,
+            response_cache::{CachedResource, ResponseCacheConfig, ResponseVariant},
         };
 
         let cache = ResponseCache::new(ResponseCacheConfig::new(1_000_000, 100));
@@ -560,7 +561,7 @@ mod tests {
             (CachedResource::TraceBlock, h1),
             (CachedResource::DebugTraceBlock, h2),
         ];
-        let response = RawJson::from_value(&serde_json::json!({"v": 1}));
+        let response = RawJson::try_new(&serde_json::json!({"v": 1})).expect("serialize");
         for (resource, hash) in entries {
             cache.insert(resource, hash, ResponseVariant::Default, &response);
         }

--- a/bin/debug-trace-server/src/main.rs
+++ b/bin/debug-trace-server/src/main.rs
@@ -68,6 +68,7 @@ mod block_data_cache;
 mod chain_sync;
 mod data_provider;
 mod metrics;
+mod raw_json;
 mod response_cache;
 mod response_size;
 mod rpc_service;

--- a/bin/debug-trace-server/src/raw_json.rs
+++ b/bin/debug-trace-server/src/raw_json.rs
@@ -1,0 +1,77 @@
+//! [`RawJson`] — the pre-serialized reply body shared by every trace handler.
+
+use std::sync::{Arc, LazyLock};
+
+use serde_json::value::RawValue;
+
+/// A pre-serialized JSON response body: the reply type of every trace handler and the
+/// value the response cache stores. Its `Serialize` impl splices the bytes verbatim (the
+/// [`RawValue`] mechanism), so serving one — fresh or cached — never rebuilds or
+/// re-serializes the JSON tree: [`RawJson::try_new`] is the single fill-path
+/// serialization, and cloning shares the bytes without copying them.
+///
+/// The `Box` inside the `Arc` is deliberate: it adopts the serializer's allocation as-is.
+/// `Arc<RawValue>` (an unsized pointee) cannot, so building one would memcpy the whole
+/// body next to a fresh refcount — a second full-body copy on every fill.
+#[derive(Debug, Clone)]
+pub struct RawJson(Arc<Box<RawValue>>);
+
+impl RawJson {
+    /// Serializes a value into its `RawJson` reply body — the one serialization a
+    /// response undergoes.
+    pub fn try_new<T: serde::Serialize + ?Sized>(value: &T) -> serde_json::Result<Self> {
+        serde_json::value::to_raw_value(value).map(|raw| Self(Arc::new(raw)))
+    }
+
+    /// The serialized length in bytes.
+    pub fn byte_len(&self) -> usize {
+        self.0.get().len()
+    }
+
+    /// The JSON literal `null`.
+    pub fn null() -> Self {
+        static NULL: LazyLock<RawJson> =
+            LazyLock::new(|| RawJson(Arc::new(RawValue::NULL.to_owned())));
+        NULL.clone()
+    }
+
+    /// The raw serialized JSON.
+    #[cfg(test)]
+    pub fn as_str(&self) -> &str {
+        self.0.get()
+    }
+
+    /// Whether two handles share the same underlying bytes (a hit is an `Arc` clone).
+    #[cfg(test)]
+    pub fn shares_bytes_with(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.0, &other.0)
+    }
+}
+
+impl serde::Serialize for RawJson {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        // Delegate to the pointee explicitly — `Arc<T>` itself is only `Serialize`
+        // behind serde's optional `rc` feature.
+        self.0.as_ref().serialize(serializer)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    /// The property the whole design rests on: serializing a [`RawJson`] (what jsonrpsee
+    /// does to build the reply) emits the stored bytes verbatim — no re-parse, no
+    /// normalization, byte-for-byte what the fill request serialized.
+    #[test]
+    fn raw_json_serializes_verbatim() {
+        let value = json!({"key": "value", "nested": [1, 2, {"deep": null}]});
+        let raw = RawJson::try_new(&value).expect("serialize");
+        assert_eq!(raw.byte_len(), raw.as_str().len());
+        assert_eq!(serde_json::to_string(&raw).expect("splice"), raw.as_str());
+        assert_eq!(serde_json::to_string(&raw).expect("splice"), value.to_string());
+        assert_eq!(serde_json::to_string(&RawJson::null()).expect("splice"), "null");
+    }
+}

--- a/bin/debug-trace-server/src/response_cache.rs
+++ b/bin/debug-trace-server/src/response_cache.rs
@@ -1,6 +1,9 @@
 //! HTTP RPC Response Cache
 //!
 //! Caches pre-serialized JSON responses for the block-level trace methods.
+//! Entries are [`RawJson`] — the exact bytes produced by the fill request's one
+//! serialization — and a hit is an `Arc` clone spliced verbatim into the reply, so the
+//! JSON tree is never re-parsed or re-serialized on either side of the cache.
 //!
 //! # Design
 //!
@@ -31,6 +34,7 @@ use alloy_rpc_types_trace::geth::{
     GethDefaultTracingOptions, PreStateConfig,
 };
 use quick_cache::{Lifecycle, Weighter, sync::Cache};
+use serde_json::value::RawValue;
 use tracing::debug;
 
 use crate::metrics::{CACHE_TYPE_DEBUG_TRACE, CACHE_TYPE_TRACE, CacheMetrics, CacheStats};
@@ -285,33 +289,55 @@ impl ResponseCacheKey {
     }
 }
 
-// Cached Response
-/// A cached JSON response entry.
+// Raw JSON
+/// A pre-serialized JSON response body, shared between the cache and the jsonrpsee reply
+/// path. Its `Serialize` impl splices the bytes verbatim (the [`RawValue`] mechanism), so
+/// serving one — fresh or cached — never rebuilds or re-serializes the JSON tree; the
+/// bytes are produced by exactly one serialization on the fill path
+/// (`serde_json::value::to_raw_value`, which also never re-validates its own output).
 #[derive(Debug, Clone)]
-pub struct CachedResponse {
-    /// Pre-serialized JSON result.
-    json: Arc<str>,
-    /// Cached byte length for efficient weight calculation.
-    byte_len: usize,
+pub struct RawJson(Arc<RawValue>);
+
+impl RawJson {
+    /// The serialized length in bytes.
+    pub fn byte_len(&self) -> usize {
+        self.0.get().len()
+    }
+
+    /// The JSON literal `null` (the not-found reply of `trace_transaction`).
+    pub fn null() -> Self {
+        RawValue::from_string("null".to_owned()).expect("null is valid JSON").into()
+    }
+
+    /// The raw serialized JSON.
+    #[cfg(test)]
+    pub fn as_str(&self) -> &str {
+        self.0.get()
+    }
+
+    /// Serializes a JSON tree into a `RawJson` — test fixtures only; production
+    /// responses are serialized once, straight from the trace output.
+    #[cfg(test)]
+    pub fn from_value(value: &serde_json::Value) -> Self {
+        serde_json::value::to_raw_value(value).expect("Value serialization cannot fail").into()
+    }
+
+    /// Whether two handles share the same underlying bytes (a hit is an `Arc` clone).
+    #[cfg(test)]
+    pub fn shares_bytes_with(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.0, &other.0)
+    }
 }
 
-impl CachedResponse {
-    /// Creates a new cached response by serializing the JSON value (no clone of the tree).
-    pub fn new(value: &serde_json::Value) -> Self {
-        let json = serde_json::to_string(value).unwrap_or_default();
-        let byte_len = json.len();
-        Self { json: json.into(), byte_len }
+impl From<Box<RawValue>> for RawJson {
+    fn from(raw: Box<RawValue>) -> Self {
+        Self(raw.into())
     }
+}
 
-    /// Returns the JSON value.
-    pub fn as_value(&self) -> serde_json::Value {
-        serde_json::from_str(&self.json).unwrap_or(serde_json::Value::Null)
-    }
-
-    /// Returns the byte length of the cached JSON.
-    #[cfg(test)]
-    pub const fn byte_len(&self) -> usize {
-        self.byte_len
+impl serde::Serialize for RawJson {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.0.serialize(serializer)
     }
 }
 
@@ -320,10 +346,10 @@ impl CachedResponse {
 #[derive(Debug, Clone, Default)]
 pub struct ResponseCacheWeighter;
 
-impl Weighter<ResponseCacheKey, CachedResponse> for ResponseCacheWeighter {
-    fn weight(&self, _key: &ResponseCacheKey, val: &CachedResponse) -> u64 {
+impl Weighter<ResponseCacheKey, RawJson> for ResponseCacheWeighter {
+    fn weight(&self, _key: &ResponseCacheKey, val: &RawJson) -> u64 {
         const ENTRY_OVERHEAD: u64 = 128;
-        ENTRY_OVERHEAD + val.byte_len as u64
+        ENTRY_OVERHEAD + val.byte_len() as u64
     }
 }
 
@@ -372,12 +398,12 @@ struct EvictionCleanupLifecycle {
     index: Arc<HashIndex>,
 }
 
-impl Lifecycle<ResponseCacheKey, CachedResponse> for EvictionCleanupLifecycle {
+impl Lifecycle<ResponseCacheKey, RawJson> for EvictionCleanupLifecycle {
     type RequestState = ();
 
     fn begin_request(&self) -> Self::RequestState {}
 
-    fn on_evict(&self, _state: &mut (), key: ResponseCacheKey, _val: CachedResponse) {
+    fn on_evict(&self, _state: &mut (), key: ResponseCacheKey, _val: RawJson) {
         self.index.remove_key(&key);
     }
 }
@@ -392,7 +418,7 @@ pub struct ResponseCache {
 struct ResponseCacheInner {
     cache: Cache<
         ResponseCacheKey,
-        CachedResponse,
+        RawJson,
         ResponseCacheWeighter,
         RandomState,
         EvictionCleanupLifecycle,
@@ -452,13 +478,14 @@ impl ResponseCache {
         }
     }
 
-    /// Retrieves a cached response for the exact block hash, recording hit/miss accounting.
+    /// Retrieves a cached response for the exact block hash, recording hit/miss
+    /// accounting. A hit is an `Arc` clone of the stored bytes — no parsing, no copy.
     pub fn get(
         &self,
         resource: CachedResource,
         block_hash: B256,
         variant: ResponseVariant,
-    ) -> Option<serde_json::Value> {
+    ) -> Option<RawJson> {
         let key = ResponseCacheKey::new(resource, block_hash, variant);
         let result = self.inner.cache.get(&key);
         let metrics = self.metrics_for_resource(resource);
@@ -469,12 +496,11 @@ impl ResponseCache {
             self.inner.misses.fetch_add(1, Ordering::Relaxed);
             metrics.record_miss();
         }
-        result.map(|r| r.as_value())
+        result
     }
 
-    /// Inserts a response computed for the exact block hash. Takes the response by
-    /// reference: serialization reads it in place, so multi-MB trace responses are never
-    /// deep-cloned on the fill path.
+    /// Inserts a response computed for the exact block hash, sharing the reply's
+    /// already-serialized bytes (an `Arc` clone — nothing is re-serialized or copied).
     ///
     /// The index is registered *before* the cache write: if `quick_cache` immediately
     /// weight-evicts the just-inserted key, `on_evict -> remove_key` then self-heals the
@@ -488,11 +514,11 @@ impl ResponseCache {
         resource: CachedResource,
         block_hash: B256,
         variant: ResponseVariant,
-        response: &serde_json::Value,
+        response: &RawJson,
     ) {
         let key = ResponseCacheKey::new(resource, block_hash, variant);
         self.inner.index.insert(key);
-        self.inner.cache.insert(key, CachedResponse::new(response));
+        self.inner.cache.insert(key, response.clone());
         self.update_size_metrics();
     }
 
@@ -816,7 +842,7 @@ mod tests {
     fn test_cache_insert_and_get() {
         let cache = ResponseCache::new(ResponseCacheConfig::new(1_000_000, 100));
         let hash = B256::from([1u8; 32]);
-        let value = json!([{"txHash": "0x01", "result": {}}]);
+        let value = RawJson::from_value(&json!([{"txHash": "0x01", "result": {}}]));
         assert!(cache.is_empty());
         assert_eq!((cache.len(), cache.weight()), (0, 0));
 
@@ -824,9 +850,12 @@ mod tests {
             cache.get(CachedResource::DebugTraceBlock, hash, ResponseVariant::Default).is_none()
         );
         cache.insert(CachedResource::DebugTraceBlock, hash, ResponseVariant::Default, &value);
-        assert_eq!(
-            cache.get(CachedResource::DebugTraceBlock, hash, ResponseVariant::Default),
-            Some(value)
+        let hit = cache
+            .get(CachedResource::DebugTraceBlock, hash, ResponseVariant::Default)
+            .expect("inserted entry must hit");
+        assert!(
+            hit.shares_bytes_with(&value),
+            "a hit must be an Arc clone of the inserted bytes, not a copy"
         );
 
         assert!(!cache.is_empty());
@@ -847,17 +876,30 @@ mod tests {
             CachedResource::DebugTraceBlock,
             h1,
             ResponseVariant::Default,
-            &json!({"v": 1}),
+            &RawJson::from_value(&json!({"v": 1})),
         );
-        cache.insert(CachedResource::TraceBlock, h1, ResponseVariant::Default, &json!({"v": 2}));
-        cache.insert(CachedResource::DebugTraceBlock, h2, call, &json!({"v": 3}));
+        cache.insert(
+            CachedResource::TraceBlock,
+            h1,
+            ResponseVariant::Default,
+            &RawJson::from_value(&json!({"v": 2})),
+        );
+        cache.insert(
+            CachedResource::DebugTraceBlock,
+            h2,
+            call,
+            &RawJson::from_value(&json!({"v": 3})),
+        );
         assert_eq!(cache.len(), 3);
 
         // Every variant cached for the reverted hash goes; other hashes survive.
         cache.invalidate_blocks(&[h1]);
         assert!(cache.get(CachedResource::DebugTraceBlock, h1, ResponseVariant::Default).is_none());
         assert!(cache.get(CachedResource::TraceBlock, h1, ResponseVariant::Default).is_none());
-        assert_eq!(cache.get(CachedResource::DebugTraceBlock, h2, call), Some(json!({"v": 3})));
+        assert_eq!(
+            cache.get(CachedResource::DebugTraceBlock, h2, call).map(|r| r.as_str().to_owned()),
+            Some(r#"{"v":3}"#.to_owned())
+        );
         assert_eq!(cache.len(), 1);
 
         cache.invalidate_all();
@@ -872,22 +914,21 @@ mod tests {
         let call = ResponseVariant::CallTracer(CallConfigKey::default());
         let prestate = ResponseVariant::PrestateTracer(PreStateConfigKey::default());
 
-        cache.insert(CachedResource::DebugTraceBlock, hash, call, &json!({"tracer": "call"}));
-        cache.insert(
-            CachedResource::DebugTraceBlock,
-            hash,
-            prestate,
-            &json!({"tracer": "prestate"}),
-        );
+        let call_response = RawJson::from_value(&json!({"tracer": "call"}));
+        let prestate_response = RawJson::from_value(&json!({"tracer": "prestate"}));
+        cache.insert(CachedResource::DebugTraceBlock, hash, call, &call_response);
+        cache.insert(CachedResource::DebugTraceBlock, hash, prestate, &prestate_response);
 
         assert_eq!(cache.len(), 2);
-        assert_eq!(
-            cache.get(CachedResource::DebugTraceBlock, hash, call),
-            Some(json!({"tracer": "call"}))
+        assert!(
+            cache
+                .get(CachedResource::DebugTraceBlock, hash, call)
+                .is_some_and(|r| r.shares_bytes_with(&call_response))
         );
-        assert_eq!(
-            cache.get(CachedResource::DebugTraceBlock, hash, prestate),
-            Some(json!({"tracer": "prestate"}))
+        assert!(
+            cache
+                .get(CachedResource::DebugTraceBlock, hash, prestate)
+                .is_some_and(|r| r.shares_bytes_with(&prestate_response))
         );
     }
 
@@ -896,8 +937,8 @@ mod tests {
     #[test]
     fn eviction_cleans_hash_index() {
         // Budget fits roughly one entry; inserting more forces evictions.
-        let payload = json!({"data": "x".repeat(512)});
-        let one_weight = 128 + CachedResponse::new(&payload).byte_len() as u64;
+        let payload = RawJson::from_value(&json!({"data": "x".repeat(512)}));
+        let one_weight = 128 + payload.byte_len() as u64;
         let cache = ResponseCache::new(ResponseCacheConfig::new(one_weight * 3 / 2, 4));
 
         let hashes: Vec<B256> = (1..=4u8).map(|i| B256::from([i; 32])).collect();
@@ -937,11 +978,16 @@ mod tests {
         assert!((empty.hit_rate() - 0.0).abs() < f64::EPSILON);
     }
 
+    /// The property the whole design rests on: serializing a [`RawJson`] (what jsonrpsee
+    /// does to build the reply) emits the stored bytes verbatim — no re-parse, no
+    /// normalization, byte-for-byte what the fill request serialized.
     #[test]
-    fn test_cached_response() {
-        let value = json!({"key": "value"});
-        let cached = CachedResponse::new(&value);
-        assert!(cached.byte_len() > 0);
-        assert_eq!(cached.as_value(), value);
+    fn raw_json_serializes_verbatim() {
+        let value = json!({"key": "value", "nested": [1, 2, {"deep": null}]});
+        let raw = RawJson::from_value(&value);
+        assert_eq!(raw.byte_len(), raw.as_str().len());
+        assert_eq!(serde_json::to_string(&raw).expect("splice"), raw.as_str());
+        assert_eq!(serde_json::to_string(&raw).expect("splice"), value.to_string());
+        assert_eq!(serde_json::to_string(&RawJson::null()).expect("splice"), "null");
     }
 }

--- a/bin/debug-trace-server/src/response_cache.rs
+++ b/bin/debug-trace-server/src/response_cache.rs
@@ -34,10 +34,12 @@ use alloy_rpc_types_trace::geth::{
     GethDefaultTracingOptions, PreStateConfig,
 };
 use quick_cache::{Lifecycle, Weighter, sync::Cache};
-use serde_json::value::RawValue;
 use tracing::debug;
 
-use crate::metrics::{CACHE_TYPE_DEBUG_TRACE, CACHE_TYPE_TRACE, CacheMetrics, CacheStats};
+use crate::{
+    metrics::{CACHE_TYPE_DEBUG_TRACE, CACHE_TYPE_TRACE, CacheMetrics, CacheStats},
+    raw_json::RawJson,
+};
 
 // Configuration
 /// Default maximum memory for the response cache (1 GB).
@@ -286,60 +288,6 @@ impl ResponseCacheKey {
     /// Creates a new cache key.
     pub const fn new(resource: CachedResource, block_hash: B256, variant: ResponseVariant) -> Self {
         Self { resource, block_hash, variant }
-    }
-}
-
-// Raw JSON
-/// A pre-serialized JSON response body, shared between the cache and the jsonrpsee reply
-/// path. Its `Serialize` impl splices the bytes verbatim (the [`RawValue`] mechanism), so
-/// serving one — fresh or cached — never rebuilds or re-serializes the JSON tree; the
-/// bytes are produced by exactly one serialization on the fill path
-/// (`serde_json::value::to_raw_value`, which also never re-validates its own output).
-#[derive(Debug, Clone)]
-pub struct RawJson(Arc<RawValue>);
-
-impl RawJson {
-    /// The serialized length in bytes.
-    pub fn byte_len(&self) -> usize {
-        self.0.get().len()
-    }
-
-    /// The JSON literal `null` (the not-found reply of `trace_transaction`).
-    pub fn null() -> Self {
-        RawValue::from_string("null".to_owned()).expect("null is valid JSON").into()
-    }
-
-    /// The raw serialized JSON.
-    #[cfg(test)]
-    pub fn as_str(&self) -> &str {
-        self.0.get()
-    }
-
-    /// Serializes a JSON tree into a `RawJson` — test fixtures only; production
-    /// responses are serialized once, straight from the trace output.
-    #[cfg(test)]
-    pub fn from_value(value: &serde_json::Value) -> Self {
-        serde_json::value::to_raw_value(value).expect("Value serialization cannot fail").into()
-    }
-
-    /// Whether two handles share the same underlying bytes (a hit is an `Arc` clone).
-    #[cfg(test)]
-    pub fn shares_bytes_with(&self, other: &Self) -> bool {
-        Arc::ptr_eq(&self.0, &other.0)
-    }
-}
-
-impl From<Box<RawValue>> for RawJson {
-    fn from(raw: Box<RawValue>) -> Self {
-        Self(raw.into())
-    }
-}
-
-impl serde::Serialize for RawJson {
-    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        // Delegate to the `RawValue` pointee explicitly — `Arc<T>` itself is only
-        // `Serialize` behind serde's optional `rc` feature.
-        self.0.as_ref().serialize(serializer)
     }
 }
 
@@ -844,7 +792,8 @@ mod tests {
     fn test_cache_insert_and_get() {
         let cache = ResponseCache::new(ResponseCacheConfig::new(1_000_000, 100));
         let hash = B256::from([1u8; 32]);
-        let value = RawJson::from_value(&json!([{"txHash": "0x01", "result": {}}]));
+        let value =
+            RawJson::try_new(&json!([{"txHash": "0x01", "result": {}}])).expect("serialize");
         assert!(cache.is_empty());
         assert_eq!((cache.len(), cache.weight()), (0, 0));
 
@@ -878,19 +827,19 @@ mod tests {
             CachedResource::DebugTraceBlock,
             h1,
             ResponseVariant::Default,
-            &RawJson::from_value(&json!({"v": 1})),
+            &RawJson::try_new(&json!({"v": 1})).expect("serialize"),
         );
         cache.insert(
             CachedResource::TraceBlock,
             h1,
             ResponseVariant::Default,
-            &RawJson::from_value(&json!({"v": 2})),
+            &RawJson::try_new(&json!({"v": 2})).expect("serialize"),
         );
         cache.insert(
             CachedResource::DebugTraceBlock,
             h2,
             call,
-            &RawJson::from_value(&json!({"v": 3})),
+            &RawJson::try_new(&json!({"v": 3})).expect("serialize"),
         );
         assert_eq!(cache.len(), 3);
 
@@ -916,8 +865,9 @@ mod tests {
         let call = ResponseVariant::CallTracer(CallConfigKey::default());
         let prestate = ResponseVariant::PrestateTracer(PreStateConfigKey::default());
 
-        let call_response = RawJson::from_value(&json!({"tracer": "call"}));
-        let prestate_response = RawJson::from_value(&json!({"tracer": "prestate"}));
+        let call_response = RawJson::try_new(&json!({"tracer": "call"})).expect("serialize");
+        let prestate_response =
+            RawJson::try_new(&json!({"tracer": "prestate"})).expect("serialize");
         cache.insert(CachedResource::DebugTraceBlock, hash, call, &call_response);
         cache.insert(CachedResource::DebugTraceBlock, hash, prestate, &prestate_response);
 
@@ -939,7 +889,7 @@ mod tests {
     #[test]
     fn eviction_cleans_hash_index() {
         // Budget fits roughly one entry; inserting more forces evictions.
-        let payload = RawJson::from_value(&json!({"data": "x".repeat(512)}));
+        let payload = RawJson::try_new(&json!({"data": "x".repeat(512)})).expect("serialize");
         let one_weight = 128 + payload.byte_len() as u64;
         let cache = ResponseCache::new(ResponseCacheConfig::new(one_weight * 3 / 2, 4));
 
@@ -978,18 +928,5 @@ mod tests {
         assert!((stats.hit_rate() - 80.0).abs() < f64::EPSILON);
         let empty = CacheStats { entry_count: 0, total_bytes: 0, hits: 0, misses: 0 };
         assert!((empty.hit_rate() - 0.0).abs() < f64::EPSILON);
-    }
-
-    /// The property the whole design rests on: serializing a [`RawJson`] (what jsonrpsee
-    /// does to build the reply) emits the stored bytes verbatim — no re-parse, no
-    /// normalization, byte-for-byte what the fill request serialized.
-    #[test]
-    fn raw_json_serializes_verbatim() {
-        let value = json!({"key": "value", "nested": [1, 2, {"deep": null}]});
-        let raw = RawJson::from_value(&value);
-        assert_eq!(raw.byte_len(), raw.as_str().len());
-        assert_eq!(serde_json::to_string(&raw).expect("splice"), raw.as_str());
-        assert_eq!(serde_json::to_string(&raw).expect("splice"), value.to_string());
-        assert_eq!(serde_json::to_string(&RawJson::null()).expect("splice"), "null");
     }
 }

--- a/bin/debug-trace-server/src/response_cache.rs
+++ b/bin/debug-trace-server/src/response_cache.rs
@@ -337,7 +337,9 @@ impl From<Box<RawValue>> for RawJson {
 
 impl serde::Serialize for RawJson {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        self.0.serialize(serializer)
+        // Delegate to the `RawValue` pointee explicitly — `Arc<T>` itself is only
+        // `Serialize` behind serde's optional `rc` feature.
+        self.0.as_ref().serialize(serializer)
     }
 }
 

--- a/bin/debug-trace-server/src/rpc_service.rs
+++ b/bin/debug-trace-server/src/rpc_service.rs
@@ -27,7 +27,7 @@ use crate::{
         METHOD_DEBUG_TRACE_TRANSACTION, METHOD_TRACE_BLOCK, METHOD_TRACE_TRANSACTION,
         ResponseSizeMetrics, RpcGlobalMetrics, SingleFlightMetrics,
     },
-    response_cache::{CachedResource, RequestShape, ResponseCache, ResponseVariant},
+    response_cache::{CachedResource, RawJson, RequestShape, ResponseCache, ResponseVariant},
     tracing_executor::TraceError,
 };
 
@@ -44,7 +44,7 @@ pub trait DebugTraceRpc {
         &self,
         block_number: BlockNumberOrTag,
         opts: Option<GethDebugTracingOptions>,
-    ) -> RpcResult<serde_json::Value>;
+    ) -> RpcResult<RawJson>;
 
     /// Trace block execution by block hash.
     #[method(name = "traceBlockByHash")]
@@ -52,7 +52,7 @@ pub trait DebugTraceRpc {
         &self,
         block_hash: B256,
         opts: Option<GethDebugTracingOptions>,
-    ) -> RpcResult<serde_json::Value>;
+    ) -> RpcResult<RawJson>;
 
     /// Trace a single transaction execution.
     #[method(name = "traceTransaction")]
@@ -60,7 +60,7 @@ pub trait DebugTraceRpc {
         &self,
         tx_hash: B256,
         opts: Option<GethDebugTracingOptions>,
-    ) -> RpcResult<serde_json::Value>;
+    ) -> RpcResult<RawJson>;
 
     /// Query current response cache status.
     #[method(name = "getCacheStatus")]
@@ -72,12 +72,12 @@ pub trait DebugTraceRpc {
 pub trait TraceRpc {
     /// Parity-style block tracing (flat call traces).
     #[method(name = "block")]
-    async fn trace_block(&self, block_number: BlockNumberOrTag) -> RpcResult<serde_json::Value>;
+    async fn trace_block(&self, block_number: BlockNumberOrTag) -> RpcResult<RawJson>;
 
     /// Parity-style transaction tracing.
     /// Returns null (not error) when transaction is not found, matching mega-reth behavior.
     #[method(name = "transaction")]
-    async fn trace_parity_transaction(&self, tx_hash: B256) -> RpcResult<serde_json::Value>;
+    async fn trace_parity_transaction(&self, tx_hash: B256) -> RpcResult<RawJson>;
 }
 
 // RPC Watch Dog
@@ -224,7 +224,7 @@ impl RpcContext {
     /// *before* the cache lookup, all on one request deadline; on a miss, fetch block data
     /// by the resolved hash on the remaining budget. Slow prelude stages are warned about
     /// here, where they are measured; trace/serialize timing lives in
-    /// [`compute_block_trace`] and cache-insert timing in [`insert_cache`].
+    /// [`compute_block_trace`].
     async fn lookup_block_by_number(
         &self,
         method: &'static str,
@@ -293,7 +293,7 @@ impl RpcContext {
         data: &BlockData,
         method: &'static str,
         opts: GethDebugTracingOptions,
-    ) -> Result<serde_json::Value, jsonrpsee::types::ErrorObjectOwned> {
+    ) -> Result<RawJson, jsonrpsee::types::ErrorObjectOwned> {
         compute_block_trace(data, method, || {
             crate::tracing_executor::trace_block(
                 &self.chain_spec,
@@ -310,7 +310,7 @@ impl RpcContext {
 /// Outcome of [`RpcContext::lookup_block_by_number`].
 enum BlockLookup {
     /// Served straight from the response cache.
-    Cached(serde_json::Value),
+    Cached(RawJson),
     /// Cache miss: block data fetched by the resolved canonical hash, ready to trace.
     Fetched(Arc<BlockData>),
 }
@@ -374,14 +374,16 @@ fn data_provider_error_to_rpc_error(e: &DataProviderError) -> jsonrpsee::types::
 
 // Trace Computation Helpers
 /// Runs a block-trace executor closure and wraps the scaffolding shared by every
-/// block-level handler: EVM timing + metrics, JSON serialization, the response-size
-/// metric, and the slow-stage warning. Returns the typed [`TraceError`] so the caller can
-/// key cache hygiene off its data-vs-request discriminant before rendering an RPC error.
+/// block-level handler: EVM timing + metrics, the single JSON serialization (straight
+/// from the trace output into [`RawJson`] bytes — the tree is never rebuilt as a
+/// `serde_json::Value`), the response-size metric, and the slow-stage warning. Returns
+/// the typed [`TraceError`] so the caller can key cache hygiene off its data-vs-request
+/// discriminant before rendering an RPC error.
 fn compute_block_trace<T: serde::Serialize>(
     data: &BlockData,
     method_name: &'static str,
     run: impl FnOnce() -> Result<T, TraceError>,
-) -> Result<serde_json::Value, TraceError> {
+) -> Result<RawJson, TraceError> {
     let start = Instant::now();
 
     let results = run()?;
@@ -390,11 +392,12 @@ fn compute_block_trace<T: serde::Serialize>(
     EvmExecutionMetrics::new_for_method(method_name)
         .record(start.elapsed().as_secs_f64(), data.block.transactions.len());
 
-    let value = serde_json::to_value(&results)
-        .map_err(|e| TraceError::Request(format!("Serialization failed: {e}")))?;
+    let json: RawJson = serde_json::value::to_raw_value(&results)
+        .map_err(|e| TraceError::Request(format!("Serialization failed: {e}")))?
+        .into();
 
     let serialize_ms = start.elapsed().as_millis() - trace_ms;
-    let response_size = value.to_string().len();
+    let response_size = json.byte_len();
     ResponseSizeMetrics::new_for_method(method_name).record(response_size);
 
     if trace_ms >= SLOW_STAGE_THRESHOLD_MS || serialize_ms >= SLOW_STAGE_THRESHOLD_MS {
@@ -409,15 +412,16 @@ fn compute_block_trace<T: serde::Serialize>(
         );
     }
 
-    Ok(value)
+    Ok(json)
 }
 
 // Cache Helper Functions
 /// Checks the cache for `(resource, block_hash, variant)`; a hit records request metrics
-/// and returns the pre-serialized response. A `None` variant marks a non-cacheable request
-/// shape and bypasses the lookup entirely (no hit/miss accounting). By-number callers
-/// resolve the canonical hash *before* calling this, so a hit is correct by construction —
-/// there is no serve-time canonicality validation anymore.
+/// and returns the pre-serialized response bytes, ready to splice into the reply. A
+/// `None` variant marks a non-cacheable request shape and bypasses the lookup entirely
+/// (no hit/miss accounting). By-number callers resolve the canonical hash *before*
+/// calling this, so a hit is correct by construction — there is no serve-time
+/// canonicality validation anymore.
 fn check_cache(
     cache: &Option<ResponseCache>,
     resource: CachedResource,
@@ -425,7 +429,7 @@ fn check_cache(
     variant: Option<ResponseVariant>,
     method_name: &'static str,
     start: Instant,
-) -> Option<serde_json::Value> {
+) -> Option<RawJson> {
     let cached_value = cache.as_ref()?.get(resource, block_hash, variant?)?;
 
     let total_ms = start.elapsed().as_secs_f64() * 1000.0;
@@ -446,30 +450,19 @@ fn check_cache(
 
 /// Inserts a computed response under the hash of the block it was computed for; a no-op
 /// when the cache is disabled or the request shape is not cacheable (`variant` is `None`).
-/// Serializing a multi-MB response into the cache can be slow, so the insert is timed and
-/// warned about here, where it happens.
+/// The insert shares the reply's already-serialized bytes (an `Arc` clone), so nothing is
+/// re-serialized and there is no multi-MB copy to time.
 fn insert_cache(
     cache: &Option<ResponseCache>,
     resource: CachedResource,
     block_hash: B256,
     variant: Option<ResponseVariant>,
-    method_name: &'static str,
-    result: &serde_json::Value,
+    result: &RawJson,
 ) {
     let (Some(cache), Some(variant)) = (cache, variant) else {
         return;
     };
-    let t = Instant::now();
     cache.insert(resource, block_hash, variant, result);
-    let insert_ms = t.elapsed().as_millis();
-    if insert_ms >= SLOW_STAGE_THRESHOLD_MS {
-        warn!(
-            method = method_name,
-            block_hash = %block_hash,
-            cache_insert_ms = insert_ms as u64,
-            "slow response-cache insert"
-        );
-    }
 }
 
 /// Records metrics and logs for a completed request.
@@ -496,7 +489,7 @@ impl DebugTraceRpcServer for RpcContext {
         &self,
         block_number: BlockNumberOrTag,
         opts: Option<GethDebugTracingOptions>,
-    ) -> RpcResult<serde_json::Value> {
+    ) -> RpcResult<RawJson> {
         let _guard = self
             .watch_dog
             .start_request(METHOD_DEBUG_TRACE_BLOCK_BY_NUMBER, format!("{block_number}"));
@@ -525,7 +518,6 @@ impl DebugTraceRpcServer for RpcContext {
             CachedResource::DebugTraceBlock,
             data.block.header.hash,
             variant,
-            METHOD_DEBUG_TRACE_BLOCK_BY_NUMBER,
             &result,
         );
         record_request_completion(
@@ -542,7 +534,7 @@ impl DebugTraceRpcServer for RpcContext {
         &self,
         block_hash: B256,
         opts: Option<GethDebugTracingOptions>,
-    ) -> RpcResult<serde_json::Value> {
+    ) -> RpcResult<RawJson> {
         let _guard =
             self.watch_dog.start_request(METHOD_DEBUG_TRACE_BLOCK_BY_HASH, format!("{block_hash}"));
         let start = Instant::now();
@@ -575,7 +567,6 @@ impl DebugTraceRpcServer for RpcContext {
             CachedResource::DebugTraceBlock,
             block_hash,
             variant,
-            METHOD_DEBUG_TRACE_BLOCK_BY_HASH,
             &result,
         );
         record_request_completion(METHOD_DEBUG_TRACE_BLOCK_BY_HASH, block_num, start);
@@ -588,7 +579,7 @@ impl DebugTraceRpcServer for RpcContext {
         &self,
         tx_hash: B256,
         opts: Option<GethDebugTracingOptions>,
-    ) -> RpcResult<serde_json::Value> {
+    ) -> RpcResult<RawJson> {
         let _guard =
             self.watch_dog.start_request(METHOD_DEBUG_TRACE_TRANSACTION, format!("{tx_hash}"));
         let start = Instant::now();
@@ -636,11 +627,11 @@ impl DebugTraceRpcServer for RpcContext {
             );
         }
 
-        let value = serde_json::to_value(&result)
-            .map_err(|e| rpc_err(format!("Serialization failed: {e}")))?;
-        ResponseSizeMetrics::new_for_method(METHOD_DEBUG_TRACE_TRANSACTION)
-            .record(value.to_string().len());
-        Ok(value)
+        let json: RawJson = serde_json::value::to_raw_value(&result)
+            .map_err(|e| rpc_err(format!("Serialization failed: {e}")))?
+            .into();
+        ResponseSizeMetrics::new_for_method(METHOD_DEBUG_TRACE_TRANSACTION).record(json.byte_len());
+        Ok(json)
     }
 
     async fn get_cache_status(&self) -> RpcResult<serde_json::Value> {
@@ -671,7 +662,7 @@ fn cache_section(stats: Option<CacheStats>) -> serde_json::Value {
 #[jsonrpsee::core::async_trait]
 impl TraceRpcServer for RpcContext {
     #[tracing::instrument(level = "trace", skip(self), fields(block_number))]
-    async fn trace_block(&self, block_number: BlockNumberOrTag) -> RpcResult<serde_json::Value> {
+    async fn trace_block(&self, block_number: BlockNumberOrTag) -> RpcResult<RawJson> {
         let _guard = self.watch_dog.start_request(METHOD_TRACE_BLOCK, format!("{block_number}"));
         let start = Instant::now();
 
@@ -707,7 +698,6 @@ impl TraceRpcServer for RpcContext {
             CachedResource::TraceBlock,
             data.block.header.hash,
             Some(ResponseVariant::Default),
-            METHOD_TRACE_BLOCK,
             &result,
         );
         record_request_completion(METHOD_TRACE_BLOCK, data.block.header.number, start);
@@ -716,7 +706,7 @@ impl TraceRpcServer for RpcContext {
     }
 
     #[tracing::instrument(level = "trace", skip(self))]
-    async fn trace_parity_transaction(&self, tx_hash: B256) -> RpcResult<serde_json::Value> {
+    async fn trace_parity_transaction(&self, tx_hash: B256) -> RpcResult<RawJson> {
         let _guard = self.watch_dog.start_request(METHOD_TRACE_TRANSACTION, format!("{tx_hash}"));
         let start = Instant::now();
 
@@ -729,7 +719,7 @@ impl TraceRpcServer for RpcContext {
                 DataProviderError::TransactionNotFound(_) |
                 DataProviderError::TransactionPending(_) |
                 DataProviderError::Timeout { .. },
-            ) => return Ok(serde_json::Value::Null),
+            ) => return Ok(RawJson::null()),
             Err(DataProviderError::Internal(_)) => {
                 metrics::record_rpc_error(METHOD_TRACE_TRANSACTION);
                 return Err(rpc_err("internal error".to_string()));
@@ -764,11 +754,11 @@ impl TraceRpcServer for RpcContext {
             );
         }
 
-        let value = serde_json::to_value(&result)
-            .map_err(|e| rpc_err(format!("Serialization failed: {e}")))?;
-        ResponseSizeMetrics::new_for_method(METHOD_TRACE_TRANSACTION)
-            .record(value.to_string().len());
-        Ok(value)
+        let json: RawJson = serde_json::value::to_raw_value(&result)
+            .map_err(|e| rpc_err(format!("Serialization failed: {e}")))?
+            .into();
+        ResponseSizeMetrics::new_for_method(METHOD_TRACE_TRANSACTION).record(json.byte_len());
+        Ok(json)
     }
 }
 
@@ -896,13 +886,9 @@ mod tests {
     fn check_cache_hit_miss_and_bypass() {
         let h1 = B256::from([1u8; 32]);
         let h2 = B256::from([2u8; 32]);
+        let inserted = RawJson::from_value(&serde_json::json!({"v": 1}));
         let cache = ResponseCache::new(ResponseCacheConfig::new(1_000_000, 100));
-        cache.insert(
-            CachedResource::DebugTraceBlock,
-            h1,
-            ResponseVariant::Default,
-            &serde_json::json!({"v": 1}),
-        );
+        cache.insert(CachedResource::DebugTraceBlock, h1, ResponseVariant::Default, &inserted);
         let cache = Some(cache);
         let check = |hash, variant| {
             check_cache(&cache, CachedResource::DebugTraceBlock, hash, variant, "m", Instant::now())
@@ -915,9 +901,33 @@ mod tests {
         assert!(check(h1, None).is_none());
         assert_eq!(stats(), (0, 0), "bypass must not touch accounting");
 
-        assert_eq!(check(h1, Some(ResponseVariant::Default)), Some(serde_json::json!({"v": 1})));
+        let hit = check(h1, Some(ResponseVariant::Default)).expect("inserted entry must hit");
+        assert!(hit.shares_bytes_with(&inserted), "a hit must serve the inserted bytes");
         assert!(check(h2, Some(ResponseVariant::Default)).is_none());
         assert_eq!(stats(), (1, 1));
+    }
+
+    /// End-to-end through the real jsonrpsee reply path: a handler returning [`RawJson`]
+    /// must have its bytes spliced verbatim into the JSON-RPC envelope — the property the
+    /// whole serialize-once design rests on.
+    #[tokio::test]
+    async fn raw_json_passes_through_jsonrpsee_verbatim() {
+        let mut module = jsonrpsee::server::RpcModule::new(());
+        module
+            .register_method("echo", |_, _, _| {
+                jsonrpsee::ResponsePayload::success(RawJson::from_value(
+                    &serde_json::json!({"a": [1, 2], "b": "x"}),
+                ))
+            })
+            .unwrap();
+        let (resp, _) = module
+            .raw_json_request(r#"{"jsonrpc":"2.0","id":1,"method":"echo"}"#, 1)
+            .await
+            .expect("call must succeed");
+        assert!(
+            resp.get().contains(r#""result":{"a":[1,2],"b":"x"}"#),
+            "reply must contain the raw bytes verbatim: {resp}"
+        );
     }
 
     /// Builds an `RpcContext` around a never-called upstream, with the given block-data
@@ -1044,10 +1054,10 @@ mod tests {
     #[test]
     fn insert_cache_skips_non_cacheable_variants() {
         let cache = Some(ResponseCache::new(ResponseCacheConfig::new(1_000_000, 100)));
-        let result = serde_json::json!([{"txHash": "0x01"}]);
+        let result = RawJson::from_value(&serde_json::json!([{"txHash": "0x01"}]));
         let hash = B256::from([1u8; 32]);
 
-        insert_cache(&cache, CachedResource::DebugTraceBlock, hash, None, "m", &result);
+        insert_cache(&cache, CachedResource::DebugTraceBlock, hash, None, &result);
         assert_eq!(cache.as_ref().unwrap().len(), 0);
 
         insert_cache(
@@ -1055,7 +1065,6 @@ mod tests {
             CachedResource::DebugTraceBlock,
             hash,
             Some(ResponseVariant::Default),
-            "m",
             &result,
         );
         assert_eq!(cache.as_ref().unwrap().len(), 1);

--- a/bin/debug-trace-server/src/rpc_service.rs
+++ b/bin/debug-trace-server/src/rpc_service.rs
@@ -450,19 +450,31 @@ fn check_cache(
 
 /// Inserts a computed response under the hash of the block it was computed for; a no-op
 /// when the cache is disabled or the request shape is not cacheable (`variant` is `None`).
-/// The insert shares the reply's already-serialized bytes (an `Arc` clone), so nothing is
-/// re-serialized and there is no multi-MB copy to time.
+/// The insert shares the reply's already-serialized bytes (an `Arc` clone), but it is not
+/// free: at the weight ceiling `quick_cache` evicts synchronously and each eviction takes
+/// the index lock, so the insert is still timed and warned about here, where it happens.
 fn insert_cache(
     cache: &Option<ResponseCache>,
     resource: CachedResource,
     block_hash: B256,
     variant: Option<ResponseVariant>,
+    method_name: &'static str,
     result: &RawJson,
 ) {
     let (Some(cache), Some(variant)) = (cache, variant) else {
         return;
     };
+    let t = Instant::now();
     cache.insert(resource, block_hash, variant, result);
+    let insert_ms = t.elapsed().as_millis();
+    if insert_ms >= SLOW_STAGE_THRESHOLD_MS {
+        warn!(
+            method = method_name,
+            block_hash = %block_hash,
+            cache_insert_ms = insert_ms as u64,
+            "slow response-cache insert"
+        );
+    }
 }
 
 /// Serializes a result into its [`RawJson`] reply body and records the response-size
@@ -532,6 +544,7 @@ impl DebugTraceRpcServer for RpcContext {
             CachedResource::DebugTraceBlock,
             data.block.header.hash,
             variant,
+            METHOD_DEBUG_TRACE_BLOCK_BY_NUMBER,
             &result,
         );
         record_request_completion(
@@ -581,6 +594,7 @@ impl DebugTraceRpcServer for RpcContext {
             CachedResource::DebugTraceBlock,
             block_hash,
             variant,
+            METHOD_DEBUG_TRACE_BLOCK_BY_HASH,
             &result,
         );
         record_request_completion(METHOD_DEBUG_TRACE_BLOCK_BY_HASH, block_num, start);
@@ -708,6 +722,7 @@ impl TraceRpcServer for RpcContext {
             CachedResource::TraceBlock,
             data.block.header.hash,
             Some(ResponseVariant::Default),
+            METHOD_TRACE_BLOCK,
             &result,
         );
         record_request_completion(METHOD_TRACE_BLOCK, data.block.header.number, start);
@@ -1064,7 +1079,7 @@ mod tests {
         let result = RawJson::try_new(&serde_json::json!([{"txHash": "0x01"}])).expect("serialize");
         let hash = B256::from([1u8; 32]);
 
-        insert_cache(&cache, CachedResource::DebugTraceBlock, hash, None, &result);
+        insert_cache(&cache, CachedResource::DebugTraceBlock, hash, None, "m", &result);
         assert_eq!(cache.as_ref().unwrap().len(), 0);
 
         insert_cache(
@@ -1072,6 +1087,7 @@ mod tests {
             CachedResource::DebugTraceBlock,
             hash,
             Some(ResponseVariant::Default),
+            "m",
             &result,
         );
         assert_eq!(cache.as_ref().unwrap().len(), 1);

--- a/bin/debug-trace-server/src/rpc_service.rs
+++ b/bin/debug-trace-server/src/rpc_service.rs
@@ -27,7 +27,8 @@ use crate::{
         METHOD_DEBUG_TRACE_TRANSACTION, METHOD_TRACE_BLOCK, METHOD_TRACE_TRANSACTION,
         ResponseSizeMetrics, RpcGlobalMetrics, SingleFlightMetrics,
     },
-    response_cache::{CachedResource, RawJson, RequestShape, ResponseCache, ResponseVariant},
+    raw_json::RawJson,
+    response_cache::{CachedResource, RequestShape, ResponseCache, ResponseVariant},
     tracing_executor::TraceError,
 };
 
@@ -392,9 +393,8 @@ fn compute_block_trace<T: serde::Serialize>(
     EvmExecutionMetrics::new_for_method(method_name)
         .record(start.elapsed().as_secs_f64(), data.block.transactions.len());
 
-    let json: RawJson = serde_json::value::to_raw_value(&results)
-        .map_err(|e| TraceError::Request(format!("Serialization failed: {e}")))?
-        .into();
+    let json = RawJson::try_new(&results)
+        .map_err(|e| TraceError::Request(format!("Serialization failed: {e}")))?;
 
     let serialize_ms = start.elapsed().as_millis() - trace_ms;
     let response_size = json.byte_len();
@@ -463,6 +463,20 @@ fn insert_cache(
         return;
     };
     cache.insert(resource, block_hash, variant, result);
+}
+
+/// Serializes a result into its [`RawJson`] reply body and records the response-size
+/// metric — the shared epilogue of the uncached transaction handlers (the block-level
+/// twin lives in `compute_block_trace`, which folds the same serialization into its
+/// stage timing and maps failures to [`TraceError`] instead).
+fn serialize_reply<T: serde::Serialize>(
+    result: &T,
+    method_name: &'static str,
+) -> RpcResult<RawJson> {
+    let json =
+        RawJson::try_new(result).map_err(|e| rpc_err(format!("Serialization failed: {e}")))?;
+    ResponseSizeMetrics::new_for_method(method_name).record(json.byte_len());
+    Ok(json)
 }
 
 /// Records metrics and logs for a completed request.
@@ -627,11 +641,7 @@ impl DebugTraceRpcServer for RpcContext {
             );
         }
 
-        let json: RawJson = serde_json::value::to_raw_value(&result)
-            .map_err(|e| rpc_err(format!("Serialization failed: {e}")))?
-            .into();
-        ResponseSizeMetrics::new_for_method(METHOD_DEBUG_TRACE_TRANSACTION).record(json.byte_len());
-        Ok(json)
+        serialize_reply(&result, METHOD_DEBUG_TRACE_TRANSACTION)
     }
 
     async fn get_cache_status(&self) -> RpcResult<serde_json::Value> {
@@ -754,11 +764,7 @@ impl TraceRpcServer for RpcContext {
             );
         }
 
-        let json: RawJson = serde_json::value::to_raw_value(&result)
-            .map_err(|e| rpc_err(format!("Serialization failed: {e}")))?
-            .into();
-        ResponseSizeMetrics::new_for_method(METHOD_TRACE_TRANSACTION).record(json.byte_len());
-        Ok(json)
+        serialize_reply(&result, METHOD_TRACE_TRANSACTION)
     }
 }
 
@@ -886,7 +892,7 @@ mod tests {
     fn check_cache_hit_miss_and_bypass() {
         let h1 = B256::from([1u8; 32]);
         let h2 = B256::from([2u8; 32]);
-        let inserted = RawJson::from_value(&serde_json::json!({"v": 1}));
+        let inserted = RawJson::try_new(&serde_json::json!({"v": 1})).expect("serialize");
         let cache = ResponseCache::new(ResponseCacheConfig::new(1_000_000, 100));
         cache.insert(CachedResource::DebugTraceBlock, h1, ResponseVariant::Default, &inserted);
         let cache = Some(cache);
@@ -915,9 +921,10 @@ mod tests {
         let mut module = jsonrpsee::server::RpcModule::new(());
         module
             .register_method("echo", |_, _, _| {
-                jsonrpsee::ResponsePayload::success(RawJson::from_value(
-                    &serde_json::json!({"a": [1, 2], "b": "x"}),
-                ))
+                jsonrpsee::ResponsePayload::success(
+                    RawJson::try_new(&serde_json::json!({"a": [1, 2], "b": "x"}))
+                        .expect("serialize"),
+                )
             })
             .unwrap();
         let (resp, _) = module
@@ -1054,7 +1061,7 @@ mod tests {
     #[test]
     fn insert_cache_skips_non_cacheable_variants() {
         let cache = Some(ResponseCache::new(ResponseCacheConfig::new(1_000_000, 100)));
-        let result = RawJson::from_value(&serde_json::json!([{"txHash": "0x01"}]));
+        let result = RawJson::try_new(&serde_json::json!([{"txHash": "0x01"}])).expect("serialize");
         let hash = B256::from([1u8; 32]);
 
         insert_cache(&cache, CachedResource::DebugTraceBlock, hash, None, &result);

--- a/bin/debug-trace-server/src/rpc_service.rs
+++ b/bin/debug-trace-server/src/rpc_service.rs
@@ -225,7 +225,7 @@ impl RpcContext {
     /// *before* the cache lookup, all on one request deadline; on a miss, fetch block data
     /// by the resolved hash on the remaining budget. Slow prelude stages are warned about
     /// here, where they are measured; trace/serialize timing lives in
-    /// [`compute_block_trace`].
+    /// [`compute_block_trace`] and cache-insert timing in [`insert_cache`].
     async fn lookup_block_by_number(
         &self,
         method: &'static str,


### PR DESCRIPTION
## Summary
Handlers now return `RawJson` (`Arc<RawValue>`, `response_cache.rs:299`) instead of `serde_json::Value`: the trace output is serialized exactly once (`to_raw_value`, `rpc_service.rs:395`), the response-size metric reads the byte length, the response cache shares the same bytes by `Arc`, and jsonrpsee splices them verbatim into the reply. A cache hit becomes an `Arc` clone — zero parsing, zero copies, zero re-serialization. Two silent-failure paths are fixed along the way: a serialization failure used to store an **empty string** in the cache (`to_string(..).unwrap_or_default()`), and a hit-side parse failure returned **null** (`unwrap_or(Value::Null)`) — both now propagate as errors through `RawJson::try_new`.

## Root cause
The cache stored pre-serialized strings but its interface to jsonrpsee was `serde_json::Value`, so both sides of the cache paid full tree work: a hit re-parsed the stored string into a `Value` and jsonrpsee re-serialized it (measured ≈7 ms CPU per MB of response — a ~20 MB block-level callTracer hit burns ~140 ms server CPU, see the baseline below; 93.7% of production traffic is repeat-after-success, i.e. exactly this path); the fill path serialized the same response three times (`value.to_string().len()` for the size metric, `CachedResponse::new`, jsonrpsee).

## Measured baseline (v2.0.15 without this PR, 2026-08-01)
Bench on the tko staging deploy (response cache enabled), 51 load-test-era blocks 6907000–6907050 — 36.7k–44.1k tx each (median 41,779), callTracer responses avg 20.0 MB, 1020 MB per round:

| round | status | total p50 / p90 / max | server CPU p50 (`x-execution-time-ns`) |
| --- | --- | --- | --- |
| 1 (cold) | 51/51 OK | 1244 / 1527 / 1760 ms | 721 ms (incl. ~337 ms EVM replay) |
| 2–3 (cache hits) | 51/51 OK | 168–188 / 305–402 / 523–803 ms | **140 / 135 ms** |

Raw data: `validator-data/debug_trace_server/bench/new/monster51_files_tko2.tar.gz`, analysis in `bench/old-vs-new-report-2026-08-01.md` §7.

## Validated on tko (2026-08-03, combined with #174)
Same segment, same box, this PR deployed together with #174 (response compression); full data in `validator-data/.../bench/0803/`, analysis in `bench/old-vs-new-report-2026-08-01.md` §9:

| | baseline (§7) | with this PR |
| --- | --- | --- |
| warm-hit server CPU p50 | 135–140 ms | **12 ms (−91%)** |
| warm-hit total p50 | 188 ms | **125–133 ms** (remainder = 20 MB loopback transfer — hit path is now IO-bound as designed) |
| cold r1 p50 / CPU p50 | 1244 ms / 721 ms | **1047 ms / 568 ms** (fill-path 3→1 serializations) |

Zero regressions vs baseline (`--compare`: 0 regressed, 51/51 OK all rounds); cold-round witness fetches confirm a genuinely cold r1. Composes cleanly with #174: encoded responses keep the 12 ms hit CPU (compression runs outside the handler, pipelined with the write).

## Fix
- `RawJson` in `response_cache.rs`: `Serialize` splices the stored bytes verbatim (`:338`); the cache stores it directly as its value type (`get`/`insert` at `:483`/`:512`), deleting `CachedResponse`.
- `compute_block_trace` produces `RawJson` via `serde_json::value::to_raw_value` — one serialization, no validation re-scan of our own output; the size metric reads `byte_len()` (`rpc_service.rs:395`).
- Both tx handlers (`debug_traceTransaction`, `trace_transaction`) drop their `to_value` + `to_string` double serialization; parity not-found returns `RawJson::null()`.
- `insert_cache` keeps its slow-insert timing (restored in e0cbc21 after review): the insert is an `Arc` clone, but at the weight ceiling `quick_cache` evicts synchronously and each eviction takes the index lock, so an insert-side stall stays attributable.
- `debug_getCacheStatus` keeps `serde_json::Value` (tiny payload, not cached).

## Testing
- `raw_json_serializes_verbatim` (`response_cache.rs:985`) pins the splice property the design rests on.
- `raw_json_passes_through_jsonrpsee_verbatim` (`rpc_service.rs:914`) proves it end-to-end through a real `RpcModule` reply.
- `shares_bytes_with` assertions pin that hits serve the inserted bytes without copying (`rpc_service.rs:905`, cache insert/get test).
- Full workspace: 20/20 test targets green; fmt/clippy/cargo-sort clean.

## Notes
- Both wins are live in production configs: the fill-path win (3 serializations → 1) applies to every response, and prod now runs with the response cache enabled (32 GB on ore/fra; the old `ESTIMATED_ITEMS=0` disable convention is rejected at startup since v2.0.15), so the hit-path win applies immediately on deploy. Verify via `debug_trace_cpu_time` / hit p50 against the tables above.
- `serde_json` gains the `raw_value` feature in this bin only.
- Cached replies now return the exact original bytes instead of a re-serialization of them.
- Wire-visible byte change: response JSON keys now serialize in **struct declaration order** (the old `Value` path emitted alphabetical order via its `BTreeMap`, `preserve_order` being off). Semantically irrelevant for JSON-RPC and closer to geth/reth, which also serialize from structs — but golden-file/snapshot comparisons will show the difference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
