### PR TITLE
chore: bump salt to v1.0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
  "cfg-if",
  "once_cell",
  "version_check",
- "zerocopy 0.8.28",
+ "zerocopy",
 ]
 
 [[package]]
@@ -456,7 +456,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde",
  "alloy-sol-types",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -1184,7 +1184,7 @@ checksum = "7b7e4c2464d97fe331d41de9d5db0def0a96f4d823b8b32a2efd503578988973"
 [[package]]
 name = "banderwagon"
 version = "0.1.0"
-source = "git+https://github.com/megaeth-labs/salt.git?tag=v1.0.5#b6b30e733276f50855a2d3c0781177803ba8f8d9"
+source = "git+https://github.com/megaeth-labs/salt.git?tag=v1.0.6#945d5bdad8c1b8fd6900923858e4592d9e955cae"
 dependencies = [
  "ark-ec 0.5.0 (git+https://github.com/megaeth-labs/algebra.git?rev=80ca69c37f79d5d00750edc1602af81b5f456695)",
  "ark-ed-on-bls12-381-bandersnatch",
@@ -2967,7 +2967,7 @@ dependencies = [
 [[package]]
 name = "ipa-multipoint"
 version = "0.1.0"
-source = "git+https://github.com/megaeth-labs/salt.git?tag=v1.0.5#b6b30e733276f50855a2d3c0781177803ba8f8d9"
+source = "git+https://github.com/megaeth-labs/salt.git?tag=v1.0.6#945d5bdad8c1b8fd6900923858e4592d9e955cae"
 dependencies = [
  "banderwagon",
  "hashbrown 0.16.1",
@@ -4083,7 +4083,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy 0.8.28",
+ "zerocopy",
 ]
 
 [[package]]
@@ -5192,8 +5192,8 @@ checksum = "dd29631678d6fb0903b69223673e122c32e9ae559d0960a38d574695ebc0ea15"
 
 [[package]]
 name = "salt"
-version = "1.0.5"
-source = "git+https://github.com/megaeth-labs/salt.git?tag=v1.0.5#b6b30e733276f50855a2d3c0781177803ba8f8d9"
+version = "1.0.6"
+source = "git+https://github.com/megaeth-labs/salt.git?tag=v1.0.6#945d5bdad8c1b8fd6900923858e4592d9e955cae"
 dependencies = [
  "auto_impl",
  "banderwagon",
@@ -5209,13 +5209,12 @@ dependencies = [
  "serde_arrays",
  "spin 0.10.0",
  "thiserror 2.0.17",
- "zerocopy 0.7.35",
 ]
 
 [[package]]
 name = "salt-macros"
 version = "0.1.0"
-source = "git+https://github.com/megaeth-labs/salt.git?tag=v1.0.5#b6b30e733276f50855a2d3c0781177803ba8f8d9"
+source = "git+https://github.com/megaeth-labs/salt.git?tag=v1.0.6#945d5bdad8c1b8fd6900923858e4592d9e955cae"
 dependencies = [
  "rayon",
 ]
@@ -6874,31 +6873,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
-dependencies = [
- "zerocopy-derive 0.7.35",
-]
-
-[[package]]
-name = "zerocopy"
 version = "0.8.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43fa6694ed34d6e57407afbccdeecfa268c470a7d2a5b0cf49ce9fcc345afb90"
 dependencies = [
- "zerocopy-derive 0.8.28",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
+ "zerocopy-derive",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ alloy-trie = { version = "0.9.0", default-features = false }
 
 # mega
 mega-evm = { git = "https://github.com/megaeth-labs/mega-evm.git", tag = "v1.7.0", default-features = false }
-salt = { git = "https://github.com/megaeth-labs/salt.git", tag = "v1.0.5", default-features = false }
+salt = { git = "https://github.com/megaeth-labs/salt.git", tag = "v1.0.6", default-features = false }
 
 # op
 op-alloy-consensus = { version = "0.18.12", default-features = false }


### PR DESCRIPTION
## Summary

Bump `salt` from v1.0.5 to v1.0.6.

v1.0.6 adds the fallible `StateUpdates::try_add` / `try_merge` (megaeth-labs/salt#149) that mega-reth's live-sync pipeline (megaeth-labs/mega-reth#2224) depends on. mega-reth pins `stateless-core` / `stateless-common` and `salt` from the same git sources, so both have to move to v1.0.6 together or the workspace ends up with two `salt` copies and type mismatches across the `stateless-core` boundary.

No code changes: `UnchainedTransition` moved crates inside salt, but nothing here references it.

## Test plan

- [x] `cargo check --workspace --all-features`