### PR TITLE
chore: bump version to 2.0.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1884,7 +1884,7 @@ dependencies = [
 
 [[package]]
 name = "debug-trace-server"
-version = "2.0.15"
+version = "2.0.16"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -5651,7 +5651,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stateless-common"
-version = "2.0.15"
+version = "2.0.16"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -5686,7 +5686,7 @@ dependencies = [
 
 [[package]]
 name = "stateless-core"
-version = "2.0.15"
+version = "2.0.16"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5726,7 +5726,7 @@ dependencies = [
 
 [[package]]
 name = "stateless-db"
-version = "2.0.15"
+version = "2.0.16"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -5745,7 +5745,7 @@ dependencies = [
 
 [[package]]
 name = "stateless-r2"
-version = "2.0.15"
+version = "2.0.16"
 dependencies = [
  "bytes",
  "chrono",
@@ -5758,7 +5758,7 @@ dependencies = [
 
 [[package]]
 name = "stateless-test-utils"
-version = "2.0.15"
+version = "2.0.16"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -5776,7 +5776,7 @@ dependencies = [
 
 [[package]]
 name = "stateless-validator"
-version = "2.0.15"
+version = "2.0.16"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.0.15"
+version = "2.0.16"
 edition = "2024"
 rust-version = "1.91"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary
Bump the workspace version from 2.0.15 to 2.0.16 (`Cargo.toml` + regenerated `Cargo.lock` via `cargo update -w`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)