### PR TITLE
feat: enrich validation logs, pin mega-kona, add justfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2315,7 +2315,7 @@ dependencies = [
  "http-body-util",
  "jsonrpsee",
  "libc",
- "mega-evm",
+ "mega-evm 1.6.1",
  "metrics",
  "metrics-derive",
  "metrics-exporter-prometheus",
@@ -3849,7 +3849,7 @@ dependencies = [
 [[package]]
 name = "kona-cli"
 version = "0.3.2"
-source = "git+https://github.com/megaeth-labs/mega-kona.git?branch=develop#c83be842ec263e2bb2d55c7f92325990288bf061"
+source = "git+https://github.com/megaeth-labs/mega-kona.git?rev=20500dfb6c14fb0ed20ccd2a2a0dab388907c5b6#20500dfb6c14fb0ed20ccd2a2a0dab388907c5b6"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -3869,7 +3869,7 @@ dependencies = [
 [[package]]
 name = "kona-derive"
 version = "0.4.5"
-source = "git+https://github.com/megaeth-labs/mega-kona.git?branch=develop#c83be842ec263e2bb2d55c7f92325990288bf061"
+source = "git+https://github.com/megaeth-labs/mega-kona.git?rev=20500dfb6c14fb0ed20ccd2a2a0dab388907c5b6#20500dfb6c14fb0ed20ccd2a2a0dab388907c5b6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3890,7 +3890,7 @@ dependencies = [
 [[package]]
 name = "kona-driver"
 version = "0.4.0"
-source = "git+https://github.com/megaeth-labs/mega-kona.git?branch=develop#c83be842ec263e2bb2d55c7f92325990288bf061"
+source = "git+https://github.com/megaeth-labs/mega-kona.git?rev=20500dfb6c14fb0ed20ccd2a2a0dab388907c5b6#20500dfb6c14fb0ed20ccd2a2a0dab388907c5b6"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -3900,7 +3900,7 @@ dependencies = [
  "kona-executor",
  "kona-genesis",
  "kona-protocol",
- "mega-evm",
+ "mega-evm 1.7.0",
  "op-alloy-consensus 0.22.4",
  "op-alloy-rpc-types-engine",
  "spin 0.10.0",
@@ -3911,7 +3911,7 @@ dependencies = [
 [[package]]
 name = "kona-executor"
 version = "0.4.0"
-source = "git+https://github.com/megaeth-labs/mega-kona.git?branch=develop#c83be842ec263e2bb2d55c7f92325990288bf061"
+source = "git+https://github.com/megaeth-labs/mega-kona.git?rev=20500dfb6c14fb0ed20ccd2a2a0dab388907c5b6#20500dfb6c14fb0ed20ccd2a2a0dab388907c5b6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3929,7 +3929,7 @@ dependencies = [
  "kona-megaevm",
  "kona-mpt",
  "kona-protocol",
- "mega-evm",
+ "mega-evm 1.7.0",
  "op-alloy-consensus 0.22.4",
  "op-alloy-rpc-types 0.22.4",
  "op-alloy-rpc-types-engine",
@@ -3944,7 +3944,7 @@ dependencies = [
 [[package]]
 name = "kona-genesis"
 version = "0.4.5"
-source = "git+https://github.com/megaeth-labs/mega-kona.git?branch=develop#c83be842ec263e2bb2d55c7f92325990288bf061"
+source = "git+https://github.com/megaeth-labs/mega-kona.git?rev=20500dfb6c14fb0ed20ccd2a2a0dab388907c5b6#20500dfb6c14fb0ed20ccd2a2a0dab388907c5b6"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -3955,7 +3955,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
  "derive_more",
- "mega-evm",
+ "mega-evm 1.7.0",
  "serde",
  "serde_repr",
  "thiserror",
@@ -3964,7 +3964,7 @@ dependencies = [
 [[package]]
 name = "kona-hardforks"
 version = "0.4.5"
-source = "git+https://github.com/megaeth-labs/mega-kona.git?branch=develop#c83be842ec263e2bb2d55c7f92325990288bf061"
+source = "git+https://github.com/megaeth-labs/mega-kona.git?rev=20500dfb6c14fb0ed20ccd2a2a0dab388907c5b6#20500dfb6c14fb0ed20ccd2a2a0dab388907c5b6"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -3975,7 +3975,7 @@ dependencies = [
 [[package]]
 name = "kona-log"
 version = "0.1.0"
-source = "git+https://github.com/megaeth-labs/mega-kona.git?branch=develop#c83be842ec263e2bb2d55c7f92325990288bf061"
+source = "git+https://github.com/megaeth-labs/mega-kona.git?rev=20500dfb6c14fb0ed20ccd2a2a0dab388907c5b6#20500dfb6c14fb0ed20ccd2a2a0dab388907c5b6"
 dependencies = [
  "risc0-zkvm",
 ]
@@ -3983,24 +3983,24 @@ dependencies = [
 [[package]]
 name = "kona-macros"
 version = "0.1.2"
-source = "git+https://github.com/megaeth-labs/mega-kona.git?branch=develop#c83be842ec263e2bb2d55c7f92325990288bf061"
+source = "git+https://github.com/megaeth-labs/mega-kona.git?rev=20500dfb6c14fb0ed20ccd2a2a0dab388907c5b6#20500dfb6c14fb0ed20ccd2a2a0dab388907c5b6"
 
 [[package]]
 name = "kona-megaevm"
 version = "0.1.0"
-source = "git+https://github.com/megaeth-labs/mega-kona.git?branch=develop#c83be842ec263e2bb2d55c7f92325990288bf061"
+source = "git+https://github.com/megaeth-labs/mega-kona.git?rev=20500dfb6c14fb0ed20ccd2a2a0dab388907c5b6#20500dfb6c14fb0ed20ccd2a2a0dab388907c5b6"
 dependencies = [
  "alloy-hardforks 0.2.13",
  "alloy-op-hardforks 0.2.13",
  "alloy-primitives",
- "mega-evm",
+ "mega-evm 1.7.0",
  "salt",
 ]
 
 [[package]]
 name = "kona-mpt"
 version = "0.3.0"
-source = "git+https://github.com/megaeth-labs/mega-kona.git?branch=develop#c83be842ec263e2bb2d55c7f92325990288bf061"
+source = "git+https://github.com/megaeth-labs/mega-kona.git?rev=20500dfb6c14fb0ed20ccd2a2a0dab388907c5b6#20500dfb6c14fb0ed20ccd2a2a0dab388907c5b6"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -4012,7 +4012,7 @@ dependencies = [
 [[package]]
 name = "kona-preimage"
 version = "0.3.0"
-source = "git+https://github.com/megaeth-labs/mega-kona.git?branch=develop#c83be842ec263e2bb2d55c7f92325990288bf061"
+source = "git+https://github.com/megaeth-labs/mega-kona.git?rev=20500dfb6c14fb0ed20ccd2a2a0dab388907c5b6#20500dfb6c14fb0ed20ccd2a2a0dab388907c5b6"
 dependencies = [
  "alloy-primitives",
  "async-channel",
@@ -4025,7 +4025,7 @@ dependencies = [
 [[package]]
 name = "kona-proof"
 version = "0.3.0"
-source = "git+https://github.com/megaeth-labs/mega-kona.git?branch=develop#c83be842ec263e2bb2d55c7f92325990288bf061"
+source = "git+https://github.com/megaeth-labs/mega-kona.git?rev=20500dfb6c14fb0ed20ccd2a2a0dab388907c5b6#20500dfb6c14fb0ed20ccd2a2a0dab388907c5b6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4048,7 +4048,7 @@ dependencies = [
  "kona-system-contracts",
  "lazy_static",
  "lru 0.16.4",
- "mega-evm",
+ "mega-evm 1.7.0",
  "op-alloy-consensus 0.22.4",
  "op-alloy-rpc-types-engine",
  "serde",
@@ -4063,7 +4063,7 @@ dependencies = [
 [[package]]
 name = "kona-protocol"
 version = "0.4.5"
-source = "git+https://github.com/megaeth-labs/mega-kona.git?branch=develop#c83be842ec263e2bb2d55c7f92325990288bf061"
+source = "git+https://github.com/megaeth-labs/mega-kona.git?rev=20500dfb6c14fb0ed20ccd2a2a0dab388907c5b6#20500dfb6c14fb0ed20ccd2a2a0dab388907c5b6"
 dependencies = [
  "alloc-no-stdlib",
  "alloy-consensus",
@@ -4092,7 +4092,7 @@ dependencies = [
 [[package]]
 name = "kona-registry"
 version = "0.4.5"
-source = "git+https://github.com/megaeth-labs/mega-kona.git?branch=develop#c83be842ec263e2bb2d55c7f92325990288bf061"
+source = "git+https://github.com/megaeth-labs/mega-kona.git?rev=20500dfb6c14fb0ed20ccd2a2a0dab388907c5b6#20500dfb6c14fb0ed20ccd2a2a0dab388907c5b6"
 dependencies = [
  "alloy-chains",
  "alloy-eips",
@@ -4111,10 +4111,10 @@ dependencies = [
 [[package]]
 name = "kona-system-contracts"
 version = "0.1.0"
-source = "git+https://github.com/megaeth-labs/mega-kona.git?branch=develop#c83be842ec263e2bb2d55c7f92325990288bf061"
+source = "git+https://github.com/megaeth-labs/mega-kona.git?rev=20500dfb6c14fb0ed20ccd2a2a0dab388907c5b6#20500dfb6c14fb0ed20ccd2a2a0dab388907c5b6"
 dependencies = [
  "alloy-primitives",
- "mega-evm",
+ "mega-evm 1.7.0",
 ]
 
 [[package]]
@@ -4383,7 +4383,35 @@ dependencies = [
  "bitflags 2.10.0",
  "delegate",
  "derive_more",
- "mega-system-contracts",
+ "mega-system-contracts 1.6.1",
+ "once_cell",
+ "op-alloy-consensus 0.18.14",
+ "op-alloy-flz",
+ "op-revm",
+ "revm",
+ "serde",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "mega-evm"
+version = "1.7.0"
+source = "git+https://github.com/megaeth-labs/mega-evm?tag=v1.7.0#30ce038cfb0ec108e886ef48105a7ab367a99b33"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-evm",
+ "alloy-hardforks 0.2.13",
+ "alloy-op-evm",
+ "alloy-op-hardforks 0.2.13",
+ "alloy-primitives",
+ "alloy-sol-types",
+ "auto_impl",
+ "bitflags 2.10.0",
+ "delegate",
+ "derive_more",
+ "mega-system-contracts 1.7.0",
  "once_cell",
  "op-alloy-consensus 0.18.14",
  "op-alloy-flz",
@@ -4398,6 +4426,18 @@ dependencies = [
 name = "mega-system-contracts"
 version = "1.6.1"
 source = "git+https://github.com/megaeth-labs/mega-evm.git?tag=v1.6.1#19f3965962c4cc1c12aaedd0ccbd972e4ab10d17"
+dependencies = [
+ "alloy-primitives",
+ "alloy-sol-types",
+ "semver 1.0.27",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "mega-system-contracts"
+version = "1.7.0"
+source = "git+https://github.com/megaeth-labs/mega-evm?tag=v1.7.0#30ce038cfb0ec108e886ef48105a7ab367a99b33"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -6829,12 +6869,12 @@ dependencies = [
 [[package]]
 name = "salt-stateless"
 version = "1.0.0"
-source = "git+https://github.com/megaeth-labs/mega-kona.git?branch=develop#c83be842ec263e2bb2d55c7f92325990288bf061"
+source = "git+https://github.com/megaeth-labs/mega-kona.git?rev=20500dfb6c14fb0ed20ccd2a2a0dab388907c5b6#20500dfb6c14fb0ed20ccd2a2a0dab388907c5b6"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "anyhow",
- "mega-evm",
+ "mega-evm 1.7.0",
  "salt",
 ]
 
@@ -7410,7 +7450,7 @@ dependencies = [
  "eyre",
  "hashbrown 0.16.1",
  "kanal",
- "mega-evm",
+ "mega-evm 1.6.1",
  "num_cpus",
  "op-alloy-consensus 0.18.14",
  "op-alloy-rpc-types 0.18.14",
@@ -7491,7 +7531,7 @@ dependencies = [
  "kona-mpt",
  "kona-proof",
  "kona-registry",
- "mega-evm",
+ "mega-evm 1.6.1",
  "metrics",
  "metrics-exporter-prometheus",
  "op-alloy-consensus 0.18.14",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,13 +47,13 @@ mega-evm = { git = "https://github.com/megaeth-labs/mega-evm.git", tag = "v1.6.1
 salt = { git = "https://github.com/megaeth-labs/salt.git", tag = "v1.0.5", default-features = false }
 
 # kona (private repo; consumed only by the opt-in `kona` feature of stateless-validator)
-kona-driver = { git = "https://github.com/megaeth-labs/mega-kona.git", branch = "develop", package = "kona-driver", default-features = false }
-kona-executor = { git = "https://github.com/megaeth-labs/mega-kona.git", branch = "develop", package = "kona-executor", default-features = false }
-kona-genesis = { git = "https://github.com/megaeth-labs/mega-kona.git", branch = "develop", package = "kona-genesis", features = ["serde"], default-features = false }
-kona-megaevm = { git = "https://github.com/megaeth-labs/mega-kona.git", branch = "develop", package = "kona-megaevm", default-features = false }
-kona-mpt = { git = "https://github.com/megaeth-labs/mega-kona.git", branch = "develop", package = "kona-mpt", default-features = false }
-kona-proof = { git = "https://github.com/megaeth-labs/mega-kona.git", branch = "develop", package = "kona-proof", default-features = false }
-kona-registry = { git = "https://github.com/megaeth-labs/mega-kona.git", branch = "develop", package = "kona-registry", default-features = false }
+kona-driver = { git = "https://github.com/megaeth-labs/mega-kona.git", rev = "20500dfb6c14fb0ed20ccd2a2a0dab388907c5b6", package = "kona-driver", default-features = false }
+kona-executor = { git = "https://github.com/megaeth-labs/mega-kona.git", rev = "20500dfb6c14fb0ed20ccd2a2a0dab388907c5b6", package = "kona-executor", default-features = false }
+kona-genesis = { git = "https://github.com/megaeth-labs/mega-kona.git", rev = "20500dfb6c14fb0ed20ccd2a2a0dab388907c5b6", package = "kona-genesis", features = ["serde"], default-features = false }
+kona-megaevm = { git = "https://github.com/megaeth-labs/mega-kona.git", rev = "20500dfb6c14fb0ed20ccd2a2a0dab388907c5b6", package = "kona-megaevm", default-features = false }
+kona-mpt = { git = "https://github.com/megaeth-labs/mega-kona.git", rev = "20500dfb6c14fb0ed20ccd2a2a0dab388907c5b6", package = "kona-mpt", default-features = false }
+kona-proof = { git = "https://github.com/megaeth-labs/mega-kona.git", rev = "20500dfb6c14fb0ed20ccd2a2a0dab388907c5b6", package = "kona-proof", default-features = false }
+kona-registry = { git = "https://github.com/megaeth-labs/mega-kona.git", rev = "20500dfb6c14fb0ed20ccd2a2a0dab388907c5b6", package = "kona-registry", default-features = false }
 
 # op
 op-alloy-consensus = { version = "0.18.12", default-features = false }

--- a/bin/stateless-validator/src/chain_sync.rs
+++ b/bin/stateless-validator/src/chain_sync.rs
@@ -194,6 +194,8 @@ where
         let block_hash = task.block.header.hash;
         let tx_count = task.block.transactions.len() as u64;
         let gas_used = task.block.header.gas_used;
+        let block_size = task.block.header.size.map(|s| s.to::<u64>());
+        let salt_kvs = task.salt_witness.kvs.len();
         let start = std::time::Instant::now();
 
         let fail = |error: String, transient: bool| ValidationFailure {
@@ -268,9 +270,24 @@ where
 
         match &validation_result {
             Ok(stats) => {
-                debug!(block_number, "Successfully validated block");
+                let validation_time = start.elapsed().as_secs_f64();
+                debug!(
+                    block_number,
+                    %block_hash,
+                    tx_count,
+                    gas_used,
+                    block_size,
+                    salt_kvs,
+                    validation_time,
+                    block_replay_time = stats.block_replay_time,
+                    witness_verification_time = stats.witness_verification_time,
+                    salt_update_time = stats.salt_update_time,
+                    state_reads = stats.state_reads,
+                    state_writes = stats.state_writes,
+                    "Successfully validated block"
+                );
                 metrics::on_validation_success(
-                    start.elapsed().as_secs_f64(),
+                    validation_time,
                     stats.witness_verification_time,
                     stats.block_replay_time,
                     stats.salt_update_time,

--- a/justfile
+++ b/justfile
@@ -1,0 +1,3 @@
+# Build the kona-validator binary (opt-in `kona` feature / Kona execution backend).
+build-kona-validator:
+    cargo build --release --features kona --bin kona-validator


### PR DESCRIPTION
## Summary

- Enrich successful block validation `debug` logs with block hash, tx/gas/size, salt KV count, and per-stage timing stats.
- Pin mega-kona dependencies to rev `20500df` (devnet Rex6 schedule) instead of floating `develop`.
- Add a `justfile` recipe to build the opt-in `kona-validator` binary.

## Test plan

- [ ] `cargo check -p stateless-validator`
- [ ] Confirm validation success logs include the new fields at debug level
- [ ] `just build-kona-validator` (or equivalent cargo command) builds successfully with network access to mega-kona