### PR TITLE
fix: type the unsatisfiable witness-provider-range failure

### DIFF
--- a/bin/debug-trace-server/src/data_provider.rs
+++ b/bin/debug-trace-server/src/data_provider.rs
@@ -45,7 +45,9 @@ use futures::{FutureExt, future::Shared};
 use op_alloy_rpc_types::Transaction;
 use quick_cache::sync::Cache;
 use revm::state::Bytecode;
-use stateless_common::{CodeFetchError, RpcClient, RpcDeadlineExceeded, WitnessSizeBreakdown};
+use stateless_common::{
+    CodeFetchError, RpcClient, RpcDeadlineExceeded, WitnessFetchError, WitnessSizeBreakdown,
+};
 use stateless_core::{
     ContractStore, LightWitness, StoreResult, db::StoreError, withdrawals::MptWitness,
 };
@@ -274,6 +276,18 @@ impl From<RpcDeadlineExceeded> for DataProviderError {
             _ => TimeoutStage::Block,
         };
         DataProviderError::Timeout { stage, elapsed: e.elapsed }
+    }
+}
+
+impl From<WitnessFetchError> for DataProviderError {
+    fn from(e: WitnessFetchError) -> Self {
+        match e {
+            // Only a blown deadline is a timeout. A range failure is a wiring bug in this
+            // process — routing it to `Timeout { Witness }` would fire the `deadline_witness`
+            // alarm, which must mean "an upstream witness fetch ran out of budget".
+            WitnessFetchError::Deadline(d) => d.into(),
+            WitnessFetchError::NoProviderInRange { .. } => eyre::eyre!("{e}").into(),
+        }
     }
 }
 
@@ -3067,5 +3081,27 @@ mod tests {
         }
         .into();
         assert!(matches!(block_err, DataProviderError::Timeout { stage: TimeoutStage::Block, .. }));
+    }
+
+    /// A witness fetch whose provider range is unsatisfiable is a wiring bug, not a blown
+    /// budget: it must land on `Internal`, never on `Timeout { Witness }`. That bucket feeds
+    /// the `deadline_witness` error reason, whose whole value is meaning "an upstream witness
+    /// fetch ran out of time" — a wiring bug landing there would page for the wrong incident.
+    /// The deadline variant still classifies by method, exactly as before.
+    #[test]
+    fn witness_range_failure_is_internal_not_a_witness_timeout() {
+        let range_err: DataProviderError =
+            WitnessFetchError::NoProviderInRange { skip: 2, configured: 1 }.into();
+        assert!(matches!(range_err, DataProviderError::Internal(_)), "got {range_err:?}");
+
+        let deadline_err: DataProviderError = WitnessFetchError::Deadline(RpcDeadlineExceeded {
+            method: stateless_common::RpcMethod::MegaGetBlockWitness,
+            elapsed: Duration::from_secs(3),
+        })
+        .into();
+        assert!(matches!(
+            deadline_err,
+            DataProviderError::Timeout { stage: TimeoutStage::Witness, .. }
+        ));
     }
 }

--- a/bin/stateless-validator/src/app.rs
+++ b/bin/stateless-validator/src/app.rs
@@ -331,8 +331,6 @@ pub async fn run() -> Result<()> {
         ..rpc_defaults
     }
     .with_metrics(Arc::new(metrics::ValidatorMetrics));
