### PR TITLE
ci(claude): mint the app token from MEGA_MAXWELL_PK

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -80,7 +80,7 @@ jobs:
         id: app-token
         with:
           client-id: ${{ vars.MEGA_MAXWELL_CLIENT_ID }}
-          private-key: ${{ secrets.MEGA_CI_APP_PK }}
+          private-key: ${{ secrets.MEGA_MAXWELL_PK }}
           owner: megaeth-labs
           repositories: stateless-validator
 


### PR DESCRIPTION
`claude.yml` minted the Maxwell app token from the org secret `MEGA_CI_APP_PK`, while the three release workflows in this repo use `MEGA_MAXWELL_PK` for the same app. Both names hold the key, so both work, but a rotation of one leaves the other stale. This switches the last workflow here to `MEGA_MAXWELL_PK`; the `client-id` input was already `MEGA_MAXWELL_CLIENT_ID`. One-line change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
