### PR TITLE
chore: bump version to 2.0.17

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1886,7 +1886,7 @@ dependencies = [
 
 [[package]]
 name = "debug-trace-server"
-version = "2.0.16"
+version = "2.0.17"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -5670,7 +5670,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stateless-common"
-version = "2.0.16"
+version = "2.0.17"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -5706,7 +5706,7 @@ dependencies = [
 
 [[package]]
 name = "stateless-core"
-version = "2.0.16"
+version = "2.0.17"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5746,7 +5746,7 @@ dependencies = [
 
 [[package]]
 name = "stateless-db"
-version = "2.0.16"
+version = "2.0.17"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -5765,7 +5765,7 @@ dependencies = [
 
 [[package]]
 name = "stateless-r2"
-version = "2.0.16"
+version = "2.0.17"
 dependencies = [
  "bytes",
  "chrono",
@@ -5782,7 +5782,7 @@ dependencies = [
 
 [[package]]
 name = "stateless-test-utils"
-version = "2.0.16"
+version = "2.0.17"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -5801,7 +5801,7 @@ dependencies = [
 
 [[package]]
 name = "stateless-validator"
-version = "2.0.16"
+version = "2.0.17"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.0.16"
+version = "2.0.17"
 edition = "2024"
 rust-version = "1.91"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary

Bumps the workspace from `2.0.16` to `2.0.17`. Every binary still reports `2.0.16` while `main` carries fifteen merges past the `v2.0.16` tag, so the version string cannot be used to tell which code a host is on — the gap that made the fra/ore triage guess at build identity. `Cargo.lock` regenerated with `cargo update -w`; no code change. Supersedes #177, which was closed while the frontier-witness P0 work was still outstanding — that work has since landed.

## Contents

Everything merged since the `v2.0.16` tag (`11078d7`), oldest first: #167 raw-JSON cache hits · #174 gzip/zstd response compression · #175 direct-from-R2 historical witnesses · #176 concurrent inbound batch entries · #169 malformed `tracerConfig` rejected in the executor · #172 HTTP connect timeout · #171 single home for block-execution env assembly · #168 resolved `(number, hash)` threaded through the fetch pipeline · #178 per-request accounting identity and error reasons · #180 deadline give-up names its phase · #182 R2-first witness fetches and a per-hop budget cap · #187 custom-domain R2 target over HTTP/2 · #188 inbound admission control and response-size caps · #190 Rex6 activation in the mainnet genesis · #191 validator R2 witness cap split from the RPC one.

## Notes

The `v2.0.17` tag is deliberately not part of this PR and still waits on #192. Two items from the above must carry into the release notes and the compatibility table, since both change what an existing deployment has to do:

- **#190** — the validator persists genesis in `GENESIS_CONFIG`, so an existing DB keeps the pre-Rex6 copy; fixing one means starting **once with `--genesis-file`** so it is overwritten. The trace server re-reads the file every start and needs only the replacement.
- **#191** — `--r2-max-concurrent-requests` is new and now caps R2 GETs. Under `--witness-source r2`, a host still carrying only the old `--witness-max-concurrent-requests` spelling is **refused at startup by name** rather than left uncapped, so env files for r2-mode roles must be migrated before upgrading.

## Testing

`cargo update -w` regenerated the seven workspace-member entries and nothing else; `cargo check --workspace` clean. No code change.
