### PR TITLE
fix(debug-trace-server): reject malformed tracerConfig in the executor

### DIFF
--- a/bin/debug-trace-server/src/tracing_executor.rs
+++ b/bin/debug-trace-server/src/tracing_executor.rs
@@ -241,9 +241,47 @@ fn mux_config_and_inspector(
     let config = tracer_config
         .clone()
         .into_mux_config()
-        .map_err(|_| TraceError::Request("Invalid mux tracer config".into()))?;
+        .map_err(|e| request_error("invalid muxTracer tracerConfig", e))?;
     let inspector = mux_inspector(config.clone())?;
     Ok((config, inspector))
+}
+
+/// Parses a config-reading builtin's `tracerConfig` into its [`TracerKind`] — the one
+/// home for the strict-parse contract shared by the block and transaction dispatchers.
+///
+/// Defense in depth: RPC handlers already reject malformed configs via
+/// `RequestShape::classify` (-32602) before the executor runs, so from the current entry
+/// points this rejection is unreachable — but a malformed config must never silently
+/// trace with default settings if a future entry point skips the boundary gate. The
+/// executor guarantees only that much: its rejection surfaces as a request-attributable
+/// [`TraceError`], not as the gate's `-32602` wire code.
+fn builtin_tracer_kind(
+    builtin: GethDebugBuiltInTracerType,
+    tracer_config: &GethDebugTracerConfig,
+) -> Result<TracerKind, TraceError> {
+    let config = tracer_config.clone();
+    match builtin {
+        GethDebugBuiltInTracerType::CallTracer => config
+            .into_call_config()
+            .map(TracerKind::Call)
+            .map_err(|e| request_error("invalid callTracer tracerConfig", e)),
+        GethDebugBuiltInTracerType::PreStateTracer => config
+            .into_pre_state_config()
+            .map(TracerKind::PreState)
+            .map_err(|e| request_error("invalid prestateTracer tracerConfig", e)),
+        GethDebugBuiltInTracerType::FlatCallTracer => config
+            .into_flat_call_config()
+            .map(TracerKind::FlatCall)
+            .map_err(|e| request_error("invalid flatCallTracer tracerConfig", e)),
+        // Not TracingInspector tracers: the dispatchers execute these in their own arms
+        // (mux via `mux_config_and_inspector`) and never route them here; kept total —
+        // a request error rather than a panic.
+        GethDebugBuiltInTracerType::FourByteTracer |
+        GethDebugBuiltInTracerType::NoopTracer |
+        GethDebugBuiltInTracerType::MuxTracer => {
+            Err(request_error("tracer takes no typed tracerConfig here", builtin))
+        }
+    }
 }
 
 /// Builds a [`JsInspector`] for one transaction context (request-attributable on failure).
@@ -525,49 +563,16 @@ pub fn trace_block(
                     })
                     .collect(),
 
