### PR TITLE
chore: bump version to 2.0.17

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1886,7 +1886,7 @@ dependencies = [
 
 [[package]]
 name = "debug-trace-server"
-version = "2.0.16"
+version = "2.0.17"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -5657,7 +5657,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stateless-common"
-version = "2.0.16"
+version = "2.0.17"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -5692,7 +5692,7 @@ dependencies = [
 
 [[package]]
 name = "stateless-core"
-version = "2.0.16"
+version = "2.0.17"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5732,7 +5732,7 @@ dependencies = [
 
 [[package]]
 name = "stateless-db"
-version = "2.0.16"
+version = "2.0.17"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -5751,7 +5751,7 @@ dependencies = [
 
 [[package]]
 name = "stateless-r2"
-version = "2.0.16"
+version = "2.0.17"
 dependencies = [
  "bytes",
  "chrono",
@@ -5768,7 +5768,7 @@ dependencies = [
 
 [[package]]
 name = "stateless-test-utils"
-version = "2.0.16"
+version = "2.0.17"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -5787,7 +5787,7 @@ dependencies = [
 
 [[package]]
 name = "stateless-validator"
-version = "2.0.16"
+version = "2.0.17"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.0.16"
+version = "2.0.17"
 edition = "2024"
 rust-version = "1.91"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary

Production has been running #167 / #174 / #175 / #176 since 2026-08-07 while every binary still reported `2.0.16`, so during the fra/ore triage the version string could not be used to tell which code a host was on. `Cargo.lock` regenerated with `cargo update -w`.

## Testing

`cargo check` clean; no code change.