-    // In R2 mode the RpcClient's witness providers are never used, but its constructor requires
-    // a non-empty list — hand it the data endpoints as a placeholder.
     let data_apis: Vec<&str> = args.rpc_endpoint.iter().map(String::as_str).collect();
     let r2_witness = match args.witness_source {
         WitnessSource::Rpc => {
@@ -361,8 +359,11 @@ pub async fn run() -> Result<()> {
         }
     };
 
+    // In R2 mode the client carries no witness providers: witnesses come straight from R2, and
+    // a witness RPC call that slipped through fails structurally instead of quietly asking the
+    // data endpoints for `mega_getBlockWitness`.
     let witness_apis: Vec<&str> = if r2_witness.is_some() {
-        data_apis.clone()
+        Vec::new()
     } else {
         args.witness_endpoint.iter().map(String::as_str).collect()
     };

--- a/crates/stateless-common/src/lib.rs
+++ b/crates/stateless-common/src/lib.rs
@@ -4,7 +4,7 @@ pub use metrics::{RpcMethod, RpcMetrics};
 pub mod rpc_client;
 pub use rpc_client::{
     BackoffPolicy, CodeFetchError, RpcClient, RpcClientConfig, RpcDeadlineExceeded,
-    SetValidatedBlocksResponse, WitnessRequestKeys,
+    SetValidatedBlocksResponse, WitnessFetchError, WitnessRequestKeys,
 };
 pub mod witness_encoding;
 pub use witness_encoding::{

--- a/crates/stateless-common/src/rpc_client.rs
+++ b/crates/stateless-common/src/rpc_client.rs
@@ -254,6 +254,24 @@ pub struct SetValidatedBlocksResponse {
     pub last_validated_block: (U64, B256),
 }
 
+/// Error returned by the witness fetches that take a caller-computed provider range.
+///
+/// `NoProviderInRange` is a wiring failure, not a transport one: either the caller's `skip`
+/// selected past the configured witness endpoints, or the client carries none at all (a
+/// deployment that sources witnesses elsewhere — the validator's R2 mode). Both binaries
+/// reject an empty witness configuration at startup, so it stays unreachable in production;
+/// it is a typed error rather than an `assert!` so a routing bug fails one request instead of
+/// the process.
+#[derive(Debug, thiserror::Error)]
+pub enum WitnessFetchError {
+    #[error(
+        "witness fetch selected providers {skip}.. of {configured} configured — no witness provider in range"
+    )]
+    NoProviderInRange { skip: usize, configured: usize },
+    #[error(transparent)]
+    Deadline(#[from] RpcDeadlineExceeded),
+}
+
 /// Errors returned by [`RpcClient::get_codes`] / [`RpcClient::get_codes_with_deadline`].
 ///
 /// - `VerificationFailure` is deterministic (upstream returned bytecode whose keccak does not match
@@ -320,7 +338,10 @@ impl RpcClient {
     /// # Arguments
     /// * `data_apis` - HTTP URLs of the standard JSON-RPC endpoints for blocks and contract data
     ///   (tried in order, non-empty)
-    /// * `witness_apis` - HTTP URLs of the witness RPC endpoints (tried in order, non-empty)
+    /// * `witness_apis` - HTTP URLs of the witness RPC endpoints (tried in order). May be empty
+    ///   when the deployment sources witnesses elsewhere (the validator's R2 witness mode); a
+    ///   witness call on such a client returns [`WitnessFetchError::NoProviderInRange`] instead of
+    ///   silently retrying against the wrong endpoints
     /// * `config` - Configuration controlling verification, retry, and concurrency behavior
     /// * `report_api` - Optional HTTP URL of the endpoint for reporting validated blocks
     pub fn new_with_config(
@@ -331,9 +352,6 @@ impl RpcClient {
     ) -> Result<Self> {
         if data_apis.is_empty() {
             return Err(eyre!("At least one data API URL must be provided"));
-        }
-        if witness_apis.is_empty() {
-            return Err(eyre!("At least one witness API URL must be provided"));
         }
 
         // One shared HTTP client for every provider (connection pools are keyed per host), so
@@ -726,7 +744,8 @@ impl RpcClient {
                 decode_witness_response,
                 "Witness decoded",
             )
-            .await?;
+            .await
+            .map_err(deadline_only)?;
 
         if let Some(ref metrics) = self.config.metrics {
             metrics.on_witness_fetch(WitnessSizeBreakdown::new(&witness.0, &witness.1));
@@ -757,7 +776,9 @@ impl RpcClient {
         hash: B256,
         deadline: Option<Instant>,
     ) -> std::result::Result<(LightWitness, MptWitness), RpcDeadlineExceeded> {
-        self.get_witness_light_with_deadline_from(0, number, hash, deadline).await
+        self.get_witness_light_with_deadline_from(0, number, hash, deadline)
+            .await
+            .map_err(deadline_only)
     }
 
     /// Like [`Self::get_witness_light_with_deadline`], but skips the first `skip` witness
@@ -766,15 +787,16 @@ impl RpcClient {
     /// position in the full configured witness endpoint list, and the shared witness
     /// concurrency cap still applies.
     ///
-    /// # Panics
-    /// Panics if `skip >= witness_provider_count()` — at least one provider must remain.
+    /// Returns [`WitnessFetchError::NoProviderInRange`] when `skip` selects past the
+    /// configured witness endpoints — a routing bug fails this one request rather than the
+    /// process.
     pub async fn get_witness_light_with_deadline_from(
         &self,
         skip: usize,
         number: u64,
         hash: B256,
         deadline: Option<Instant>,
-    ) -> std::result::Result<(LightWitness, MptWitness), RpcDeadlineExceeded> {
+    ) -> std::result::Result<(LightWitness, MptWitness), WitnessFetchError> {
         self.witness_round_robin(
             skip..self.witness_providers.len(),
             number,
@@ -809,7 +831,7 @@ impl RpcClient {
             "Witness light-decoded",
         )
         .await
-        .expect("None deadline cannot time out")
+        .expect("pinned 0..1 range and a None deadline cannot fail")
     }
 
     /// Shared `mega_getBlockWitness` retry loop: primary-failover rounds (always start from
@@ -821,8 +843,8 @@ impl RpcClient {
     /// the logged endpoint labels stay aligned with the full configured list because each
     /// label bakes in its original index (see [`endpoint_label`]).
     ///
-    /// # Panics
-    /// Panics if `providers` is empty or out of bounds — at least one provider must remain.
+    /// An empty or out-of-bounds `providers` range is a wiring failure, surfaced as
+    /// [`WitnessFetchError::NoProviderInRange`] rather than a panic.
     // A `warn`-level span (not the usual `info`) so it stays enabled at the default `warn` log
     // filter: the generic retry loop's per-attempt failure logs then inherit `block_number`,
     // which they cannot see otherwise, so an endpoint stall/error is traceable to its block.
@@ -835,12 +857,11 @@ impl RpcClient {
         deadline: Option<Instant>,
         decode: fn(&str) -> std::result::Result<T, crate::WitnessDecodingError>,
         trace_msg: &'static str,
-    ) -> std::result::Result<T, RpcDeadlineExceeded> {
-        assert!(
-            !providers.is_empty() && providers.end <= self.witness_providers.len(),
-            "witness provider range ({providers:?}) must select at least one of {} providers",
-            self.witness_providers.len()
-        );
+    ) -> std::result::Result<T, WitnessFetchError> {
+        let configured = self.witness_providers.len();
+        if providers.is_empty() || providers.end > configured {
+            return Err(WitnessFetchError::NoProviderInRange { skip: providers.start, configured });
+        }
         // Deadline-bound witness attempts run under the reserve-half policy: the tightest of
         // the configured ceiling, the general per-attempt timeout, and — recomputed at each
         // attempt, after any permit wait — half of what the call still has, so neither a
@@ -876,6 +897,7 @@ impl RpcClient {
             },
         )
         .await
+        .map_err(WitnessFetchError::Deadline)
     }
 
     /// Reports a range of validated blocks via the dedicated report endpoint.
@@ -1613,6 +1635,19 @@ async fn verify_block_on_blocking_pool(block: Block<Transaction>) -> Result<Bloc
     .context("block verification task panicked")?
 }
 
+/// Unwraps a [`WitnessFetchError`] from a full-range witness fetch, where
+/// [`WitnessFetchError::NoProviderInRange`] cannot occur: `0..len` is empty only when the
+/// client carries no witness providers at all, which both binaries reject at startup.
+fn deadline_only(e: WitnessFetchError) -> RpcDeadlineExceeded {
+    match e {
+        WitnessFetchError::Deadline(d) => d,
+        WitnessFetchError::NoProviderInRange { skip, configured } => unreachable!(
+            "full-range witness fetch on a client with no witness providers \
+             (skip={skip}, configured={configured})"
+        ),
+    }
+}
+
 /// Verifies structural integrity of a block fetched from RPC.
 ///
 /// Checks:
@@ -1833,11 +1868,12 @@ mod tests {
                 .to_string()
                 .contains("At least one data API")
         );
-        assert!(
-            RpcClient::new(&[LOCALHOST_A], &[])
-                .unwrap_err()
-                .to_string()
-                .contains("At least one witness API")
+        // An empty witness list is a legal configuration (the validator's R2 witness mode);
+        // a witness call on such a client returns `NoProviderInRange` instead.
+        assert_eq!(
+            RpcClient::new(&[LOCALHOST_A], &[]).unwrap().witness_provider_count(),
+            0,
+            "an empty witness list must construct"
         );
 
         for endpoints in [&[LOCALHOST_B][..], &[LOCALHOST_B, "http://localhost:8547"]] {
@@ -2116,6 +2152,32 @@ mod tests {
         hb.stop().unwrap();
     }
 
+    /// A `skip` past the configured witness endpoints — or a client built with none at all —
+    /// is a wiring failure, and must fail this one request rather than take the process down.
+    #[tokio::test]
+    async fn witness_fetch_out_of_range_returns_a_typed_error() {
+        let client = RpcClient::new(&[LOCALHOST_A], &[LOCALHOST_B]).unwrap();
+        let err = client
+            .get_witness_light_with_deadline_from(1, 7, B256::ZERO, None)
+            .await
+            .expect_err("skip == provider count leaves no provider");
+        assert!(
+            matches!(err, WitnessFetchError::NoProviderInRange { skip: 1, configured: 1 }),
+            "unexpected error: {err:?}"
+        );
+
+        // Same variant covers the no-witness-providers deployment (R2 mode).
+        let witnessless = RpcClient::new(&[LOCALHOST_A], &[]).unwrap();
+        let err = witnessless
+            .get_witness_light_with_deadline_from(0, 7, B256::ZERO, None)
+            .await
+            .expect_err("a client with no witness providers cannot fetch a witness");
+        assert!(
+            matches!(err, WitnessFetchError::NoProviderInRange { skip: 0, configured: 0 }),
+            "unexpected error: {err:?}"
+        );
+    }
+
     /// `get_witness` pins `rr_start = 0`, so every round visits the primary first and only
     /// falls through to the backup on failure. We can't easily make the primary succeed in
     /// a unit test (a valid witness payload needs real cryptographic proof material), but
@@ -2267,15 +2329,6 @@ mod tests {
         ha.stop().unwrap();
         hb.stop().unwrap();
         hc.stop().unwrap();
-    }
-
-    /// Skipping every configured witness provider is a caller bug and must panic loudly
-    /// instead of silently retrying over an empty provider set.
-    #[tokio::test]
-    #[should_panic(expected = "must select at least one")]
-    async fn test_witness_fetch_skip_of_all_providers_panics() {
-        let client = RpcClient::new(&[LOCALHOST_A], &[LOCALHOST_B]).unwrap();
-        let _ = client.get_witness_light_with_deadline_from(1, 1, BlockHash::ZERO, None).await;
     }
 
     /// Serves `mega_getBlockWitness` returning a stub that decodes-fails, while recording


### PR DESCRIPTION
## Summary

PR 6/6 of the #170 split, stacked on #198. The caller-contract `assert!` that guarded the witness provider range becomes a typed error, so a routing bug fails one request instead of the process.

[vincent's review of #170](https://github.com/megaeth-labs/stateless-validator/pull/170#pullrequestreview-4852987751): *"It is also strictly better than the old 'hand it the data endpoints as a placeholder' behavior, which silently pointed witness calls at the wrong endpoints. Still **worth being deliberate** about `assert!` vs a typed error in a validator that is expected to stay up."*

## Scope change: the witness-less half is gone, superseded by #221

This PR originally did two things. The second — letting `RpcClient` carry no witness providers, so `--witness-source r2` stopped handing it `--rpc-endpoint` as placeholder witness endpoints — **has been dropped**, because #221 removed the problem at its source while this PR sat in the queue.

#221 deleted `--witness-source` entirely and derives the mode from the `--r2-*` flags, with `--witness-endpoint` now always required (`app.rs:415`). R2 is tried first and the RPC witness endpoints are its fallback, so no placeholder is ever passed. Under that design an empty witness list is not a configuration to support — passing one would delete the fallback #221 deliberately added. The constructor's non-empty check therefore stays, and the merge commit records the resolution.

What remains is the half vincent asked to be deliberate about, which is independent of how witnesses are configured.

## The change

`witness_round_robin`'s `assert!` becomes `WitnessFetchError::NoProviderInRange { skip, configured }` (`rpc_client.rs:236`), following the shape `CodeFetchError` already uses in this file (`#[error(transparent)] Deadline(#[from] RpcDeadlineExceeded)` plus the domain variant).

The check is raised where the caller-computed value enters — `get_witness_light_with_deadline_from` (`rpc_client.rs:782`, raised at `:793`) — rather than in the rotation it used to guard. The other two witness fetches build their range from the provider count and cannot be out of range, so leaving the guard deeper would have widened their error type for a case they cannot produce. `witness_round_robin` keeps returning `RpcDeadlineExceeded` and states its precondition as a `debug_assert!` (`rpc_client.rs:859`), beside the one `round_robin_with_backoff` already carries. **Public signatures are unchanged**, so mega-reth's `get_witness_with_deadline` caller is untouched.

**Why not keep the `assert!`.** A routing bug in the trace server's witness-skip computation would take the process down on a request path. As a typed error it fails one request, and the reason label says which.

**What the variant now means.** With the constructor rejecting an empty list, the fetch is unsatisfiable for exactly one reason: a caller's `skip` ran past the configured endpoints. That is a routing bug, not a transport condition and not a misconfiguration — it cannot be reached by deploying badly, only by computing a skip wrongly. The error's two fields describe exactly that case; the earlier form also fired on an out-of-bounds range end and reported it as a bad `skip`, which no call site could produce.

**What deliberately did *not* change.** Only `get_witness_light_with_deadline_from` — the one method taking a caller-computed range — returns `WitnessFetchError`. The full-range methods (`get_witness_with_deadline`, `get_witness_light_with_deadline`) keep `RpcDeadlineExceeded`; they pass `0..len`, where the range variant is unreachable, and threading the enum through them would have rippled into the trace server's error classification for no behavioural gain. `get_witness_light_first_provider_only` stays infallible with a pinned `0..1`, its `.expect` naming the startup contract — the same idiom as the `.expect("None deadline cannot time out")` beside it.

## Trace-server classification

`From<WitnessFetchError> for DataProviderError` (`data_provider.rs:273`) sends `Deadline` down the existing method-based path and `NoProviderInRange` to `Internal`. That distinction matters operationally: `Timeout { Witness }` feeds the `deadline_witness` error reason, whose entire value is meaning *"an upstream witness fetch ran out of budget"* — a wiring bug landing there would page for the wrong incident. `witness_range_failure_is_internal_not_a_witness_timeout` (`data_provider.rs:3175`) pins both halves.

## Testing

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets --all-features` (0 warnings), `cargo sort --check`, full workspace suite **491 passed / 0 failed**, `cargo test -p stateless-core --no-default-features --lib --no-run` clean.

New: `witness_fetch_out_of_range_returns_a_typed_error` (`rpc_client.rs:2152`) and `witness_range_failure_is_internal_not_a_witness_timeout` (`data_provider.rs:3175`). `test_witness_fetch_skip_of_all_providers_panics` is removed — superseded by the typed-error test over the same call. Both new tests were mutation-checked (disabling the range check, and misrouting the variant to `Timeout { Witness }`, each kill their test). The constructor test keeps pinning that an empty witness list is rejected.

## Notes

Closes the last of the #170 split. `TODO-A-2` in the internal ledger is satisfied by the typed error; the placeholder-endpoint half of that entry was satisfied by #221 instead.

A quality pass landed in `a418e8e`: the guard moved from the private rotation to the one public method taking a caller-computed `skip`, which deleted the `deadline_only` adapter and its `unreachable!`, both `map_err` sites and a bespoke `expect` string (net −16 lines in `rpc_client.rs`). Mutation-checked again at the new site.
