### PR TITLE
ci(claude): mint the app token with the client id

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -79,7 +79,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ vars.CI_APP_ID }}
+          client-id: ${{ vars.MEGA_MAXWELL_CLIENT_ID }}
           private-key: ${{ secrets.MEGA_CI_APP_PK }}
           owner: megaeth-labs
           repositories: stateless-validator


### PR DESCRIPTION
`create-github-app-token@v3` deprecates `app-id` in favour of `client-id`; the release workflows (#201) already use `client-id: ${{ vars.MEGA_MAXWELL_CLIENT_ID }}`. This moves `claude.yml` to the same input. Same app, same private key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)