-                // Defense in depth: RPC handlers already reject malformed configs via
-                // `RequestShape::classify` (-32602) before the executor runs, so these
-                // rejections are unreachable from the current entry points — but a
-                // malformed config must never silently trace with default settings if a
-                // future entry point skips the boundary gate.
-                GethDebugBuiltInTracerType::CallTracer => {
-                    let call_config = tracer_config
-                        .clone()
-                        .into_call_config()
-                        .map_err(|e| request_error("invalid callTracer tracerConfig", e))?;
-                    trace_block_with_tracing_inspector(
-                        &env,
-                        block,
-                        &mut state,
-                        &TracerKind::Call(call_config),
-                    )?
-                }
-
-                GethDebugBuiltInTracerType::PreStateTracer => {
-                    let prestate_config = tracer_config
-                        .clone()
-                        .into_pre_state_config()
-                        .map_err(|e| request_error("invalid prestateTracer tracerConfig", e))?;
-                    trace_block_with_tracing_inspector(
-                        &env,
-                        block,
-                        &mut state,
-                        &TracerKind::PreState(prestate_config),
-                    )?
-                }
-
-                GethDebugBuiltInTracerType::FlatCallTracer => {
-                    let flat_call_config = tracer_config
-                        .clone()
-                        .into_flat_call_config()
-                        .map_err(|e| request_error("invalid flatCallTracer tracerConfig", e))?;
-                    trace_block_with_tracing_inspector(
-                        &env,
-                        block,
-                        &mut state,
-                        &TracerKind::FlatCall(flat_call_config),
-                    )?
-                }
+                // Strict parse in `builtin_tracer_kind` — see its doc for why the
+                // executor re-rejects what the boundary gate already screens.
+                GethDebugBuiltInTracerType::CallTracer |
+                GethDebugBuiltInTracerType::PreStateTracer |
+                GethDebugBuiltInTracerType::FlatCallTracer => trace_block_with_tracing_inspector(
+                    &env,
+                    block,
+                    &mut state,
+                    &builtin_tracer_kind(*builtin, tracer_config)?,
+                )?,
 
                 GethDebugBuiltInTracerType::FourByteTracer => {
                     setup_executor!(&env, &mut state, FourByteInspector::default() => executor);
@@ -784,52 +789,17 @@ pub fn trace_transaction(
                     Ok(GethTrace::NoopTracer(NoopFrame::default()))
                 }
 
-                // Defense in depth: RPC handlers already reject malformed configs via
-                // `RequestShape::classify` (-32602) before the executor runs, so these
-                // rejections are unreachable from the current entry points — but a
-                // malformed config must never silently trace with default settings if a
-                // future entry point skips the boundary gate.
-                GethDebugBuiltInTracerType::CallTracer => {
-                    let call_config = tracer_config
-                        .clone()
-                        .into_call_config()
-                        .map_err(|e| request_error("invalid callTracer tracerConfig", e))?;
-                    trace_tx_with_tracing_inspector(
-                        &env,
-                        block,
-                        &mut state,
-                        tx_index,
-                        &TracerKind::Call(call_config),
-                    )
-                }
-
-                GethDebugBuiltInTracerType::PreStateTracer => {
-                    let prestate_config = tracer_config
-                        .clone()
-                        .into_pre_state_config()
-                        .map_err(|e| request_error("invalid prestateTracer tracerConfig", e))?;
-                    trace_tx_with_tracing_inspector(
-                        &env,
-                        block,
-                        &mut state,
-                        tx_index,
-                        &TracerKind::PreState(prestate_config),
-                    )
-                }
-
-                GethDebugBuiltInTracerType::FlatCallTracer => {
-                    let flat_call_config = tracer_config
-                        .clone()
-                        .into_flat_call_config()
-                        .map_err(|e| request_error("invalid flatCallTracer tracerConfig", e))?;
-                    trace_tx_with_tracing_inspector(
-                        &env,
-                        block,
-                        &mut state,
-                        tx_index,
-                        &TracerKind::FlatCall(flat_call_config),
-                    )
-                }
+                // Strict parse in `builtin_tracer_kind` — see its doc for why the
+                // executor re-rejects what the boundary gate already screens.
+                GethDebugBuiltInTracerType::CallTracer |
+                GethDebugBuiltInTracerType::PreStateTracer |
+                GethDebugBuiltInTracerType::FlatCallTracer => trace_tx_with_tracing_inspector(
+                    &env,
+                    block,
+                    &mut state,
+                    tx_index,
+                    &builtin_tracer_kind(*builtin, tracer_config)?,
+                ),
 
                 GethDebugBuiltInTracerType::FourByteTracer => {
                     setup_executor!(&env, &mut state, FourByteInspector::default() => executor);
@@ -1180,6 +1150,7 @@ mod tests {
                 GethDebugBuiltInTracerType::FlatCallTracer,
                 serde_json::json!({"convertParityErrors": "yes"}),
             ),
+            (GethDebugBuiltInTracerType::MuxTracer, serde_json::json!({"notATracer": {}})),
         ];
         for (tracer, config) in malformed {
             let opts = GethDebugTracingOptions {

--- a/bin/debug-trace-server/src/tracing_executor.rs
+++ b/bin/debug-trace-server/src/tracing_executor.rs
@@ -525,11 +525,16 @@ pub fn trace_block(
                     })
                     .collect(),
 
-                // The `unwrap_or_default()` on these three config parses is unreachable in
-                // practice: RPC handlers reject malformed configs via
-                // `RequestShape::classify` (-32602) before reaching the executor.
+                // Defense in depth: RPC handlers already reject malformed configs via
+                // `RequestShape::classify` (-32602) before the executor runs, so these
+                // rejections are unreachable from the current entry points — but a
+                // malformed config must never silently trace with default settings if a
+                // future entry point skips the boundary gate.
                 GethDebugBuiltInTracerType::CallTracer => {
-                    let call_config = tracer_config.clone().into_call_config().unwrap_or_default();
+                    let call_config = tracer_config
+                        .clone()
+                        .into_call_config()
+                        .map_err(|e| request_error("invalid callTracer tracerConfig", e))?;
                     trace_block_with_tracing_inspector(
                         &env,
                         block,
@@ -539,8 +544,10 @@ pub fn trace_block(
                 }
 
                 GethDebugBuiltInTracerType::PreStateTracer => {
-                    let prestate_config =
-                        tracer_config.clone().into_pre_state_config().unwrap_or_default();
+                    let prestate_config = tracer_config
+                        .clone()
+                        .into_pre_state_config()
+                        .map_err(|e| request_error("invalid prestateTracer tracerConfig", e))?;
                     trace_block_with_tracing_inspector(
                         &env,
                         block,
@@ -550,8 +557,10 @@ pub fn trace_block(
                 }
 
                 GethDebugBuiltInTracerType::FlatCallTracer => {
-                    let flat_call_config =
-                        tracer_config.clone().into_flat_call_config().unwrap_or_default();
+                    let flat_call_config = tracer_config
+                        .clone()
+                        .into_flat_call_config()
+                        .map_err(|e| request_error("invalid flatCallTracer tracerConfig", e))?;
                     trace_block_with_tracing_inspector(
                         &env,
                         block,
@@ -775,11 +784,16 @@ pub fn trace_transaction(
                     Ok(GethTrace::NoopTracer(NoopFrame::default()))
                 }
 
-                // The `unwrap_or_default()` on these three config parses is unreachable in
-                // practice: RPC handlers reject malformed configs via
-                // `RequestShape::classify` (-32602) before reaching the executor.
+                // Defense in depth: RPC handlers already reject malformed configs via
+                // `RequestShape::classify` (-32602) before the executor runs, so these
+                // rejections are unreachable from the current entry points — but a
+                // malformed config must never silently trace with default settings if a
+                // future entry point skips the boundary gate.
                 GethDebugBuiltInTracerType::CallTracer => {
-                    let call_config = tracer_config.clone().into_call_config().unwrap_or_default();
+                    let call_config = tracer_config
+                        .clone()
+                        .into_call_config()
+                        .map_err(|e| request_error("invalid callTracer tracerConfig", e))?;
                     trace_tx_with_tracing_inspector(
                         &env,
                         block,
@@ -790,8 +804,10 @@ pub fn trace_transaction(
                 }
 
                 GethDebugBuiltInTracerType::PreStateTracer => {
-                    let prestate_config =
-                        tracer_config.clone().into_pre_state_config().unwrap_or_default();
+                    let prestate_config = tracer_config
+                        .clone()
+                        .into_pre_state_config()
+                        .map_err(|e| request_error("invalid prestateTracer tracerConfig", e))?;
                     trace_tx_with_tracing_inspector(
                         &env,
                         block,
@@ -802,8 +818,10 @@ pub fn trace_transaction(
                 }
 
                 GethDebugBuiltInTracerType::FlatCallTracer => {
-                    let flat_call_config =
-                        tracer_config.clone().into_flat_call_config().unwrap_or_default();
+                    let flat_call_config = tracer_config
+                        .clone()
+                        .into_flat_call_config()
+                        .map_err(|e| request_error("invalid flatCallTracer tracerConfig", e))?;
                     trace_tx_with_tracing_inspector(
                         &env,
                         block,
@@ -1137,5 +1155,57 @@ mod tests {
         let err = trace_block(&chain_spec, &block, witness, &contracts, opts)
             .expect_err("an unparsable mux config must be rejected");
         assert!(matches!(err, TraceError::Request(_)), "got: {err:?}");
+    }
+
+    /// Defense in depth behind the RPC boundary gate: a type-malformed `tracerConfig` on
+    /// a config-reading builtin is rejected with [`TraceError::Request`] by the executor
+    /// itself — on both the block and the single-transaction paths — never silently
+    /// traced with default settings, while a well-formed config still traces. (The RPC
+    /// layer's own `-32602` rejection is pinned by
+    /// `invalid_tracer_config_maps_to_invalid_params` in `rpc_service`.)
+    #[test]
+    fn malformed_tracer_config_is_rejected_not_defaulted() {
+        use stateless_test_utils::fixtures::TestFixtures;
+
+        use crate::data_provider::{BlockData, test_support::fixture_block_data};
+
+        let chain_spec =
+            ChainSpec::from_genesis(TestFixtures::synthetic().load_genesis().expect("genesis"));
+        let BlockData { block, witness, contracts } = fixture_block_data();
+
+        let malformed = [
+            (GethDebugBuiltInTracerType::CallTracer, serde_json::json!({"onlyTopCall": "yes"})),
+            (GethDebugBuiltInTracerType::PreStateTracer, serde_json::json!({"diffMode": "yes"})),
+            (
+                GethDebugBuiltInTracerType::FlatCallTracer,
+                serde_json::json!({"convertParityErrors": "yes"}),
+            ),
+        ];
+        for (tracer, config) in malformed {
+            let opts = GethDebugTracingOptions {
+                tracer: Some(GethDebugTracerType::BuiltInTracer(tracer)),
+                tracer_config: GethDebugTracerConfig(config),
+                ..Default::default()
+            };
+
+            let err = trace_block(&chain_spec, &block, witness.clone(), &contracts, opts.clone())
+                .expect_err("malformed config must fail the block trace");
+            assert!(matches!(&err, TraceError::Request(msg) if msg.contains("tracerConfig")));
+
+            let err = trace_transaction(&chain_spec, &block, 0, witness.clone(), &contracts, opts)
+                .expect_err("malformed config must fail the tx trace");
+            assert!(matches!(&err, TraceError::Request(msg) if msg.contains("tracerConfig")));
+        }
+
+        // Control: a well-formed config on the same inputs still traces.
+        let opts = GethDebugTracingOptions {
+            tracer: Some(GethDebugTracerType::BuiltInTracer(
+                GethDebugBuiltInTracerType::CallTracer,
+            )),
+            tracer_config: GethDebugTracerConfig(serde_json::json!({"onlyTopCall": true})),
+            ..Default::default()
+        };
+        trace_block(&chain_spec, &block, witness, &contracts, opts)
+            .expect("a well-formed config must trace");
     }
 }


### PR DESCRIPTION
## Summary
The executor's six tracerConfig parses (call/prestate/flatCall on the block path `tracing_executor.rs:528` and the single-tx path `:787`) now fail with `TraceError::Request` on a type-malformed config instead of silently falling back to default settings (`unwrap_or_default`). Pure defense in depth — no user-visible behavior change through the RPC surface.

## Root cause
The `-32602` rejection of malformed configs lives at the RPC boundary (`RequestShape::classify` in `classify_and_gate`), so the executor parse sites are unreachable with bad configs today — but the two layers were coupled only by an "unreachable in practice" comment. Any future entry point that skips the boundary gate would have traced with default settings and returned HTTP 200: exactly the silent-degradation behavior the boundary fix (vincent's review on #161) was written to eliminate. Deferred back then because the parse sites' functions returned the shared crate's `ValidationError`; the bin-local `TraceError { Request, Data }` that has since landed removed that blocker.

## Fix
Six `unwrap_or_default()` → `.map_err(|e| request_error("invalid <tracer> tracerConfig", e))?`, matching the muxTracer parse right above them (`:244`); the coupling comments become a defense-in-depth note. The boundary `-32602` remains the user-facing rejection; executor-level rejection surfaces through the existing `TraceError::Request` mapping (`-32000`), and — like all request-attributable failures — never evicts cached block data, so a cheap invalid request still cannot drop hot entries.

## Testing
`malformed_tracer_config_is_rejected_not_defaulted` (`tracing_executor.rs:1167`): all three config-reading builtins, on both the block and single-tx paths, reject a type-malformed config with a tracerConfig-naming `Request` error, and a well-formed config on the same fixture inputs still traces. The RPC layer's own `-32602` stays pinned by the existing `invalid_tracer_config_maps_to_invalid_params`. Workspace fmt/clippy clean, all debug-trace-server unit tests green (107).

## Notes
Out of scope, unchanged from the deferred-findings plan: threading classify's already-parsed typed config into the executor to remove the double parse — a larger interface change not worth bundling into this backstop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
