### PR TITLE
fix(release): give debug-trace-server a --version and gate the release on it

### DIFF
--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -78,10 +78,14 @@ jobs:
           version: ${{ env.TAG }}
           dry_run: ${{ env.DRY_RUN }}
 
-      - name: Check debug-trace-server runs
-        # No version flag to gate on; `--help` proves it loads and runs (a
-        # missing library or a crash fails the step, dry run or not).
-        run: target/release/debug-trace-server --help > /dev/null
+      # debug-trace-server carries a clap version too (added for this gate).
+      # The workspace builds clap without its `help` feature, so `--version`
+      # is the only flag either binary answers; `--help` is an error.
+      - uses: megaeth-labs/.github/.github/actions/release-verify-version@main
+        with:
+          command: target/release/debug-trace-server --version
+          version: ${{ env.TAG }}
+          dry_run: ${{ env.DRY_RUN }}
 
       - uses: megaeth-labs/.github/.github/actions/release-assets@main
         with:

--- a/bin/debug-trace-server/src/main.rs
+++ b/bin/debug-trace-server/src/main.rs
@@ -102,7 +102,7 @@ use crate::chain_sync::{TraceFetcher, TraceHooks, TraceProcessor};
 
 /// Command line arguments for the debug-trace-server.
 #[derive(Parser, Debug)]
-#[clap(name = "debug-trace-server", about = "Debug/Trace RPC Server")]
+#[clap(name = "debug-trace-server", version, about = "Debug/Trace RPC Server")]
 // Every `--r2-*` coherence rule is enforced after parsing, by
 // `stateless_common::validate_r2_flags`, rather than through clap attributes: this workspace
 // builds clap without its `error-context` feature (root `Cargo.toml`), so every clap rejection


### PR DESCRIPTION
The v2.0.18 [On Release run](https://github.com/megaeth-labs/stateless-validator/actions/runs/34321016184) failed at the binary check, so no assets were attached to the Release. The stateless-validator version gate passed; the load probe `debug-trace-server --help` did not: this workspace builds clap with `default-features = false, features = ["derive", "env", "std"]`, so there is no `help` feature and `--help` is "error: unexpected argument found" (exit 2) on every binary here. `--version` is the only flag that exists, and only where `version` is declared (verified with a scratch crate on the same feature set: `--help` fails, `--version` prints `name X.Y.Z`).

- `bin/debug-trace-server/src/main.rs`: add `version` to the clap attribute. The binary now answers `--version` with `debug-trace-server X.Y.Z` (workspace version). No other behaviour changes.
- `.github/workflows/on-release.yml`: the `--help` step becomes a second `release-verify-version` use, so both binaries are gated the same way.

The v2.0.18 tag's own workflow file cannot change, so this fixes the next release; v2.0.18's page assets are a separate decision. The Artifact Registry archive (`release.yaml`) is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
