### PR TITLE
fix: add Rex6 activation to mainnet genesis

### DIFF
--- a/bin/stateless-validator/tests/integration.rs
+++ b/bin/stateless-validator/tests/integration.rs
@@ -175,6 +175,9 @@ fn witness_source_flag_and_env() {
 /// for `r2`), so the parse itself must accept its absence in both modes.
 #[test]
 fn witness_endpoint_is_optional_at_parse_time() {
+    // `try_parse_from` reads the env for every `#[clap(env = ...)]` field, so this test
+    // must hold the lock too: a sibling's `with_env_var` would otherwise land in this parse.
+    let _guard = stateless_test_utils::env::env_lock();
     let parse =
         |extra: &[&str]| CommandLineArgs::try_parse_from(BASE_ARGS_NO_WITNESS.iter().chain(extra));
 

--- a/bin/stateless-validator/tests/integration.rs
+++ b/bin/stateless-validator/tests/integration.rs
@@ -175,6 +175,12 @@ fn witness_source_flag_and_env() {
 /// for `r2`), so the parse itself must accept its absence in both modes.
 #[test]
 fn witness_endpoint_is_optional_at_parse_time() {
+    // `try_parse_from` reads the environment for every `#[clap(env = ...)]` field, so this
+    // is an env-touching test and must hold the lock like every other one in this binary --
+    // without it, a sibling test's `with_env_var` can both set
+    // `STATELESS_VALIDATOR_WITNESS_ENDPOINT` under this parse (a spurious failure) and
+    // realloc `environ` while clap reads it.
+    let _guard = stateless_test_utils::env::env_lock();
     let parse =
         |extra: &[&str]| CommandLineArgs::try_parse_from(BASE_ARGS_NO_WITNESS.iter().chain(extra));
 

--- a/crates/stateless-core/src/chain_spec.rs
+++ b/crates/stateless-core/src/chain_spec.rs
@@ -667,4 +667,52 @@ mod tests {
             .unwrap();
         let _ = ChainSpec::from_genesis(genesis);
     }
+
+    /// Every fork in the canonical [`mega_mainnet_hardforks()`] ladder must be scheduled by
+    /// the shipped mainnet genesis file, minus an explicit not-yet-scheduled allowlist.
+    ///
+    /// The schema tests above all run on synthetic genesis JSON, so none of them can notice
+    /// the shipped data file missing a fork — the shape of a real production failure: the
+    /// pinned mega-evm already supports the fork, genesis never schedules it, chain-spec
+    /// loading stays green, and every block past the activation timestamp fails to replay.
+    /// A fork added to the ladder without its genesis field fails here at test time instead
+    /// of at the activation boundary.
+    #[cfg(feature = "std")]
+    #[test]
+    fn mainnet_genesis_schedules_every_canonical_hardfork() {
+        use stateless_test_utils::fixtures::TestFixtures;
+
+        // Ladder forks mainnet has deliberately not scheduled yet — empty today, every fork
+        // through Rex6 is live. An entry here must actually be unscheduled: once its genesis
+        // field lands, the assertion below demands the entry's removal, so the allowlist
+        // cannot rot into shadowing the check.
+        const NOT_YET_SCHEDULED: &[&str] = &[];
+
+        let genesis = TestFixtures::mainnet_shared().load_genesis().expect("mainnet genesis");
+        let spec = ChainSpec::from_genesis(genesis);
+        let scheduled: Vec<(&str, ForkCondition)> =
+            spec.hardforks.forks_iter().map(|(fork, condition)| (fork.name(), condition)).collect();
+
+        let ladder = mega_mainnet_hardforks();
+        for (fork, _) in ladder.forks_iter() {
+            let activation =
+                scheduled.iter().find(|(name, _)| *name == fork.name()).map(|(_, c)| *c);
+            if NOT_YET_SCHEDULED.contains(&fork.name()) {
+                assert_eq!(
+                    activation,
+                    None,
+                    "{} is scheduled now — remove it from NOT_YET_SCHEDULED",
+                    fork.name()
+                );
+            } else {
+                assert!(
+                    matches!(activation, Some(ForkCondition::Timestamp(_))),
+                    "mainnet genesis does not schedule {} (activation: {activation:?}); add \
+                     its genesis field, or allowlist it in NOT_YET_SCHEDULED if it is \
+                     genuinely not scheduled yet",
+                    fork.name()
+                );
+            }
+        }
+    }
 }

--- a/test_data/mainnet/genesis.json
+++ b/test_data/mainnet/genesis.json
@@ -44,7 +44,9 @@
     "rex4Time": 1776659200,
     "rex5Time": 1780632000,
     "rex5InitialSequencer": "0x7A49197dd1EBb8D38C67e4EB7626AF6adE432445",
-    "rex5InitialAdmin": "0x92e0E0B15e3e99b32c9ED9AD284F939553C7b7d6"
+    "rex5InitialAdmin": "0x92e0E0B15e3e99b32c9ED9AD284F939553C7b7d6",
+    "rex6Time": 1787626800,
+    "rex6MinRotationDelay": 21600
   },
   "nonce": "0x0",
   "timestamp": "0x691225d3",


### PR DESCRIPTION
## Summary

Rex6 activated on mainnet at `1787626800` (2026-08-25 03:00 UTC) and replaced the `SequencerRegistry` contract at `0x6342000000000000000000000000000000000006`. Our mainnet genesis never carried the fork, so every block past the activation fails to replay. This adds the two fields the fork needs.

## Symptom

Every tracer shape except `noopTracer` fails on post-activation blocks:

```
-32000  Trace execution failed: Block replay failed during transaction execution:
        failed to apply blockhash contract call: SequencerRegistry at
        0x6342000000000000000000000000000000000006 has unexpected code hash
        0xabd7e8f1... (expected 0x63cd411a...);
        refusing to overwrite stateful contract storage without migration
```

`noopTracer` does not go through that replay path and keeps succeeding, so a smoke test built on it alone reads green while every real tracer is broken — worth knowing when triaging a similar report.

## Root cause

`ChainSpec::from_genesis` gates the Rex6 registry config on `rex6Time` (`crates/stateless-core/src/chain_spec.rs:142`). With the field absent it builds `sequencer_registry_rex6_config: None`, the executor keeps applying the Rex5 expectations, and the code-hash guard refuses the now-Rex6 contract.

Not a code regression — `mega-evm` is pinned at `v1.7.0` throughout and already supports Rex6; the gap is purely genesis data. On-chain confirmation: `eth_getCode` at that address returns 3874 bytes at block 24,372,730 and 5365 bytes at 24,850,266, matching the observed failure boundary.

## Fix

```json
"rex6Time": 1787626800,
"rex6MinRotationDelay": 21600
```

Both are required together — `parse_required_from` rejects a `rex6Time` without its `rex6MinRotationDelay`. The values match the production node's genesis; with this commit the two `config` sections are field-for-field identical.

## Regression test

Nothing on this branch failed on the parent commit (review finding): the chain-spec suite runs entirely on synthetic genesis JSON, the largest paired execution fixture is block 15,412,411 — a year before the activation — so the shipped genesis file itself had no discriminating coverage. `mainnet_genesis_schedules_every_canonical_hardfork` now walks the canonical `mega_mainnet_hardforks()` ladder against `ChainSpec::from_genesis` of the real `test_data/mainnet/genesis.json` and demands a `Timestamp` activation for every fork outside an explicit not-yet-scheduled allowlist (empty today; an allowlisted fork that becomes scheduled fails too, so the list cannot rot into shadowing the check). On the parent commit's genesis it fails naming Rex6, and it trips automatically when a future fork lands in the ladder without its genesis field — the failure mode actually being fixed here.

## Testing

Trace server built at `7f1d870`, deployed on a test box against a local upgraded rpc-node:

- **Before**: every tracer variant fails on post-activation blocks; `noopTracer` passes at every depth.
- **After**: all six RPC methods and every tracer variant (`callTracer` / `flatCallTracer` / `4byteTracer` / `prestateTracer` / default struct logger / `noopTracer`), plus `trace_block` / `trace_transaction`, plus deep historical blocks served from R2 (h2 negotiated, `witness_r2` source) — all pass.
- `cargo test --workspace`: 475 passed, 0 failed (1 new). The new test was verified to discriminate: against the parent commit's genesis it fails naming Rex6; against this branch it passes.

## Notes

Deployment paths differ between the two binaries:

- **debug-trace-server** re-reads `--genesis-file` on every start — replace the file and restart.
- **stateless-validator** persists genesis in the DB's `GENESIS_CONFIG` table (`bin/stateless-validator/src/app.rs:41-58`) and reads the stored copy when `--genesis-file` is omitted. Fixing an existing deployment means starting once **with** `--genesis-file` so `store_genesis` overwrites it.

The branch also carries `test: hold the env lock in witness_endpoint_is_optional_at_parse_time` — unrelated to Rex6, riding along: `try_parse_from` reads env for every `#[clap(env = ...)]` field, so a concurrent sibling test's `with_env_var` can leak into this parse without the lock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
